### PR TITLE
feature: add multi-stop gradients

### DIFF
--- a/examples/gradients.rs
+++ b/examples/gradients.rs
@@ -1,0 +1,748 @@
+use std::time::Instant;
+
+use glutin::{
+    event::{Event, WindowEvent},
+    event_loop::{ControlFlow, EventLoop},
+    window::WindowBuilder,
+    ContextBuilder,
+};
+
+use femtovg::{Align, Baseline, Canvas, Color, Paint, Path, Renderer, renderer::OpenGl};
+
+fn main() {
+    let window_size = glutin::dpi::PhysicalSize::new(1000, 670);
+    let el = EventLoop::new();
+    let wb = WindowBuilder::new()
+        .with_inner_size(window_size)
+        .with_resizable(false)
+        .with_title("Gradient test");
+
+    let windowed_context = ContextBuilder::new().build_windowed(wb, &el).unwrap();
+    let windowed_context = unsafe { windowed_context.make_current().unwrap() };
+
+    let renderer = OpenGl::new(|s| windowed_context.get_proc_address(s) as *const _).expect("Cannot create renderer");
+    let mut canvas = Canvas::new(renderer).expect("Cannot create canvas");
+    canvas.set_size(
+        window_size.width as u32,
+        window_size.height as u32,
+        windowed_context.window().scale_factor() as f32,
+    );
+    canvas.add_font("examples/assets/Roboto-Regular.ttf")
+        .expect("Cannot add font");
+    
+    let start = Instant::now();
+    let mut prevt = start;
+
+    let mut perf = PerfGraph::new();
+
+    el.run(move |event, _, control_flow| {
+        *control_flow = ControlFlow::Poll;
+
+        match event {
+            Event::LoopDestroyed => return,
+            Event::WindowEvent { ref event, .. } => match event {
+                WindowEvent::Resized(physical_size) => {
+                    windowed_context.resize(*physical_size);
+                }
+                WindowEvent::CloseRequested => *control_flow = ControlFlow::Exit,
+                _ => (),
+            },
+            Event::RedrawRequested(_) => {
+                let dpi_factor = windowed_context.window().scale_factor();
+                let size = windowed_context.window().inner_size();
+                canvas.set_size(size.width as u32, size.height as u32, dpi_factor as f32);
+                canvas.clear_rect(0, 0, size.width as u32, size.height as u32, Color::rgbf(0.9, 0.9, 0.9));
+
+                let now = Instant::now();
+                let dt = (now - prevt).as_secs_f32();
+                prevt = now;
+
+                perf.update(dt);
+
+                draw_gradients(&mut canvas);
+
+                canvas.save();
+                canvas.reset();
+                perf.render(&mut canvas, 5.0, 5.0);
+                canvas.restore();
+
+                canvas.flush();
+                windowed_context.swap_buffers().unwrap();
+            }
+            Event::MainEventsCleared => windowed_context.window().request_redraw(),
+            _ => (),
+        }
+    });
+}
+
+fn draw_gradients<T: Renderer>(canvas: &mut Canvas<T>) {
+    let mut r = |x, y, name, paint| {
+        let mut p = Path::new();
+        p.rect(0.0, 0.0, 100.0, 100.0);
+        canvas.translate(x, y);
+        canvas.fill_path(&mut p, paint);
+        canvas.translate(-x, -y);
+        let mut text_paint = Paint::color(Color::black());
+        text_paint.set_font_size(14.0);
+        let _ = canvas.fill_text(x, y + 114.0, name, text_paint);
+    };
+    // Various two stop gradients
+    let mut x = 10.0;
+    let mut y = 10.0;
+
+    // OPAQUE LINEAR
+    r(
+        x, y,
+        "x linear opaque",
+        Paint::linear_gradient(
+            0.0, 0.0,
+            100.0, 0.0,
+            Color::rgba(255, 0, 0, 255),
+            Color::rgba(0, 0, 255, 255)
+        )
+    );
+    x += 110.0;
+    r(
+        x, y,
+        "y linear opaque",
+        Paint::linear_gradient(
+            0.0, 0.0,
+            0.0, 100.0,
+            Color::rgba(255, 0, 0, 255),
+            Color::rgba(0, 0, 255, 255)
+        )
+    );
+    x += 110.0;
+    r(
+        x, y,
+        "xy linear opaque",
+        Paint::linear_gradient(
+            0.0, 0.0,
+            100.0, 100.0,
+            Color::rgba(255, 0, 0, 255),
+            Color::rgba(0, 0, 255, 255)
+        )
+    );
+
+    // 50% LINEAR
+    x += 110.0;
+    r(
+        x, y,
+        "x linear 50%",
+        Paint::linear_gradient(
+            0.0, 0.0,
+            100.0, 0.0,
+            Color::rgba(255, 0, 0, 128),
+            Color::rgba(0, 0, 255, 128)
+        )
+    );
+    x += 110.0;
+    r(
+        x, y,
+        "y linear 50%",
+        Paint::linear_gradient(
+            0.0, 0.0,
+            0.0, 100.0,
+            Color::rgba(255, 0, 0, 128),
+            Color::rgba(0, 0, 255, 128)
+        )
+    );
+    x += 110.0;
+    r(
+        x, y,
+        "xy linear 50%",
+        Paint::linear_gradient(
+            0.0, 0.0,
+            100.0, 100.0,
+            Color::rgba(255, 0, 0, 128),
+            Color::rgba(0, 0, 255, 128)
+        )
+    );
+
+    // TRANSPARENT TO OPAQUE LINEAR
+    x += 110.0;
+    r(
+        x, y,
+        "x linear 0-100",
+        Paint::linear_gradient(
+            0.0, 0.0,
+            100.0, 0.0,
+            Color::rgba(255, 0, 0, 0),
+            Color::rgba(0, 0, 255, 255)
+        )
+    );
+    x += 110.0;
+    r(
+        x, y,
+        "y linear 0-100",
+        Paint::linear_gradient(
+            0.0, 0.0,
+            0.0, 100.0,
+            Color::rgba(255, 0, 0, 0),
+            Color::rgba(0, 0, 255, 255)
+        )
+    );
+    x += 110.0;
+    r(
+        x, y,
+        "xy linear 0-100",
+        Paint::linear_gradient(
+            0.0, 0.0,
+            100.0, 100.0,
+            Color::rgba(255, 0, 0, 0),
+            Color::rgba(0, 0, 255, 255)
+        )
+    );
+
+    y += 130.0;
+    x = 10.0;
+    // OPAQUE RADIAL
+    r(
+        x, y,
+        "radial opaque",
+        Paint::radial_gradient(
+            50.0, 50.0,
+            0.0, 50.0,
+            Color::rgba(255, 0, 0, 255),
+            Color::rgba(0, 0, 255, 255)
+        )
+    );
+    x += 110.0;
+    r(
+        x, y,
+        "0,0 rad opaque",
+        Paint::radial_gradient(
+            0.0, 0.0,
+            0.0, 100.0,
+            Color::rgba(255, 0, 0, 255),
+            Color::rgba(0, 0, 255, 255)
+        )
+    );
+    x += 110.0;
+    r(
+        x, y,
+        "fill rad opaque",
+        Paint::radial_gradient(
+            50.0, 50.0,
+            25.0, 75.0,
+            Color::rgba(255, 0, 0, 255),
+            Color::rgba(0, 0, 255, 255)
+        )
+    );
+
+    // 50% LINEAR
+    x += 110.0;
+    r(
+        x, y,
+        "radial 50%",
+        Paint::radial_gradient(
+            50.0, 50.0,
+            0.0, 50.0,
+            Color::rgba(255, 0, 0, 128),
+            Color::rgba(0, 0, 255, 128)
+        )
+    );
+    x += 110.0;
+    r(
+        x, y,
+        "0,0 rad 50%",
+        Paint::radial_gradient(
+            0.0, 0.0,
+            0.0, 100.0,
+            Color::rgba(255, 0, 0, 128),
+            Color::rgba(0, 0, 255, 128)
+        )
+    );
+    x += 110.0;
+    r(
+        x, y,
+        "fill rad 50%",
+        Paint::radial_gradient(
+            50.0, 50.0,
+            25.0, 75.0,
+            Color::rgba(255, 0, 0, 128),
+            Color::rgba(0, 0, 255, 128)
+        )
+    );
+
+    // TRANSPARENT TO OPAQUE LINEAR
+    x += 110.0;
+    r(
+        x, y,
+        "radial 0-100",
+        Paint::radial_gradient(
+            50.0, 50.0,
+            0.0, 50.0,
+            Color::rgba(255, 0, 0, 0),
+            Color::rgba(0, 0, 255, 128)
+        )
+    );
+    x += 110.0;
+    r(
+        x, y,
+        "0,0 rad 0-100",
+        Paint::radial_gradient(
+            0.0, 0.0,
+            0.0, 100.0,
+            Color::rgba(255, 0, 0, 0),
+            Color::rgba(0, 0, 255, 128)
+        )
+    );
+    x += 110.0;
+    r(
+        x, y,
+        "fill rad 0-100",
+        Paint::radial_gradient(
+            50.0, 50.0,
+            25.0, 75.0,
+            Color::rgba(255, 0, 0, 0),
+            Color::rgba(0, 0, 255, 128)
+        )
+    );
+
+    // Multistop!
+    y += 130.0;
+    x = 10.0;
+    r(
+        x, y,
+        "ms x linear op",
+        Paint::linear_gradient_stops(
+            0.0, 0.0,
+            100.0, 0.0,
+            &[
+                (0.0, Color::rgba(255, 0, 0, 255)),
+                (0.5, Color::rgba(0, 255, 0, 255)),
+                (1.0, Color::rgba(0, 0, 255, 255))
+            ]
+        )
+    );
+    x += 110.0;
+    r(
+        x, y,
+        "ms y linear op",
+        Paint::linear_gradient_stops(
+            0.0, 0.0,
+            0.0, 100.0,
+            &[
+                (0.0, Color::rgba(255, 0, 0, 255)),
+                (0.5, Color::rgba(0, 255, 0, 255)),
+                (1.0, Color::rgba(0, 0, 255, 255))
+            ]
+        )
+    );
+    x += 110.0;
+    r(
+        x, y,
+        "ms xy linear op",
+        Paint::linear_gradient_stops(
+            0.0, 0.0,
+            100.0, 100.0,
+            &[
+                (0.0, Color::rgba(255, 0, 0, 255)),
+                (0.5, Color::rgba(0, 255, 0, 255)),
+                (1.0, Color::rgba(0, 0, 255, 255))
+            ]
+        )
+    );
+    // Multistop linear 50%
+    x += 110.0;
+    r(
+        x, y,
+        "ms x linear 50%",
+        Paint::linear_gradient_stops(
+            0.0, 0.0,
+            100.0, 0.0,
+            &[
+                (0.0, Color::rgba(255, 0, 0, 128)),
+                (0.5, Color::rgba(0, 255, 0, 128)),
+                (1.0, Color::rgba(0, 0, 255, 128))
+            ]
+        )
+    );
+    x += 110.0;
+    r(
+        x, y,
+        "ms y linear 50%",
+        Paint::linear_gradient_stops(
+            0.0, 0.0,
+            0.0, 100.0,
+            &[
+                (0.0, Color::rgba(255, 0, 0, 128)),
+                (0.5, Color::rgba(0, 255, 0, 128)),
+                (1.0, Color::rgba(0, 0, 255, 128))
+            ]
+        )
+    );
+    x += 110.0;
+    r(
+        x, y,
+        "ms xy linear 50%",
+        Paint::linear_gradient_stops(
+            0.0, 0.0,
+            100.0, 100.0,
+            &[
+                (0.0, Color::rgba(255, 0, 0, 128)),
+                (0.5, Color::rgba(0, 255, 0, 128)),
+                (1.0, Color::rgba(0, 0, 255, 128))
+            ]
+        )
+    );
+    // Multistop linear transparent & opaque
+    x += 110.0;
+    r(
+        x, y,
+        "ms x linear 0-100",
+        Paint::linear_gradient_stops(
+            0.0, 0.0,
+            100.0, 0.0,
+            &[
+                (0.0, Color::rgba(255, 0, 0, 0)),
+                (0.5, Color::rgba(0, 255, 0, 255)),
+                (1.0, Color::rgba(0, 0, 255, 128))
+            ]
+        )
+    );
+    x += 110.0;
+    r(
+        x, y,
+        "ms y linear 0-100",
+        Paint::linear_gradient_stops(
+            0.0, 0.0,
+            0.0, 100.0,
+            &[
+                (0.0, Color::rgba(255, 0, 0, 0)),
+                (0.5, Color::rgba(0, 255, 0, 255)),
+                (1.0, Color::rgba(0, 0, 255, 128))
+            ]
+        )
+    );
+    x += 110.0;
+    r(
+        x, y,
+        "ms xy linear 0-100%",
+        Paint::linear_gradient_stops(
+            0.0, 0.0,
+            100.0, 100.0,
+            &[
+                (0.0, Color::rgba(255, 0, 0, 0)),
+                (0.5, Color::rgba(0, 255, 0, 255)),
+                (1.0, Color::rgba(0, 0, 255, 128))
+            ]
+        )
+    );
+    // Multistop radial
+    y += 130.0;
+    x = 10.0;
+    r(
+        x, y,
+        "ms radial opq",
+        Paint::radial_gradient_stops(
+            50.0, 50.0,
+            0.0, 50.0,
+            &[
+                (0.0, Color::rgba(255, 0, 0, 255)),
+                (0.5, Color::rgba(0, 255, 0, 255)),
+                (1.0, Color::rgba(0, 0, 255, 255))
+            ]
+        )
+    );
+    x += 110.0;
+    r(
+        x, y,
+        "ms 0,0 rad opq",
+        Paint::radial_gradient_stops(
+            0.0, 0.0,
+            0.0, 100.0,
+            &[
+                (0.0, Color::rgba(255, 0, 0, 255)),
+                (0.5, Color::rgba(0, 255, 0, 255)),
+                (1.0, Color::rgba(0, 0, 255, 255))
+            ]
+        )
+    );
+    x += 110.0;
+    r(
+        x, y,
+        "ms rad opq",
+        Paint::radial_gradient_stops(
+            50.0, 50.0,
+            25.0, 75.0,
+            &[
+                (0.0, Color::rgba(255, 0, 0, 255)),
+                (0.5, Color::rgba(0, 255, 0, 255)),
+                (1.0, Color::rgba(0, 0, 255, 255))
+            ]
+        )
+    );
+    // Multistop radial 50%
+    x += 110.0;
+    r(
+        x, y,
+        "ms radial 50%",
+        Paint::radial_gradient_stops(
+            50.0, 50.0,
+            0.0, 50.0,
+            &[
+                (0.0, Color::rgba(255, 0, 0, 128)),
+                (0.5, Color::rgba(0, 255, 0, 128)),
+                (1.0, Color::rgba(0, 0, 255, 128))
+            ]
+        )
+    );
+    x += 110.0;
+    r(
+        x, y,
+        "ms 0,0 rad 50%",
+        Paint::radial_gradient_stops(
+            0.0, 0.0,
+            0.0, 100.0,
+            &[
+                (0.0, Color::rgba(255, 0, 0, 128)),
+                (0.5, Color::rgba(0, 255, 0, 128)),
+                (1.0, Color::rgba(0, 0, 255, 128))
+            ]
+        )
+    );
+    x += 110.0;
+    r(
+        x, y,
+        "ms rad 50%",
+        Paint::radial_gradient_stops(
+            50.0, 50.0,
+            25.0, 75.0,
+            &[
+                (0.0, Color::rgba(255, 0, 0, 128)),
+                (0.5, Color::rgba(0, 255, 0, 128)),
+                (1.0, Color::rgba(0, 0, 255, 128))
+            ]
+        )
+    );
+    // Multistop radial transparent
+    x += 110.0;
+    r(
+        x, y,
+        "ms radial 0-100",
+        Paint::radial_gradient_stops(
+            50.0, 50.0,
+            0.0, 50.0,
+            &[
+                (0.0, Color::rgba(255, 0, 0, 0)),
+                (0.5, Color::rgba(0, 255, 0, 255)),
+                (1.0, Color::rgba(0, 0, 255, 128))
+            ]
+        )
+    );
+    x += 110.0;
+    r(
+        x, y,
+        "ms 0,0 rad 0-100",
+        Paint::radial_gradient_stops(
+            0.0, 0.0,
+            0.0, 100.0,
+            &[
+                (0.0, Color::rgba(255, 0, 0, 0)),
+                (0.5, Color::rgba(0, 255, 0, 255)),
+                (1.0, Color::rgba(0, 0, 255, 128))
+            ]
+        )
+    );
+    x += 110.0;
+    r(
+        x, y,
+        "ms rad 0-100",
+        Paint::radial_gradient_stops(
+            50.0, 50.0,
+            25.0, 75.0,
+            &[
+                (0.0, Color::rgba(255, 0, 0, 0)),
+                (0.5, Color::rgba(0, 255, 0, 255)),
+                (1.0, Color::rgba(0, 0, 255, 128))
+            ]
+        )
+    );
+
+    // Multistop padding cases
+    x = 10.0;
+    y += 130.0;
+    r(
+        x, y,
+        "ms pad start",
+        Paint::linear_gradient_stops(
+            0.0, 0.0,
+            100.0, 0.0,
+            &[
+                (0.5, Color::rgba(255, 0, 0, 255)),
+                (1.0, Color::rgba(0, 0, 255, 255))
+            ]
+        )
+    );
+    x += 110.0;
+    r(
+        x, y,
+        "ms pad both",
+        Paint::linear_gradient_stops(
+            0.0, 0.0,
+            100.0, 0.0,
+            &[
+                (0.4, Color::rgba(255, 0, 0, 255)),
+                (0.6, Color::rgba(0, 0, 255, 255))
+            ]
+        )
+    );
+    x += 110.0;
+    r(
+        x, y,
+        "ms pad end",
+        Paint::linear_gradient_stops(
+            0.0, 0.0,
+            100.0, 0.0,
+            &[
+                (0.0, Color::rgba(255, 0, 0, 255)),
+                (0.5, Color::rgba(0, 0, 255, 255))
+            ]
+        )
+    );
+    x += 110.0;
+    r(
+        x, y,
+        "ms same stop",
+        Paint::linear_gradient_stops(
+            0.0, 0.0,
+            100.0, 0.0,
+            &[
+                (0.5, Color::rgba(255, 0, 0, 255)),
+                (0.5, Color::rgba(0, 0, 255, 255))
+            ]
+        )
+    );
+    x += 110.0;
+    r(
+        x, y,
+        "ms one stop",
+        Paint::linear_gradient_stops(
+            0.0, 0.0,
+            100.0, 0.0,
+            &[
+                (0.5, Color::rgba(255, 0, 0, 255)),
+            ]
+        )
+    );
+    x += 110.0;
+    r(
+        x, y,
+        "ms zero stops",
+        Paint::linear_gradient_stops(
+            0.0, 0.0,
+            100.0, 0.0,
+            &[]
+        )
+    );
+    x += 110.0;
+    r(
+        x, y,
+        "ms non-seq 1",
+        Paint::linear_gradient_stops(
+            0.0, 0.0,
+            100.0, 0.0,
+            &[
+                (0.5, Color::rgba(255, 0, 0, 255)),
+                (0.0, Color::rgba(0, 0, 255, 255))
+            ]
+        )
+    );
+    x += 110.0;
+    r(
+        x, y,
+        "ms non-seq 2",
+        Paint::linear_gradient_stops(
+            0.0, 0.0,
+            100.0, 0.0,
+            &[
+                (0.5, Color::rgba(255, 0, 0, 255)),
+                (0.3, Color::rgba(0, 0, 255, 255))
+            ]
+        )
+    );
+    x += 110.0;
+    r(
+        x, y,
+        "ms non-seq 3",
+        Paint::linear_gradient_stops(
+            0.0, 0.0,
+            100.0, 0.0,
+            &[
+                (0.5, Color::rgba(255, 0, 0, 255)),
+                (0.6, Color::rgba(0, 255, 0, 255)),
+                (0.3, Color::rgba(0, 0, 255, 255)),
+            ]
+        )
+    );
+}
+
+struct PerfGraph {
+    history_count: usize,
+    values: Vec<f32>,
+    head: usize,
+}
+
+impl PerfGraph {
+    fn new() -> Self {
+        Self {
+            history_count: 100,
+            values: vec![0.0; 100],
+            head: Default::default(),
+        }
+    }
+
+    fn update(&mut self, frame_time: f32) {
+        self.head = (self.head + 1) % self.history_count;
+        self.values[self.head] = frame_time;
+    }
+
+    fn get_average(&self) -> f32 {
+        self.values.iter().map(|v| *v).sum::<f32>() / self.history_count as f32
+    }
+
+    fn render<T: Renderer>(&self, canvas: &mut Canvas<T>, x: f32, y: f32) {
+        let avg = self.get_average();
+
+        let w = 200.0;
+        let h = 35.0;
+
+        let mut path = Path::new();
+        path.rect(x, y, w, h);
+        canvas.fill_path(&mut path, Paint::color(Color::rgba(0, 0, 0, 128)));
+
+        let mut path = Path::new();
+        path.move_to(x, y + h);
+
+        for i in 0..self.history_count {
+            let mut v = 1.0 / (0.00001 + self.values[(self.head + i) % self.history_count]);
+            if v > 80.0 {
+                v = 80.0;
+            }
+            let vx = x + (i as f32 / (self.history_count - 1) as f32) * w;
+            let vy = y + h - ((v / 80.0) * h);
+            path.line_to(vx, vy);
+        }
+
+        path.line_to(x + w, y + h);
+        canvas.fill_path(&mut path, Paint::color(Color::rgba(255, 192, 0, 128)));
+
+        let mut text_paint = Paint::color(Color::rgba(240, 240, 240, 255));
+        text_paint.set_font_size(12.0);
+        let _ = canvas.fill_text(x + 5.0, y + 13.0, "Frame time", text_paint);
+
+        let mut text_paint = Paint::color(Color::rgba(240, 240, 240, 255));
+        text_paint.set_font_size(14.0);
+        text_paint.set_text_align(Align::Right);
+        text_paint.set_text_baseline(Baseline::Top);
+        let _ = canvas.fill_text(x + w - 5.0, y, &format!("{:.2} FPS", 1.0 / avg), text_paint);
+
+        let mut text_paint = Paint::color(Color::rgba(240, 240, 240, 200));
+        text_paint.set_font_size(12.0);
+        text_paint.set_text_align(Align::Right);
+        text_paint.set_text_baseline(Baseline::Alphabetic);
+        let _ = canvas.fill_text(x + w - 5.0, y + h - 5.0, &format!("{:.2} ms", avg * 1000.0), text_paint);
+    }
+}

