### PR TITLE
Add support for applying a gaussian blur filter to images

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "femtovg"
 description = "Antialiased 2D vector drawing library"
-version = "0.1.3"
+version = "0.2.0"
 license = "MIT/Apache-2.0"
 readme = "README.md"
 authors = ["Peter Todorov <ptodorov@cytec.bg>", "Adam Nemecek <adamnemecek@gmail.com>"]

--- a/examples/paint_filter.rs
+++ b/examples/paint_filter.rs
@@ -1,0 +1,140 @@
+/**
+ * Shows how to use Canvas::filter_image() to apply a blur filter.
+ */
+use instant::Instant;
+
+use resource::resource;
+
+use glutin::{
+    event::{
+        Event,
+        WindowEvent,
+    },
+    event_loop::{
+        ControlFlow,
+        EventLoop,
+    },
+    window::WindowBuilder,
+    ContextBuilder,
+};
+
+use femtovg::{
+    renderer::OpenGl,
+    Canvas,
+    Color,
+    ImageFlags,
+    Paint,
+    Path,
+};
+
+fn main() {
+    let window_size = glutin::dpi::PhysicalSize::new(1000, 600);
+    let el = EventLoop::new();
+    let wb = WindowBuilder::new()
+        .with_inner_size(window_size)
+        .with_resizable(false)
+        .with_title("Canvas::filter_image example");
+
+    let windowed_context = ContextBuilder::new().build_windowed(wb, &el).unwrap();
+    let windowed_context = unsafe { windowed_context.make_current().unwrap() };
+
+    let renderer = OpenGl::new(|s| windowed_context.get_proc_address(s) as *const _).expect("Cannot create renderer");
+    let mut canvas = Canvas::new(renderer).expect("Cannot create canvas");
+    canvas.set_size(
+        window_size.width as u32,
+        window_size.height as u32,
+        windowed_context.window().scale_factor() as f32,
+    );
+
+    let image_id = canvas
+        .load_image_mem(&resource!("examples/assets/rust-logo.png"), ImageFlags::empty())
+        .unwrap();
+
+    let start = Instant::now();
+
+    el.run(move |event, _, control_flow| {
+        *control_flow = ControlFlow::Poll;
+
+        match event {
+            Event::LoopDestroyed => return,
+            Event::WindowEvent { ref event, .. } => match event {
+                WindowEvent::Resized(physical_size) => {
+                    windowed_context.resize(*physical_size);
+                }
+                WindowEvent::CloseRequested => *control_flow = ControlFlow::Exit,
+                _ => (),
+            },
+            Event::RedrawRequested(_) => {
+                let dpi_factor = windowed_context.window().scale_factor();
+                let window_size = windowed_context.window().inner_size();
+                canvas.set_size(window_size.width as u32, window_size.height as u32, dpi_factor as f32);
+                canvas.clear_rect(
+                    0,
+                    0,
+                    window_size.width as u32,
+                    window_size.height as u32,
+                    Color::rgbf(0.2, 0.2, 0.2),
+                );
+
+                canvas.save();
+                canvas.reset();
+
+                let mut filtered_image = None;
+
+                if let Ok(size) = canvas.image_size(image_id) {
+                    filtered_image = Some(
+                        canvas
+                            .create_image_empty(
+                                size.0,
+                                size.1,
+                                femtovg::PixelFormat::Rgba8,
+                                femtovg::ImageFlags::PREMULTIPLIED,
+                            )
+                            .unwrap(),
+                    );
+
+                    let now = Instant::now();
+                    let t = (now - start).as_secs_f32();
+                    let sigma = 2.5 + 2.5 * t.cos();
+
+                    canvas.filter_image(
+                        filtered_image.unwrap(),
+                        femtovg::ImageFilter::GaussianBlur { sigma },
+                        image_id,
+                    );
+
+                    let width = size.0 as f32;
+                    let height = size.1 as f32;
+                    let x = window_size.width as f32 / 2.0;
+                    let y = window_size.height as f32 / 2.0;
+
+                    let mut path = Path::new();
+                    path.rect(x - width / 2.0, y - height / 2.0, width, height);
+
+                    // Get the bounding box of the path so that we can stretch
+                    // the paint to cover it exactly:
+                    let bbox = canvas.path_bbox(&mut path);
+
+                    // Now we need to apply the current canvas transform
+                    // to the path bbox:
+                    let a = canvas.transform().inversed().transform_point(bbox.minx, bbox.miny);
+                    let b = canvas.transform().inversed().transform_point(bbox.maxx, bbox.maxy);
+
+                    canvas.fill_path(
+                        &mut path,
+                        Paint::image(filtered_image.unwrap(), a.0, a.1, b.0 - a.0, b.1 - a.1, 0f32, 1f32),
+                    );
+                }
+
+                canvas.restore();
+
+                canvas.flush();
+                windowed_context.swap_buffers().unwrap();
+
+                filtered_image.map(|img| canvas.delete_image(img));
+            }
+            Event::MainEventsCleared => windowed_context.window().request_redraw(),
+            _ => (),
+        }
+    });
+}

