### PR TITLE
hide alpha mask functions from public API, and update README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Run with `cargo run --example text`
 * [x] Anti-aliasing
 * [x] Bézier paths filling and stroking
 * [x] Solid color and image pattern fills and strokes
-* [x] Gradients - box, linear (2 points only) and radial
+* [x] Gradients - box, linear and radial
 * [x] Stroke width and miterlimit
 * [x] Stroke caps: butt, round and square
 * [x] Stroke joins: miter, round and bevel

--- a/src/paint.rs
+++ b/src/paint.rs
@@ -492,11 +492,15 @@ impl Paint {
         self.flavor = PaintFlavor::Color(color);
     }
 
-    pub fn alpha_mask(&self) -> Option<ImageId> {
+    pub(crate) fn alpha_mask(&self) -> Option<ImageId> {
         self.alpha_mask
     }
 
-    pub fn set_alpha_mask(&mut self, image_id: Option<ImageId>) {
+    /// Set an alpha mask; this is only used by draw_triangles which is used for text.
+    // This is scoped to crate visibility because fill_path and stroke_path don't propagate
+    // the alpha mask (so nothing draws), and the texture coordinates are used for antialiasing
+    // when path drawing.
+    pub(crate) fn set_alpha_mask(&mut self, image_id: Option<ImageId>) {
         self.alpha_mask = image_id;
     }
 


### PR DESCRIPTION
The alpha mask can only really be used via draw_triangles which also isn't exported (and is only used when drawing text from an atlas). This commit changes the public API by removing Paint::set_alpha_mask and Paint::alpha_mask.

The README removes the note that only two stops are supported in gradients, because we now have multi-stop gradients.