--- a/src/gradient_store.rs
+++ b/src/gradient_store.rs
@@ -1,0 +1,150 @@
+use std::collections::BTreeMap;
+
+use imgref;
+use rgb;
+
+use crate::{Color, ErrorKind, ImageFlags, ImageId, ImageInfo, ImageSource, Renderer, image::ImageStore, paint::MultiStopGradient};
+
+/// GradientStore holds image ids for multi-stop gradients. The actual image/textures
+/// are contained by the Canvas's ImageStore.
+//
+// If many gradients are used in a frame, we could combine them into a single texture
+// and update the texture immediately prior to giving the renderer the command list.
+pub(crate) struct GradientStore {
+    this_frame: BTreeMap<MultiStopGradient, ImageId>,
+    prev_frame: BTreeMap<MultiStopGradient, ImageId>
+}
+impl GradientStore {
+    /// Create a new empty gradient store
+    pub fn new() -> GradientStore {
+        GradientStore {
+            this_frame: BTreeMap::new(),
+            prev_frame: BTreeMap::new()
+        }
+    }
+
+    /// Lookup or add a multi-stop gradient in this gradient store.
+    pub fn lookup_or_add<R: Renderer>(&mut self, colors: MultiStopGradient, images: &mut ImageStore<R::Image>, renderer: &mut R) -> Result<ImageId, ErrorKind> {
+        if let Some(gradient_image_id) = self.prev_frame.remove(&colors) {
+            // See if we already have this texture from the previous frame. If we find
+            // it then we migrate it to the current frame so we don't release it and
+            // return the texture id to the caller.
+            self.this_frame.insert(colors, gradient_image_id);
+            Ok(gradient_image_id)
+        }
+        else if let Some(gradient_image_id) = self.this_frame.get(&colors) {
+            // See if we already used this gradient in this frame, and return the texture
+            // id if we do.
+            Ok(*gradient_image_id)
+        } else {
+            // We need to allocate a texture and synthesize the gradient image.
+            let info = ImageInfo::new(
+                ImageFlags::REPEAT_Y,
+                256,
+                1,
+                crate::PixelFormat::Rgba8,  
+            );
+            let gradient_image_id = images.alloc(renderer, info)?;
+            let image = linear_gradient_stops(&colors);
+            images.update(renderer, gradient_image_id, ImageSource::Rgba(image.as_ref()), 0, 0)?;
+
+            self.this_frame.insert(colors, gradient_image_id);
+            Ok(gradient_image_id)
+        }
+    }
+
+    /// Release the textures that were not used in the most recently rendered frame. This
+    /// method should be called when all the commands have been submitted.
+    pub fn release_old_gradients<R: Renderer>(&mut self, images: &mut ImageStore<R::Image>, renderer: &mut R) {
+        let mut prev_textures = BTreeMap::new();
+        std::mem::swap(&mut prev_textures, &mut self.prev_frame);
+        for (_, gradient_image_id) in prev_textures {
+            images.remove(renderer, gradient_image_id);
+        }
+        // Move the "this_frame" textures to "prev_frame". "prev_frame" is already empty.
+        std::mem::swap(&mut self.this_frame, &mut self.prev_frame);
+    }
+}
+
+// Gradient filling, adapted from https://github.com/lieff/lvg/blob/master/render/common.c#L147
+fn gradient_span(dest: &mut [rgb::RGBA8; 256], color0: Color, color1: Color, offset0: f32, offset1: f32)
+{
+    let s0o = offset0.max(0.0).min(1.0);
+    let s1o = offset1.max(0.0).min(1.0);
+
+    if s1o < s0o { return }
+
+    let s = (s0o * 256.0) as usize;
+    let e = (s1o * 256.0) as usize;
+
+    let mut r = color0.r;
+    let mut g = color0.g;
+    let mut b = color0.b;
+    let mut a = color0.a;
+
+    let steps = (e - s) as f32;
+
+    let dr = (color1.r - r) / steps;
+    let dg = (color1.g - g) / steps;
+    let db = (color1.b - b) / steps;
+    let da = (color1.a - a) / steps;
+
+    for i in s..e {
+        // The output must be premultiplied, but we don't premultiply until this point
+        // so that we can do gradients from transparent colors correctly -- for example
+        // if we have a stop that is fully transparent red and it transitions to opaque
+        // blue, we should see some red in the gradient. If we premultiply the stops
+        // then we won't see any red, because we will have already multiplied it to zero.
+        // This way we'll get the red contribution.
+        dest[i] = rgb::RGBA8::new(
+            (r * a * 255.0) as u8,
+            (g * a * 255.0) as u8,
+            (b * a * 255.0) as u8,
+            (a * 255.0) as u8
+        );
+        r += dr;
+        g += dg;
+        b += db;
+        a += da;
+    }
+}
+fn linear_gradient_stops(gradient: &MultiStopGradient) -> imgref::Img<Vec<rgb::RGBA8>> {
+    let mut dest = [rgb::RGBA8::new(0, 0, 0, 0); 256];
+
+    // Fill the gradient up to the first stop.
+    if gradient[0].0 > 0.0 {
+        let s0 = gradient[0].0;
+        let color0 = gradient[0].1;
+        gradient_span(
+            &mut dest, 
+            color0, 
+            color0, 
+            0.0, 
+            s0);
+    }
+
+    // Iterate over the stops in overlapping pairs and fill out the rest of the
+    // gradient. If the stop position is > 1.0 then we have exhausted the stops
+    // and should break. As a special case, if the second stop is > 1.0 then we
+    // fill the current color to the end of the gradient.
+    for stop in gradient.windows(2) {
+        let s0 = stop[0].0;
+        let s1 = stop[1].0;
+        let color0 = stop[0].1;
+        let color1 = stop[1].1;
+    
+        // Catch the case where the last stop doesn't go all the way to 1.0 and
+        // pad it.
+        if s0 < 1.0 && s1 > 1.0 {
+            gradient_span(&mut dest, color0, color0, s0, 1.0);
+        } else {
+            gradient_span(&mut dest, color0, color1, s0, s1);
+        }
+
+        // If the first stop is >1.0 then we're done.
+        if s0 > 1.0 {
+            break
+        };
+    }
+    imgref::Img::new(dest.to_vec(), 256, 1)
+}

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -120,6 +120,7 @@ pub enum ShaderType {
     FillGradient,
     FillImage,
     Stencil,
+    FillImageGradient
 }
 
 impl Default for ShaderType {
@@ -134,6 +135,7 @@ impl ShaderType {
             Self::FillGradient => 0.0,
             Self::FillImage => 1.0,
             Self::Stencil => 2.0,
+            Self::FillImageGradient => 3.0
         }
     }
 }