--- a/src/image.rs
+++ b/src/image.rs
@@ -253,3 +253,11 @@ impl<T> ImageStore<T> {
         }
     }
 }
+
+/// ImageFilter allows specifying the type of filter to apply to images with
+/// [`crate::Canvas::filter_image`].
+#[derive(Clone, Copy, Debug)]
+pub enum ImageFilter {
+    /// The filter shall be a gaussian blur with given sigma as standard deviation.
+    GaussianBlur { sigma: f32 },
+}

--- a/src/image.rs
+++ b/src/image.rs
@@ -257,6 +257,7 @@ impl<T> ImageStore<T> {
 /// ImageFilter allows specifying the type of filter to apply to images with
 /// [`crate::Canvas::filter_image`].
 #[derive(Clone, Copy, Debug)]
+#[non_exhaustive]
 pub enum ImageFilter {
     /// The filter shall be a gaussian blur with given sigma as standard deviation.
     GaussianBlur { sigma: f32 },

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -8,6 +8,7 @@ use crate::{
     CompositeOperationState,
     ErrorKind,
     FillRule,
+    ImageFilter,
     ImageId,
     ImageInfo,
     ImageSource,
@@ -56,6 +57,10 @@ pub enum CommandType {
     Triangles {
         params: Params,
     },
+    RenderFilteredImage {
+        target_image: ImageId,
+        filter: ImageFilter,
+    },
 }
 
 pub struct Command {
@@ -94,7 +99,7 @@ pub trait Renderer {
 
     fn set_size(&mut self, width: u32, height: u32, dpi: f32);
 
-    fn render(&mut self, images: &ImageStore<Self::Image>, verts: &[Vertex], commands: &[Command]);
+    fn render(&mut self, images: &mut ImageStore<Self::Image>, verts: &[Vertex], commands: Vec<Command>);
 
     fn alloc_image(&mut self, info: ImageInfo) -> Result<Self::Image, ErrorKind>;
     fn update_image(&mut self, image: &mut Self::Image, data: ImageSource, x: usize, y: usize)
@@ -130,6 +135,7 @@ pub enum ShaderType {
     FillImage,
     Stencil,
     FillImageGradient,
+    FilterImage,
 }
 
 impl Default for ShaderType {
@@ -145,6 +151,7 @@ impl ShaderType {
             Self::FillImage => 1.0,
             Self::Stencil => 2.0,
             Self::FillImageGradient => 3.0,
+            Self::FilterImage => 4.0,
         }
     }
 }

--- a/src/renderer/opengl.rs
+++ b/src/renderer/opengl.rs
@@ -18,9 +18,11 @@ use crate::{
     CompositeOperationState,
     ErrorKind,
     FillRule,
+    ImageFilter,
     ImageInfo,
     ImageSource,
     ImageStore,
+    Scissor,
 };
 
 use glow::HasContext;
@@ -31,6 +33,7 @@ use super::{
     Params,
     RenderTarget,
     Renderer,
+    ShaderType,
 };
 
 mod program;
@@ -57,6 +60,7 @@ pub struct OpenGl {
     framebuffers: FnvHashMap<ImageId, Result<Framebuffer, ErrorKind>>,
     context: Rc<glow::Context>,
     screen_target: Option<Framebuffer>,
+    current_render_target: RenderTarget,
 }
 
 impl OpenGl {
@@ -106,6 +110,7 @@ impl OpenGl {
             framebuffers: Default::default(),
             context: context.clone(),
             screen_target: None,
+            current_render_target: RenderTarget::Screen,
         };
 
         unsafe {
@@ -406,6 +411,7 @@ impl OpenGl {
     }
 
     fn set_target(&mut self, images: &ImageStore<GlTexture>, target: RenderTarget) {
+        self.current_render_target = target;
         match (target, &self.screen_target) {
             (RenderTarget::Screen, None) => unsafe {
                 Framebuffer::unbind(&self.context);
@@ -455,6 +461,94 @@ impl OpenGl {
             None => self.screen_target = None,
         }
     }
+
+    fn render_filtered_image(
+        &mut self,
+        images: &mut ImageStore<GlTexture>,
+        cmd: Command,
+        target_image: ImageId,
+        filter: ImageFilter,
+    ) {
+        match filter {
+            ImageFilter::GaussianBlur { sigma } => self.render_gaussian_blur(images, cmd, target_image, sigma),
+        }
+    }
+
+    fn render_gaussian_blur(
+        &mut self,
+        images: &mut ImageStore<GlTexture>,
+        mut cmd: Command,
+        target_image: ImageId,
+        sigma: f32,
+    ) {
+        let original_render_target = self.current_render_target;
+
+        // The filtering happens in two passes, first a horizontal blur and then the vertial blur. The
+        // first pass therefore renders into an intermediate, temporarily allocated texture.
+
+        let source_image_info = images.get(cmd.image.unwrap()).unwrap().info();
+
+        let image_paint = crate::Paint::image(
+            cmd.image.unwrap(),
+            0.,
+            0.,
+            source_image_info.width() as _,
+            source_image_info.height() as _,
+            0.,
+            1.,
+        );
+        let mut blur_params = Params::new(images, &image_paint, &Scissor::default(), 0., 0., 0.);
+        blur_params.shader_type = ShaderType::FilterImage.to_f32();
+
+        let gauss_coeff_x = 1. / ((2. * std::f32::consts::PI).sqrt() * sigma);
+        let gauss_coeff_y = f32::exp(-0.5 / (sigma * sigma));
+        let gauss_coeff_z = gauss_coeff_y * gauss_coeff_y;
+
+        blur_params.image_blur_filter_coeff[0] = gauss_coeff_x;
+        blur_params.image_blur_filter_coeff[1] = gauss_coeff_y;
+        blur_params.image_blur_filter_coeff[2] = gauss_coeff_z;
+
+        blur_params.image_blur_filter_direction = [1.0, 0.0];
+
+        blur_params.image_blur_filter_sigma = sigma;
+
+        let horizontal_blur_buffer = images.alloc(self, source_image_info).unwrap();
+        self.set_target(images, RenderTarget::Image(horizontal_blur_buffer));
+        self.main_program.set_view(self.view);
+
+        self.clear_rect(
+            0,
+            0,
+            source_image_info.width() as _,
+            source_image_info.height() as _,
+            Color::rgbaf(0., 0., 0., 0.),
+        );
+
+        self.triangles(images, &cmd, &blur_params);
+
+        self.set_target(images, RenderTarget::Image(target_image));
+        self.main_program.set_view(self.view);
+
+        self.clear_rect(
+            0,
+            0,
+            source_image_info.width() as _,
+            source_image_info.height() as _,
+            Color::rgbaf(0., 0., 0., 0.),
+        );
+
+        blur_params.image_blur_filter_direction = [0.0, 1.0];
+
+        cmd.image = Some(horizontal_blur_buffer);
+
+        self.triangles(images, &cmd, &blur_params);
+
+        images.remove(self, horizontal_blur_buffer);
+
+        // restore previous render target and view
+        self.set_target(images, original_render_target);
+        self.main_program.set_view(self.view);
+    }
 }
 
 impl Renderer for OpenGl {
@@ -471,7 +565,7 @@ impl Renderer for OpenGl {
         }
     }
 
-    fn render(&mut self, images: &ImageStore<Self::Image>, verts: &[Vertex], commands: &[Command]) {
+    fn render(&mut self, images: &mut ImageStore<Self::Image>, verts: &[Vertex], commands: Vec<Command>) {
         self.main_program.bind();
 
         unsafe {
@@ -520,18 +614,21 @@ impl Renderer for OpenGl {
 
         self.check_error("render prepare");
 
-        for cmd in commands {
+        for cmd in commands.into_iter() {
             self.set_composite_operation(cmd.composite_operation);
 
-            match &cmd.cmd_type {
-                CommandType::ConvexFill { params } => self.convex_fill(images, cmd, params),
+            match cmd.cmd_type {
+                CommandType::ConvexFill { ref params } => self.convex_fill(images, &cmd, params),
                 CommandType::ConcaveFill {
-                    stencil_params,
-                    fill_params,
-                } => self.concave_fill(images, cmd, stencil_params, fill_params),
-                CommandType::Stroke { params } => self.stroke(images, cmd, params),
-                CommandType::StencilStroke { params1, params2 } => self.stencil_stroke(images, cmd, params1, params2),
-                CommandType::Triangles { params } => self.triangles(images, cmd, params),
+                    ref stencil_params,
+                    ref fill_params,
+                } => self.concave_fill(images, &cmd, stencil_params, fill_params),
+                CommandType::Stroke { ref params } => self.stroke(images, &cmd, params),
+                CommandType::StencilStroke {
+                    ref params1,
+                    ref params2,
+                } => self.stencil_stroke(images, &cmd, params1, params2),
+                CommandType::Triangles { ref params } => self.triangles(images, &cmd, params),
                 CommandType::ClearRect {
                     x,
                     y,
@@ -539,11 +636,14 @@ impl Renderer for OpenGl {
                     height,
                     color,
                 } => {
-                    self.clear_rect(*x, *y, *width, *height, *color);
+                    self.clear_rect(x, y, width, height, color);
                 }
                 CommandType::SetRenderTarget(target) => {
-                    self.set_target(images, *target);
+                    self.set_target(images, target);
                     self.main_program.set_view(self.view);
+                }
+                CommandType::RenderFilteredImage { target_image, filter } => {
+                    self.render_filtered_image(images, cmd, target_image, filter)
                 }
             }
         }

--- a/src/renderer/opengl.rs
+++ b/src/renderer/opengl.rs
@@ -510,7 +510,9 @@ impl OpenGl {
 
         blur_params.image_blur_filter_direction = [1.0, 0.0];
 
-        blur_params.image_blur_filter_sigma = sigma;
+        // GLES 2.0 does not allow non-constant loop indices, so limit the standard devitation to allow for a upper fixed limit
+        // on the number of iterations in the fragment shader.
+        blur_params.image_blur_filter_sigma = sigma.min(8.);
 
         let horizontal_blur_buffer = images.alloc(self, source_image_info).unwrap();
         self.set_target(images, RenderTarget::Image(horizontal_blur_buffer));

--- a/src/renderer/opengl/main-fs.glsl
+++ b/src/renderer/opengl/main-fs.glsl
@@ -115,7 +115,12 @@ void main(void) {
         float coefficient_sum = gaussian_coeff.x;
         gaussian_coeff.xy *= gaussian_coeff.yz;
 
-        for (float i = 1.0; i <= sampleCount; i += 1.) {
+        for (float i = 1.0; i <= 12.0; i += 1.) {
+            // Work around GLES 2.0 limitation of only allowing constant loop indices
+            // by breaking here. Sigma has an upper bound of 8, imposed on the Rust side.
+            if (i >= sampleCount) {
+                break;
+            }
             color_sum += texture2D(tex, (fpos.xy - i * imageBlurFilterDirection) / extent) * gaussian_coeff.x;         
             color_sum += texture2D(tex, (fpos.xy + i * imageBlurFilterDirection) / extent) * gaussian_coeff.x;         
             coefficient_sum += 2.0 * gaussian_coeff.x;

--- a/src/renderer/opengl/main-fs.glsl
+++ b/src/renderer/opengl/main-fs.glsl
@@ -1,7 +1,7 @@
 
 precision highp float;
 
-#define UNIFORMARRAY_SIZE 12
+#define UNIFORMARRAY_SIZE 14
 
 uniform vec4 frag[UNIFORMARRAY_SIZE];
 
@@ -19,6 +19,9 @@ uniform vec4 frag[UNIFORMARRAY_SIZE];
 #define texType int(frag[10].z)
 #define shaderType int(frag[10].w)
 #define hasMask int(frag[11].x)
+#define imageBlurFilterDirection frag[11].yz
+#define imageBlurFilterSigma frag[11].w
+#define imageBlurFilterCoeff frag[12].xyz
 
 uniform sampler2D tex;
 uniform sampler2D masktex;
@@ -101,6 +104,33 @@ void main(void) {
     } else if (shaderType == 2) {
         // Stencil fill
         result = vec4(1,1,1,1);
+    } else if (shaderType == 4) {
+        // Filter Image
+
+        float sampleCount = ceil(1.5 * imageBlurFilterSigma);
+
+        vec3 gaussian_coeff = imageBlurFilterCoeff;
+
+        vec4 color_sum = texture2D(tex, fpos.xy / extent) * gaussian_coeff.x;
+        float coefficient_sum = gaussian_coeff.x;
+        gaussian_coeff.xy *= gaussian_coeff.yz;
+
+        for (float i = 1.0; i <= sampleCount; i += 1.) {
+            color_sum += texture2D(tex, (fpos.xy - i * imageBlurFilterDirection) / extent) * gaussian_coeff.x;         
+            color_sum += texture2D(tex, (fpos.xy + i * imageBlurFilterDirection) / extent) * gaussian_coeff.x;         
+            coefficient_sum += 2.0 * gaussian_coeff.x;
+            
+            // Compute the coefficients incrementally:
+            // https://developer.nvidia.com/gpugems/gpugems3/part-vi-gpu-computing/chapter-40-incremental-computation-gaussian
+            gaussian_coeff.xy *= gaussian_coeff.yz;
+        }
+
+        vec4 color = color_sum / coefficient_sum;
+
+        if (texType == 1) color = vec4(color.xyz * color.w, color.w);
+        if (texType == 2) color = vec4(color.x);
+
+        result = color;
     }
 
     if (hasMask == 1) {
@@ -113,7 +143,7 @@ void main(void) {
 
         mask *= scissor;
         result *= mask;
-    } else if (shaderType != 2) { // Not stencil fill
+    } else if (shaderType != 2 && shaderType != 4) { // Not stencil fill
         // Combine alpha
         result *= strokeAlpha * scissor;
     }

--- a/src/renderer/opengl/uniform_array.rs
+++ b/src/renderer/opengl/uniform_array.rs
@@ -1,6 +1,6 @@
 use super::Params;
 
-const UNIFORMARRAY_SIZE: usize = 12;
+const UNIFORMARRAY_SIZE: usize = 14;
 
 pub struct UniformArray([f32; UNIFORMARRAY_SIZE * 4]);
 
@@ -9,7 +9,7 @@ impl Default for UniformArray {
         Self([
             0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
             0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
-            0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+            0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
         ])
     }
 }
@@ -74,6 +74,18 @@ impl UniformArray {
     pub fn set_has_mask(&mut self, has_mask: f32) {
         self.0[44] = has_mask;
     }
+
+    pub fn set_image_blur_filter_direction(&mut self, direction: [f32; 2]) {
+        self.0[45..47].copy_from_slice(&direction);
+    }
+
+    pub fn set_image_blur_filter_sigma(&mut self, sigma: f32) {
+        self.0[47] = sigma;
+    }
+
+    pub fn set_image_blur_filter_coeff(&mut self, coeff: [f32; 3]) {
+        self.0[48..51].copy_from_slice(&coeff);
+    }
 }
 
 impl From<&Params> for UniformArray {
@@ -94,6 +106,9 @@ impl From<&Params> for UniformArray {
         arr.set_shader_type(params.shader_type);
         arr.set_tex_type(params.tex_type);
         arr.set_has_mask(params.has_mask);
+        arr.set_image_blur_filter_direction(params.image_blur_filter_direction);
+        arr.set_image_blur_filter_sigma(params.image_blur_filter_sigma);
+        arr.set_image_blur_filter_coeff(params.image_blur_filter_coeff);
 
         arr
     }

--- a/src/renderer/params.rs
+++ b/src/renderer/params.rs
@@ -28,6 +28,9 @@ pub struct Params {
     pub(crate) tex_type: f32,
     pub(crate) shader_type: f32,
     pub(crate) has_mask: f32,
+    pub(crate) image_blur_filter_direction: [f32; 2],
+    pub(crate) image_blur_filter_sigma: f32,
+    pub(crate) image_blur_filter_coeff: [f32; 3],
 }
 
 impl Params {

--- a/src/renderer/void.rs
+++ b/src/renderer/void.rs
@@ -25,7 +25,7 @@ impl Renderer for Void {
 
     fn set_size(&mut self, width: u32, height: u32, dpi: f32) {}
 
-    fn render(&mut self, images: &ImageStore<VoidImage>, verts: &[Vertex], commands: &[Command]) {}
+    fn render(&mut self, images: &mut ImageStore<VoidImage>, verts: &[Vertex], commands: Vec<Command>) {}
 
     fn alloc_image(&mut self, info: ImageInfo) -> Result<Self::Image, ErrorKind> {
         Ok(VoidImage { info })


### PR DESCRIPTION
This adds the

```rust
   pub fn filter_image(&mut self, target_image: ImageId, filter: ImageFilter, source_image: ImageId)
```

function to the renderer, where the ImageFilter is an enum that starts
with a gaussian blur and the standard deviation parameter.

The GL renderer renders this in two passes, a horizontal and a vertical
blur.

Apart from adding filter code path, this patch makes one other change to
the rendering interface: The drawing commands are now moved from the
canvas to the renderer. This is needed because then the second pass in
the blur filter can just change the Command's image parameter, as it
consumes it. Otherwise Command would have to implement Clone, which
would likely be expensive due to the Vec fields within.