### PR TITLE
Add API to allow specifying the index for true type font collections

### DIFF
--- a/examples/breakout.rs
+++ b/examples/breakout.rs
@@ -91,13 +91,13 @@ impl Game {
 
         let fonts = Fonts {
             regular: canvas
-                .add_font("examples/assets/Roboto-Regular.ttf")
+                .add_font("examples/assets/Roboto-Regular.ttf", None)
                 .expect("Cannot add font"),
             bold: canvas
-                .add_font("examples/assets/Roboto-Bold.ttf")
+                .add_font("examples/assets/Roboto-Bold.ttf", None)
                 .expect("Cannot add font"),
             light: canvas
-                .add_font("examples/assets/Roboto-Light.ttf")
+                .add_font("examples/assets/Roboto-Light.ttf", None)
                 .expect("Cannot add font"),
         };
 

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -90,13 +90,13 @@ fn main() {
 
     let fonts = Fonts {
         regular: canvas
-            .add_font_mem(&resource!("examples/assets/Roboto-Regular.ttf"))
+            .add_font_mem(&resource!("examples/assets/Roboto-Regular.ttf"), None)
             .expect("Cannot add font"),
         bold: canvas
-            .add_font_mem(&resource!("examples/assets/Roboto-Light.ttf"))
+            .add_font_mem(&resource!("examples/assets/Roboto-Light.ttf"), None)
             .expect("Cannot add font"),
         icons: canvas
-            .add_font_mem(&resource!("examples/assets/entypo.ttf"))
+            .add_font_mem(&resource!("examples/assets/entypo.ttf"), None)
             .expect("Cannot add font"),
     };
 

--- a/examples/gradients.rs
+++ b/examples/gradients.rs
@@ -27,7 +27,8 @@ fn main() {
         window_size.height as u32,
         windowed_context.window().scale_factor() as f32,
     );
-    canvas.add_font("examples/assets/Roboto-Regular.ttf")
+    canvas
+        .add_font("examples/assets/Roboto-Regular.ttf", None)
         .expect("Cannot add font");
     
     let start = Instant::now();

--- a/examples/svg.rs
+++ b/examples/svg.rs
@@ -25,11 +25,11 @@ fn main() {
     let mut canvas = Canvas::new(renderer).expect("Cannot create canvas");
 
     let roboto_light = canvas
-        .add_font("examples/assets/Roboto-Light.ttf")
+        .add_font("examples/assets/Roboto-Light.ttf", None)
         .expect("Cannot add font");
 
     let roboto_regular = canvas
-        .add_font("examples/assets/Roboto-Regular.ttf")
+        .add_font("examples/assets/Roboto-Regular.ttf", None)
         .expect("Cannot add font");
 
     let mut screenshot_image_id = None;

--- a/examples/text.rs
+++ b/examples/text.rs
@@ -36,19 +36,19 @@ fn main() {
 
     let fonts = Fonts {
         sans: canvas
-            .add_font("examples/assets/Roboto-Regular.ttf")
+            .add_font("examples/assets/Roboto-Regular.ttf", None)
             .expect("Cannot add font"),
         bold: canvas
-            .add_font("examples/assets/Roboto-Bold.ttf")
+            .add_font("examples/assets/Roboto-Bold.ttf", None)
             .expect("Cannot add font"),
         light: canvas
-            .add_font("examples/assets/Roboto-Light.ttf")
+            .add_font("examples/assets/Roboto-Light.ttf", None)
             .expect("Cannot add font"),
     };
 
     // The fact that a font is added to the canvas is enough for it to be considered when
     // searching for fallbacks
-    let _ = canvas.add_font("examples/assets/amiri-regular.ttf");
+    let _ = canvas.add_font("examples/assets/amiri-regular.ttf", None);
 
     let flags = ImageFlags::GENERATE_MIPMAPS | ImageFlags::REPEAT_X | ImageFlags::REPEAT_Y;
     let image_id = canvas

--- a/src/text/font.rs
+++ b/src/text/font.rs
@@ -90,8 +90,9 @@ pub(crate) struct Font {
 }
 
 impl Font {
-    pub fn new(data: &[u8]) -> Result<Self, ErrorKind> {
-        let owned_ttf_font = OwnedFont::from_vec(data.to_owned(), 0).ok_or(ErrorKind::FontParseError)?;
+    pub fn new(data: &[u8], index: Option<u32>) -> Result<Self, ErrorKind> {
+        let owned_ttf_font =
+            OwnedFont::from_vec(data.to_owned(), index.unwrap_or(0)).ok_or(ErrorKind::FontParseError)?;
 
         let units_per_em = owned_ttf_font
             .as_font()

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -149,7 +149,7 @@ fn text_location_respects_scale() {
     let mut canvas = Canvas::new(Void).unwrap();
 
     canvas
-        .add_font("examples/assets/Roboto-Regular.ttf")
+        .add_font("examples/assets/Roboto-Regular.ttf", None)
         .expect("Font not found");
 
     let mut paint = Paint::color(Color::black());


### PR DESCRIPTION
This is particularly useful for example when using femtovg in
combination with font-kit, which returns results that point towards
system fonts that may be font collections and then the index is
relevant.