### PR TITLE
Fix #2: use high precision in the fragment shader so that linear gradients render correctly on NVidia hardware.

### DIFF
--- a/src/renderer/opengl/main-fs.glsl
+++ b/src/renderer/opengl/main-fs.glsl
@@ -1,5 +1,5 @@
 
-precision mediump float;
+precision highp float;
 
 #define UNIFORMARRAY_SIZE 12
 


### PR DESCRIPTION
The linear gradient code uses extents with small deltas around 1e5, and this causes lumpy interpolation in the sdRoundRect function used to calculate gradients. Box gradients and radial gradients don't use smaller extents and don't have the same issue.