### PR TITLE
Fix Canvas::intersect_scissor

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -656,7 +656,7 @@ where
         // Transform the current scissor rect into current transform space.
         // If there is difference in rotation, this will be approximation.
 
-        let mut pxform = Transform2D::identity();
+        let mut pxform = state.scissor.transform;
 
         let mut invxform = state.transform;
         invxform.inverse();


### PR DESCRIPTION
When a scissor rect is set initially, state.scissor.extent stores
half of the width and height, and state.scissir.transform holds
the translation matrix to reach the center of the scissor rectangle
(x + w * 0.5, y + w * 0.5).

When intersect_scissor tries to restore the original scissor rect in the
current transform space, the code started out just taking an identity
matrix and applying the inverse of the current transform. The "restored"
scissor rect that would be intersected with the new rect would have the
correct width and height (derived from state.scissor.extent), but it
would not have the correct location, because state.scissor.transform was
not used at all.

This appears to be an oversight in the port from NanoVG, which correctly
starts out with `pxform` at `state.scissor.transform` instead of the
identity matrix.