### PR TITLE
Fix polygon area calculation

### DIFF
--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -13,15 +13,6 @@ pub fn quantize(a: f32, d: f32) -> f32 {
     (a / d + 0.5).trunc() * d
 }
 
-pub fn triarea2(ax: f32, ay: f32, bx: f32, by: f32, cx: f32, cy: f32) -> f32 {
-    let abx = bx - ax;
-    let aby = by - ay;
-    let acx = cx - ax;
-    let acy = cy - ay;
-
-    acx * aby - abx * acy
-}
-
 pub fn pt_equals(x1: f32, y1: f32, x2: f32, y2: f32, tol: f32) -> bool {
     let dx = x2 - x1;
     let dy = y2 - y1;

--- a/src/path/cache.rs
+++ b/src/path/cache.rs
@@ -113,12 +113,8 @@ impl Contour {
     fn polygon_area(points: &[Point]) -> f32 {
         let mut area = 0.0;
 
-        for window in points.windows(3) {
-            let p0 = window[0];
-            let p1 = window[1];
-            let p2 = window[2];
-
-            area += geometry::triarea2(p0.x, p0.y, p1.x, p1.y, p2.x, p2.y);
+        for (p0, p1) in (PointPairsIter { curr: 0, points }) {
+            area += (p1.x - p0.x) * (p1.y + p0.y);
         }
 
         area * 0.5


### PR DESCRIPTION
The previous algorithm was incorrect because it didn't consider the triangle of the last two points and the first point, or of the last point and the first two points. It's been replaced with [one that works without calculating triangle area at all](https://stackoverflow.com/a/1165943).

This fixes some shapes being "randomly" thickened by the AA algorithm:
Before | After
--- | ---
![image](https://user-images.githubusercontent.com/25993062/115995295-bbdf6280-a5a8-11eb-9491-d85c0a712401.png) | ![image](https://user-images.githubusercontent.com/25993062/115995306-c568ca80-a5a8-11eb-974f-ffaa97b4cf14.png)

Holes in glyphs are still incorrectly thickened, but that's because they're clockwise shapes using the even-odd fill rule, so there's no way to tell that they're holes, and they get offset inwards. That seems to be a much harder problem to fix.