### PR TITLE
Add font atlas debug functions, --features "debug_inspector"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ wasm-bindgen = { version = "0.2" }
 [features]
 default = ["image-loading"]
 image-loading = ["image"]
+debug_inspector = []
 
 [dev-dependencies]
 winit = { version = "0.24", default-features = false }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1154,6 +1154,26 @@ where
     fn state_mut(&mut self) -> &mut State {
         self.state_stack.last_mut().unwrap()
     }
+
+    #[cfg(feature = "debug_inspector")]
+    pub fn debug_inspector_get_font_textures(&self) -> Vec<ImageId> {
+        self.text_context.debug_inspector_get_textures()
+    }
+
+    #[cfg(feature = "debug_inspector")]
+    pub fn debug_inspector_draw_image(&mut self, id: ImageId) {
+        if let Ok(size) = self.image_size(id) {
+            let width  = size.0 as f32;
+            let height = size.1 as f32;
+            let mut path = Path::new();
+            path.rect(0f32, 0f32, width, height);
+            self.fill_path(&mut path, Paint::image(
+                id,
+                0f32, 0f32, width, height,
+                0f32, 1f32
+            ));
+        }
+    }
 }
 
 impl<T: Renderer> Drop for Canvas<T> {


### PR DESCRIPTION
cargo run --example text --features "debug_inspector" --release
Debug builds additionally fill unused areas of the font textures
with red to highlight the difference with the glyph boxes.

![Captura de pantalla_2021-01-12_19-25-27](https://user-images.githubusercontent.com/2456465/104356277-095d2580-550c-11eb-86d5-236c547ff1b9.png)