--- a/src/renderer/opengl.rs
+++ b/src/renderer/opengl.rs
@@ -374,7 +374,7 @@ impl OpenGl {
         self.check_error("set_uniforms texture");
     }
 
-    fn clear_rect(&mut self, x: u32, y: u32, width: u32, height: u32, color: Color) {
+    fn clear_rect(&self, x: u32, y: u32, width: u32, height: u32, color: Color) {
         unsafe {
             self.context.enable(glow::SCISSOR_TEST);
             self.context.scissor(

--- a/src/renderer/opengl/main-fs.glsl
+++ b/src/renderer/opengl/main-fs.glsl
@@ -73,6 +73,16 @@ void main(void) {
         vec4 color = mix(innerCol,outerCol,d);
 
         result = color;
+    } else if (shaderType == 3) {
+        // Image-based Gradient; sample a texture using the gradient position.
+
+        // Calculate gradient color using box gradient
+        vec2 pt = (paintMat * vec3(fpos, 1.0)).xy;
+
+        float d = clamp((sdroundrect(pt, extent, radius) + feather*0.5) / feather, 0.0, 1.0);
+        vec4 color = texture2D(tex, vec2(d, 0.0));//mix(innerCol,outerCol,d);
+
+        result = color;
     } else if (shaderType == 1) {
         // Image
 


### PR DESCRIPTION
This change implements multi-stop gradients, and works for basic cases. It adds a gradient store, which is a cache of gradient textures maintained by the renderer. It might be that we want the Canvas to maintain the gradient cache.