### PR TITLE
Fix WASM build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Install toolchain
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        override: true
+        profile: minimal
+        target: wasm32-unknown-unknown
+    - run: cargo build --verbose
+    - run: cargo build --verbose --target wasm32-unknown-unknown

--- a/src/renderer/opengl.rs
+++ b/src/renderer/opengl.rs
@@ -433,7 +433,7 @@ impl OpenGl {
     ///
     /// Pass `None` to clear any previous Framebuffer Object ID that was passed and target rendering to
     /// the default target (normally the window).
-    pub fn set_screen_target(&mut self, framebuffer_object: Option<u32>) {
+    pub fn set_screen_target(&mut self, framebuffer_object: Option<<glow::Context as glow::HasContext>::Framebuffer>) {
         match framebuffer_object {
             Some(fbo_id) => self.screen_target = Some(Framebuffer::from_external(&self.context, fbo_id)),
             None => self.screen_target = None


### PR DESCRIPTION
Use the glow Framebuffer type alias for set_screen_target, which aliases
to Gluint for native GL and a different type for web_sys.

This also includes a small very basic CI setup. Sample build: https://github.com/tronical/femtovg/actions/runs/454885480