### PR TITLE
Fix leaking FBOs with the OpenGL renderer

### DIFF
--- a/src/image.rs
+++ b/src/image.rs
@@ -243,13 +243,13 @@ impl<T> ImageStore<T> {
 
     pub fn remove<R: Renderer<Image = T>>(&mut self, renderer: &mut R, id: ImageId) {
         if let Some(image) = self.0.remove(id.0) {
-            renderer.delete_image(image.1);
+            renderer.delete_image(image.1, id);
         }
     }
 
     pub fn clear<R: Renderer<Image = T>>(&mut self, renderer: &mut R) {
-        for (_idx, image) in self.0.drain() {
-            renderer.delete_image(image.1);
+        for (idx, image) in self.0.drain() {
+            renderer.delete_image(image.1, ImageId(idx));
         }
     }
 }

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -99,7 +99,7 @@ pub trait Renderer {
     fn alloc_image(&mut self, info: ImageInfo) -> Result<Self::Image, ErrorKind>;
     fn update_image(&mut self, image: &mut Self::Image, data: ImageSource, x: usize, y: usize)
         -> Result<(), ErrorKind>;
-    fn delete_image(&mut self, image: Self::Image);
+    fn delete_image(&mut self, image: Self::Image, image_id: ImageId);
 
     fn screenshot(&mut self) -> Result<ImgVec<RGBA8>, ErrorKind>;
 }

--- a/src/renderer/opengl.rs
+++ b/src/renderer/opengl.rs
@@ -577,7 +577,8 @@ impl Renderer for OpenGl {
         image.update(data, x, y, self.is_opengles_2_0)
     }
 
-    fn delete_image(&mut self, image: Self::Image) {
+    fn delete_image(&mut self, image: Self::Image, image_id: ImageId) {
+        self.framebuffers.remove(&image_id);
         image.delete();
     }
 

--- a/src/renderer/void.rs
+++ b/src/renderer/void.rs
@@ -14,6 +14,7 @@ use super::{
     Command,
     Renderer,
     Vertex,
+    ImageId
 };
 
 /// Void renderer used for testing
@@ -50,7 +51,7 @@ impl Renderer for Void {
         Ok(())
     }
 
-    fn delete_image(&mut self, image: Self::Image) {}
+    fn delete_image(&mut self, image: Self::Image, _image_id: ImageId) {}
 
     fn screenshot(&mut self) -> Result<ImgVec<RGBA8>, ErrorKind> {
         Ok(ImgVec::new(Vec::new(), 0, 0))


### PR DESCRIPTION
When rendering into an Image, we store the associated FBO (and depth
stencil RBO) in a hash in the GL renderer, indexed by the image id.
When deleting an image on the canvas, we should also delete the FBO/RBO,
instead of leaking it until the renderer is destroyed.

With this change it's even more important to not delete images that are
used as rendering targets until after flush().