### PR TITLE
miniquad renderer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,6 @@ lru = { version = "0.6.5", default-features = false }
 image = { version = "0.23.6", optional = true, default-features = false }
 serde = { version = "1.0", optional = true, features = ["derive"] }
 miniquad = "0.3.0-alpha.37"
-glam = "0.17"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 glow = { version = "0.10.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,8 @@ generational-arena = "0.2.8"
 lru = { version = "0.6.5", default-features = false }
 image = { version = "0.23.6", optional = true, default-features = false }
 serde = { version = "1.0", optional = true, features = ["derive"] }
+miniquad = "0.3.0-alpha.37"
+glam = "0.17"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 glow = { version = "0.10.0", default-features = false }

--- a/examples/miniquad.rs
+++ b/examples/miniquad.rs
@@ -1,0 +1,97 @@
+use instant::Instant;
+
+use miniquad::*;
+
+use femtovg::{renderer::Miniquad, Canvas, Color, Paint, Path};
+struct Stage {
+    canvas: Canvas<Miniquad>,
+
+    screen_size: (f32, f32),
+    dpi_scale: f32,
+
+    start: Instant,
+    size: (f32, f32),
+}
+
+impl Stage {
+    pub fn new(ctx: Context) -> Stage {
+        let screen_size = ctx.screen_size();
+        let dpi_scale = ctx.dpi_scale();
+
+        let renderer = Miniquad::new(ctx).expect("Cannot create renderer");
+        let canvas = Canvas::new(renderer).expect("Cannot create canvas");
+
+        let start = Instant::now();
+        let size = (512., 416.);
+
+        Stage {
+            canvas,
+            screen_size,
+            dpi_scale,
+            start,
+            size,
+        }
+    }
+}
+
+impl EventHandlerFree for Stage {
+    fn update(&mut self) {}
+
+    fn draw(&mut self) {
+        self.canvas
+            .set_size(self.screen_size.0 as u32, self.screen_size.1 as u32, self.dpi_scale);
+        self.canvas.clear_rect(
+            0,
+            0,
+            self.screen_size.0 as u32,
+            self.screen_size.1 as u32,
+            Color::rgbf(0.2, 0.2, 0.2),
+        );
+
+        self.canvas.save();
+        self.canvas.reset();
+
+        self.canvas
+            .translate(self.screen_size.0 as f32 / 2.0, self.screen_size.1 as f32 / 2.0);
+        self.canvas
+            .translate(self.screen_size.0 as f32 / -2.0, self.screen_size.1 as f32 / -2.0);
+
+        let now = Instant::now();
+        let t = (now - self.start).as_secs_f32();
+
+        // Shake things a bit to notice if we forgot something:
+        self.canvas.translate(60.0 * (t / 3.0).cos(), 60.0 * (t / 5.0).sin());
+
+        let rx = 100.0 * t.cos();
+        let ry = 100.0 * t.sin();
+        let width = f32::max(1.0, self.size.0 as f32 + rx);
+        let height = f32::max(1.0, self.size.1 as f32 + ry);
+        let x = self.screen_size.0 as f32 / 2.0;
+        let y = self.screen_size.1 as f32 / 2.0;
+
+        let mut path = Path::new();
+        path.rect(x - width / 2.0, y - height / 2.0, width, height);
+
+        self.canvas.fill_path(&mut path, Paint::color(Color::rgb(255, 80, 255)));
+
+        self.canvas.restore();
+
+        self.canvas.flush();
+
+        // ctx.commit_frame();
+    }
+}
+
+fn main() {
+    miniquad::start(
+        conf::Conf {
+            window_title: "pink box example".to_string(),
+            window_width: 1000,
+            window_height: 600,
+            window_resizable: false,
+            high_dpi: true,
+            ..Default::default()
+        },
+        |ctx| UserData::free(Stage::new(ctx)),
+    );
+}

--- a/examples/paint_filter_miniquad.rs
+++ b/examples/paint_filter_miniquad.rs
@@ -1,0 +1,130 @@
+/**
+ * Shows how to use Canvas::filter_image() to apply a blur filter.
+ */
+use instant::Instant;
+
+use resource::resource;
+
+use miniquad::*;
+
+use femtovg::{renderer::Miniquad, Canvas, Color, ImageFlags, ImageId, Paint, Path};
+struct Stage {
+    canvas: Canvas<Miniquad>,
+
+    screen_size: (f32, f32),
+    dpi_scale: f32,
+
+    image_id: ImageId,
+    start: Instant,
+}
+
+impl Stage {
+    pub fn new(ctx: Context) -> Stage {
+        let screen_size = ctx.screen_size();
+        let dpi_scale = ctx.dpi_scale();
+
+        let renderer = Miniquad::new(ctx).expect("Cannot create renderer");
+        let mut canvas = Canvas::new(renderer).expect("Cannot create canvas");
+
+        let image_id = canvas
+            .load_image_mem(&resource!("examples/assets/rust-logo.png"), ImageFlags::empty())
+            .unwrap();
+
+        let start = Instant::now();
+
+        Stage {
+            canvas,
+            screen_size,
+            dpi_scale,
+            image_id,
+            start,
+        }
+    }
+}
+
+impl EventHandlerFree for Stage {
+    fn update(&mut self) {}
+
+    fn draw(&mut self) {
+        self.canvas
+            .set_size(self.screen_size.0 as u32, self.screen_size.1 as u32, self.dpi_scale);
+        self.canvas.clear_rect(
+            0,
+            0,
+            self.screen_size.0 as u32,
+            self.screen_size.1 as u32,
+            Color::rgbf(0.2, 0.2, 0.2),
+        );
+
+        self.canvas.save();
+        self.canvas.reset();
+
+        let mut filtered_image = None;
+
+        if let Ok(size) = self.canvas.image_size(self.image_id) {
+            filtered_image = Some(
+                self.canvas
+                    .create_image_empty(
+                        size.0,
+                        size.1,
+                        femtovg::PixelFormat::Rgba8,
+                        femtovg::ImageFlags::PREMULTIPLIED,
+                    )
+                    .unwrap(),
+            );
+
+            let now = Instant::now();
+            let t = (now - self.start).as_secs_f32();
+            let sigma = 2.5 + 2.5 * t.cos();
+
+            self.canvas.filter_image(
+                filtered_image.unwrap(),
+                femtovg::ImageFilter::GaussianBlur { sigma },
+                self.image_id,
+            );
+
+            let width = size.0 as f32;
+            let height = size.1 as f32;
+            let x = self.screen_size.0 as f32 / 2.0;
+            let y = self.screen_size.1 as f32 / 2.0;
+
+            let mut path = Path::new();
+            path.rect(x - width / 2.0, y - height / 2.0, width, height);
+
+            // Get the bounding box of the path so that we can stretch
+            // the paint to cover it exactly:
+            let bbox = self.canvas.path_bbox(&mut path);
+
+            // Now we need to apply the current canvas transform
+            // to the path bbox:
+            let a = self.canvas.transform().inversed().transform_point(bbox.minx, bbox.miny);
+            let b = self.canvas.transform().inversed().transform_point(bbox.maxx, bbox.maxy);
+
+            self.canvas.fill_path(
+                &mut path,
+                Paint::image(filtered_image.unwrap(), a.0, a.1, b.0 - a.0, b.1 - a.1, 0f32, 1f32),
+            );
+        }
+
+        self.canvas.restore();
+
+        self.canvas.flush();
+        // ctx.commit_frame();
+
+        filtered_image.map(|img| self.canvas.delete_image(img));
+    }
+}
+
+fn main() {
+    miniquad::start(
+        conf::Conf {
+            window_title: "Canvas::filter_image example".to_string(),
+            window_width: 1000,
+            window_height: 600,
+            window_resizable: false,
+            high_dpi: true,
+            ..Default::default()
+        },
+        |ctx| UserData::free(Stage::new(ctx)),
+    );
+}

--- a/examples/paint_image_miniquad.rs
+++ b/examples/paint_image_miniquad.rs
@@ -1,0 +1,235 @@
+/**
+ * Shows how to work with Paint::image() to fill paths.
+ * The image is rendered independently of the shape of the path,
+ * it does not get stretched to fit the path’s bounding box.
+ * If that’s what you want, you have to compute the bounding box with
+ * Canvas::path_bbox() and use it to set the cx, cy, width, height values
+ * in Paint::image() as shown in this example.
+ */
+use instant::Instant;
+
+use miniquad::*;
+
+use femtovg::{renderer::Miniquad, Canvas, Color, ImageFlags, ImageId, Paint, Path, PixelFormat, RenderTarget};
+struct Stage {
+    canvas: Canvas<Miniquad>,
+
+    screen_size: (f32, f32),
+    dpi_scale: f32,
+
+    image_id: ImageId,
+    start: Instant,
+    zoom: i32,
+    shape: Shape,
+    time_warp: i32,
+    swap_directions: bool,
+}
+
+enum Shape {
+    Rect,
+    Ellipse,
+    Polar,
+}
+
+impl Stage {
+    pub fn new(ctx: Context) -> Stage {
+        let screen_size = ctx.screen_size();
+        let dpi_scale = ctx.dpi_scale();
+
+        let renderer = Miniquad::new(ctx).expect("Cannot create renderer");
+        let mut canvas = Canvas::new(renderer).expect("Cannot create canvas");
+
+        // Prepare the image, in this case a grid.
+        let grid_size: usize = 16;
+        let image_id = canvas
+            .create_image_empty(
+                32 * grid_size + 1,
+                26 * grid_size + 1,
+                PixelFormat::Rgba8,
+                ImageFlags::empty(),
+            )
+            .unwrap();
+        canvas.save();
+        canvas.reset();
+        if let Ok(size) = canvas.image_size(image_id) {
+            canvas.set_render_target(RenderTarget::Image(image_id));
+            canvas.clear_rect(0, 0, size.0 as u32, size.1 as u32, Color::rgb(0, 0, 0));
+            let x_max = (size.0 / grid_size) - 1;
+            let y_max = (size.1 / grid_size) - 1;
+            for x in 0..(size.0 / grid_size) {
+                for y in 0..(size.1 / grid_size) {
+                    canvas.clear_rect(
+                        (x * grid_size + 1) as u32,
+                        (y * grid_size + 1) as u32,
+                        (grid_size - 1) as u32,
+                        (grid_size - 1) as u32,
+                        if x == 0 || y == 0 || x == x_max || y == y_max {
+                            Color::rgb(40, 80, 40)
+                        } else {
+                            match (x % 2, y % 2) {
+                                (0, 0) => Color::rgb(125, 125, 125),
+                                (1, 0) => Color::rgb(155, 155, 155),
+                                (0, 1) => Color::rgb(155, 155, 155),
+                                (1, 1) => Color::rgb(105, 105, 155),
+                                _ => Color::rgb(255, 0, 255),
+                            }
+                        },
+                    );
+                }
+            }
+        }
+        canvas.restore();
+
+        let start = Instant::now();
+
+        let zoom = 0;
+        let shape = Shape::Rect;
+        let time_warp = 0;
+
+        eprintln!("Scroll vertically to change zoom, horizontally (or vertically with Shift) to change time warp, click to cycle shape.");
+
+        let swap_directions = false;
+
+        Stage {
+            canvas,
+            screen_size,
+            dpi_scale,
+            image_id,
+            start,
+            zoom,
+            shape,
+            time_warp,
+            swap_directions,
+        }
+    }
+}
+
+impl EventHandlerFree for Stage {
+    fn update(&mut self) {}
+
+    fn key_down_event(&mut self, _keycode: KeyCode, keymods: KeyMods, _repeat: bool) {
+        self.swap_directions = keymods.shift;
+    }
+
+    fn key_up_event(&mut self, _keycode: KeyCode, keymods: KeyMods) {
+        self.swap_directions = keymods.shift;
+    }
+
+    fn mouse_wheel_event(&mut self, x: f32, y: f32) {
+        if self.swap_directions {
+            self.time_warp += y as i32;
+            self.zoom += x as i32;
+        } else {
+            self.time_warp += x as i32;
+            self.zoom += y as i32;
+        }
+    }
+
+    fn mouse_button_down_event(&mut self, _button: MouseButton, _x: f32, _y: f32) {
+        self.shape = match self.shape {
+            Shape::Rect => Shape::Ellipse,
+            Shape::Ellipse => Shape::Polar,
+            Shape::Polar => Shape::Rect,
+        };
+    }
+
+    fn draw(&mut self) {
+        self.canvas
+            .set_size(self.screen_size.0 as u32, self.screen_size.1 as u32, self.dpi_scale);
+        self.canvas.clear_rect(
+            0,
+            0,
+            self.screen_size.0 as u32,
+            self.screen_size.1 as u32,
+            Color::rgbf(0.2, 0.2, 0.2),
+        );
+
+        self.canvas.save();
+        self.canvas.reset();
+
+        let zoom = (self.zoom as f32 / 40.0).exp();
+        let time_warp = (self.time_warp as f32 / 20.0).exp();
+        self.canvas
+            .translate(self.screen_size.0 as f32 / 2.0, self.screen_size.1 as f32 / 2.0);
+        self.canvas.scale(zoom, zoom);
+        self.canvas
+            .translate(self.screen_size.0 as f32 / -2.0, self.screen_size.1 as f32 / -2.0);
+
+        if let Ok(size) = self.canvas.image_size(self.image_id) {
+            let now = Instant::now();
+            let t = (now - self.start).as_secs_f32() * time_warp;
+
+            // Shake things a bit to notice if we forgot something:
+            self.canvas.translate(60.0 * (t / 3.0).cos(), 60.0 * (t / 5.0).sin());
+
+            let rx = 100.0 * t.cos();
+            let ry = 100.0 * t.sin();
+            let width = f32::max(1.0, size.0 as f32 * zoom + rx);
+            let height = f32::max(1.0, size.1 as f32 * zoom + ry);
+            let x = self.screen_size.0 as f32 / 2.0;
+            let y = self.screen_size.1 as f32 / 2.0;
+
+            let mut path = Path::new();
+            match &self.shape {
+                Shape::Rect => {
+                    path.rect(x - width / 2.0, y - height / 2.0, width, height);
+                }
+                Shape::Ellipse => {
+                    let rx = width / 2.0;
+                    let ry = height / 2.0;
+                    path.ellipse(x, y, rx, ry);
+                }
+                Shape::Polar => {
+                    const TO_RADIANS: f32 = std::f32::consts::PI / 180.0;
+                    for theta in 0..360 {
+                        let theta = theta as f32 * TO_RADIANS;
+                        let r = width / 3.0 + width / 2.0 * (3.0 * theta + t).cos();
+                        let x = x + r * theta.cos();
+                        let y = y + r * theta.sin();
+                        if path.is_empty() {
+                            path.move_to(x, y);
+                        } else {
+                            path.line_to(x, y);
+                        }
+                    }
+                    path.close();
+                    path.circle(x, y, width / 5.0);
+                }
+            }
+
+            // Get the bounding box of the path so that we can stretch
+            // the paint to cover it exactly:
+            let bbox = self.canvas.path_bbox(&mut path);
+
+            // Now we need to apply the current canvas transform
+            // to the path bbox:
+            let a = self.canvas.transform().inversed().transform_point(bbox.minx, bbox.miny);
+            let b = self.canvas.transform().inversed().transform_point(bbox.maxx, bbox.maxy);
+
+            self.canvas.fill_path(
+                &mut path,
+                Paint::image(self.image_id, a.0, a.1, b.0 - a.0, b.1 - a.1, 0f32, 1f32),
+            );
+        }
+
+        self.canvas.restore();
+
+        self.canvas.flush();
+
+        // ctx.commit_frame();
+    }
+}
+
+fn main() {
+    miniquad::start(
+        conf::Conf {
+            window_title: "Paint::image example".to_string(),
+            window_width: 1000,
+            window_height: 600,
+            window_resizable: false,
+            high_dpi: true,
+            ..Default::default()
+        },
+        |ctx| UserData::free(Stage::new(ctx)),
+    );
+}

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -58,6 +58,7 @@ pub enum CommandType {
     },
 }
 
+#[derive(Debug)]
 pub struct Command {
     pub(crate) cmd_type: CommandType,
     pub(crate) drawables: Vec<Drawable>,

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -4,19 +4,14 @@ use imgref::ImgVec;
 use rgb::RGBA8;
 
 use crate::{
-    Color,
-    CompositeOperationState,
-    ErrorKind,
-    FillRule,
-    ImageFilter,
-    ImageId,
-    ImageInfo,
-    ImageSource,
-    ImageStore,
+    Color, CompositeOperationState, ErrorKind, FillRule, ImageFilter, ImageId, ImageInfo, ImageSource, ImageStore,
 };
 
 mod opengl;
 pub use opengl::OpenGl;
+
+mod miniquad;
+pub use self::miniquad::Miniquad;
 
 mod void;
 pub use void::Void;

--- a/src/renderer/miniquad.rs
+++ b/src/renderer/miniquad.rs
@@ -1,0 +1,995 @@
+use imgref::ImgVec;
+use rgb::RGBA8;
+
+use miniquad as mq;
+type GlTexture = mq::Texture;
+
+use crate::{
+    renderer::{ImageId, Vertex},
+    BlendFactor, Color, CompositeOperationState, ErrorKind, FillRule, ImageFilter, ImageFlags, ImageInfo, ImageSource,
+    ImageStore, PixelFormat, Scissor,
+};
+
+use super::{Command, CommandType, Params, RenderTarget, Renderer, ShaderType};
+
+pub struct Miniquad {
+    debug: bool,
+    antialias: bool,
+    is_opengles_2_0: bool,
+    view: [f32; 2],
+    screen_view: [f32; 2],
+    pipeline: mq::Pipeline,
+    bindings: mq::Bindings,
+    empty_texture: mq::Texture,
+    // vert_arr: Option<<glow::Context as glow::HasContext>::VertexArray>,
+    // vert_buff: Option<<glow::Context as glow::HasContext>::Buffer>,
+    // framebuffers: FnvHashMap<ImageId, Result<Framebuffer, ErrorKind>>,
+    ctx: mq::Context,
+    // screen_target: Option<Framebuffer>,
+    current_render_target: RenderTarget,
+}
+
+mod shader {
+    use miniquad::*;
+
+    pub const GLSL_VERSION: &str = "#version 100";
+    pub const VERTEX: &str = include_str!("opengl/main-vs.glsl");
+    pub const FRAGMENT: &str = include_str!("opengl/main-fs.glsl");
+
+    pub const MAX_VERTICES: usize = 21845; // u16.max / 3 due to index buffer limitations
+    pub const MAX_INDICES: usize = u16::max_value() as usize;
+
+    pub const ATTRIBUTES: &[VertexAttribute] = &[
+        VertexAttribute::new("vertex", VertexFormat::Float2),
+        VertexAttribute::new("tcoord", VertexFormat::Float2),
+    ];
+    pub fn meta() -> ShaderMeta {
+        ShaderMeta {
+            images: vec!["tex".to_string(), "masktex".to_string()],
+            uniforms: UniformBlockLayout {
+                uniforms: vec![
+                    UniformDesc::new("viewSize", UniformType::Float2),
+                    UniformDesc::new("scissorMat", UniformType::Mat4),
+                    UniformDesc::new("paintMat", UniformType::Mat4),
+                    UniformDesc::new("innerCol", UniformType::Float4),
+                    UniformDesc::new("outerCol", UniformType::Float4),
+                    UniformDesc::new("scissorExt", UniformType::Float2),
+                    UniformDesc::new("scissorScale", UniformType::Float2),
+                    UniformDesc::new("extent", UniformType::Float2),
+                    UniformDesc::new("radius", UniformType::Float1),
+                    UniformDesc::new("feather", UniformType::Float1),
+                    UniformDesc::new("strokeMult", UniformType::Float1),
+                    UniformDesc::new("strokeThr", UniformType::Float1),
+                    UniformDesc::new("texType", UniformType::Int1),
+                    UniformDesc::new("shaderType", UniformType::Int1),
+                    UniformDesc::new("hasMask", UniformType::Int1),
+                    UniformDesc::new("imageBlurFilterDirection", UniformType::Float2),
+                    UniformDesc::new("imageBlurFilterSigma", UniformType::Float1),
+                    UniformDesc::new("imageBlurFilterCoeff", UniformType::Float3),
+                ],
+            },
+        }
+    }
+
+    #[derive(Default)]
+    #[repr(C)]
+    pub struct Uniforms {
+        pub view_size: [f32; 2],
+        pub scissor_mat: glam::Mat4,
+        pub paint_mat: glam::Mat4,
+        pub inner_col: [f32; 4],
+        pub outer_col: [f32; 4],
+        pub scissor_ext: [f32; 2],
+        pub scissor_scale: [f32; 2],
+        pub extent: [f32; 2],
+        pub radius: f32,
+        pub feather: f32,
+        pub stroke_mult: f32,
+        pub stroke_thr: f32,
+        pub tex_type: i32,
+        pub shader_type: i32,
+        pub has_mask: i32,
+        pub image_blur_filter_direction: [f32; 2],
+        pub image_blur_filter_sigma: f32,
+        pub image_blur_filter_coeff: [f32; 3],
+    }
+}
+
+impl From<&Params> for shader::Uniforms {
+    fn from(params: &Params) -> Self {
+        let mut scissor_vec = params.scissor_mat.to_vec();
+        scissor_vec.extend([0., 0., 0., 1.].to_vec());
+        let mut paint_vec = params.paint_mat.to_vec();
+        paint_vec.extend([0., 0., 0., 1.].to_vec());
+
+        Self {
+            scissor_mat: glam::Mat4::from_cols_slice(scissor_vec.as_slice()),
+            paint_mat: glam::Mat4::from_cols_slice(paint_vec.as_slice()),
+            inner_col: params.inner_col,
+            outer_col: params.outer_col,
+            scissor_ext: params.scissor_ext,
+            scissor_scale: params.scissor_scale,
+            extent: params.extent,
+            radius: params.radius,
+            feather: params.feather,
+            stroke_mult: params.stroke_mult,
+            stroke_thr: params.stroke_thr,
+            tex_type: params.tex_type as i32,
+            shader_type: params.shader_type as i32,
+            has_mask: params.has_mask as i32,
+            image_blur_filter_direction: params.image_blur_filter_direction,
+            image_blur_filter_sigma: params.image_blur_filter_sigma,
+            image_blur_filter_coeff: params.image_blur_filter_coeff,
+            ..Default::default()
+        }
+    }
+}
+
+impl Miniquad {
+    pub fn new(mut ctx: mq::Context) -> Result<Self, ErrorKind> {
+        let debug = cfg!(debug_assertions);
+        let antialias = true;
+
+        let shader_defs = if antialias { "#define EDGE_AA 1" } else { "" };
+        let vert_shader_src = format!("{}\n{}\n{}", shader::GLSL_VERSION, shader_defs, shader::VERTEX);
+        let frag_shader_src = format!("{}\n{}\n{}", shader::GLSL_VERSION, shader_defs, shader::FRAGMENT);
+
+        let shader = mq::Shader::new(
+            &mut ctx,
+            vert_shader_src.as_str(),
+            frag_shader_src.as_str(),
+            shader::meta(),
+        )
+        .map_err(|error| ErrorKind::ShaderCompileError(error.to_string()))?;
+        let pipeline = mq::Pipeline::with_params(
+            &mut ctx,
+            &[mq::BufferLayout::default()],
+            shader::ATTRIBUTES,
+            shader,
+            mq::PipelineParams {
+                depth_write: false,
+                color_blend: None,
+                color_write: (true, true, true, true),
+                front_face_order: mq::FrontFaceOrder::CounterClockwise,
+                ..Default::default()
+            },
+        );
+
+        let vertex_buffer = mq::Buffer::stream(
+            &mut ctx,
+            mq::BufferType::VertexBuffer,
+            shader::MAX_VERTICES * std::mem::size_of::<Vertex>(),
+        );
+        let index_buffer = mq::Buffer::stream(
+            &mut ctx,
+            mq::BufferType::IndexBuffer,
+            shader::MAX_INDICES * std::mem::size_of::<u16>(),
+        );
+
+        let empty_texture = mq::Texture::new_render_texture(&mut ctx, mq::TextureParams::default());
+
+        let bindings = mq::Bindings {
+            vertex_buffers: vec![vertex_buffer],
+            index_buffer,
+            images: vec![empty_texture, empty_texture],
+        };
+
+        let mq = Miniquad {
+            debug,
+            antialias,
+            is_opengles_2_0: false,
+            view: [0.0, 0.0],
+            screen_view: [0.0, 0.0],
+            pipeline,
+            bindings,
+            empty_texture,
+            // vert_arr: Default::default(),
+            // vert_buff: Default::default(),
+            // framebuffers: Default::default(),
+            ctx,
+            // screen_target: None,
+            current_render_target: RenderTarget::Screen,
+        };
+
+        Ok(mq)
+    }
+
+    pub fn is_opengles(&self) -> bool {
+        self.is_opengles_2_0
+    }
+
+    fn check_error(&self, label: &str) {
+        if !self.debug {
+            return;
+        }
+
+        // let err = unsafe { self.context.get_error() };
+
+        // if err == glow::NO_ERROR {
+        //     return;
+        // }
+
+        // let message = match err {
+        //     glow::INVALID_ENUM => "Invalid enum",
+        //     glow::INVALID_VALUE => "Invalid value",
+        //     glow::INVALID_OPERATION => "Invalid operation",
+        //     glow::OUT_OF_MEMORY => "Out of memory",
+        //     glow::INVALID_FRAMEBUFFER_OPERATION => "Invalid framebuffer operation",
+        //     _ => "Unknown error",
+        // };
+
+        // eprintln!("({}) Error on {} - {}", err, label, message);
+    }
+
+    fn gl_factor(factor: BlendFactor) -> mq::BlendFactor {
+        match factor {
+            BlendFactor::Zero => mq::BlendFactor::Zero,
+            BlendFactor::One => mq::BlendFactor::One,
+            BlendFactor::SrcColor => mq::BlendFactor::Value(mq::BlendValue::SourceColor),
+            BlendFactor::OneMinusSrcColor => mq::BlendFactor::OneMinusValue(mq::BlendValue::SourceColor),
+            BlendFactor::DstColor => mq::BlendFactor::Value(mq::BlendValue::DestinationColor),
+            BlendFactor::OneMinusDstColor => mq::BlendFactor::OneMinusValue(mq::BlendValue::DestinationColor),
+            BlendFactor::SrcAlpha => mq::BlendFactor::Value(mq::BlendValue::SourceAlpha),
+            BlendFactor::OneMinusSrcAlpha => mq::BlendFactor::OneMinusValue(mq::BlendValue::SourceAlpha),
+            BlendFactor::DstAlpha => mq::BlendFactor::Value(mq::BlendValue::DestinationAlpha),
+            BlendFactor::OneMinusDstAlpha => mq::BlendFactor::OneMinusValue(mq::BlendValue::DestinationAlpha),
+            BlendFactor::SrcAlphaSaturate => mq::BlendFactor::SourceAlphaSaturate,
+        }
+    }
+
+    fn set_composite_operation(&mut self, blend_state: CompositeOperationState) {
+        self.ctx.set_blend(
+            Some(mq::BlendState::new(
+                mq::Equation::Add,
+                Self::gl_factor(blend_state.src_rgb),
+                Self::gl_factor(blend_state.dst_rgb),
+            )),
+            Some(mq::BlendState::new(
+                mq::Equation::Add,
+                Self::gl_factor(blend_state.src_alpha),
+                Self::gl_factor(blend_state.dst_alpha),
+            )),
+        );
+    }
+
+    // from https://www.khronos.org/opengl/wiki/Primitive:
+    // GL_TRIANGLE_FAN:
+    // Indices:     0 1 2 3 4 5 ... (6 total indices)
+    // Triangles:  {0 1 2}
+    //             {0} {2 3}
+    //             {0}   {3 4}
+    //             {0}     {4 5}    (4 total triangles)
+    //
+    // GL_TRIANGLES:
+    // Indices:     0 1 2 3 4 5 ...
+    // Triangles:  {0 1 2}
+    //                   {3 4 5}
+    /// Adds indices to convert from GL_TRIANGLE_FAN to GL_TRIANGLES
+    #[inline]
+    fn add_triangle_fan(indices: &mut Vec<u16>, first_vertex_index: u16, index_count: u16) {
+        let start_index = first_vertex_index;
+        for i in first_vertex_index..first_vertex_index + index_count - 2 {
+            indices.push(start_index);
+            indices.push(i + 1);
+            indices.push(i + 2);
+        }
+    }
+
+    // from https://www.khronos.org/opengl/wiki/Primitive:
+    // GL_TRIANGLES:
+    // Indices:     0 1 2 3 4 5 ... (6 total indices)
+    // Triangles:  {0 1 2}
+    //                   {3 4 5}    (2 total indices)
+    /// Adds indices to draw GL_TRIANGLES
+    #[inline]
+    fn add_triangles(indices: &mut Vec<u16>, first_vertex_index: u16, index_count: u16) {
+        // TODO: test!
+        for i in (first_vertex_index..first_vertex_index + index_count).step_by(3) {
+            indices.push(i);
+            indices.push(i + 1);
+            indices.push(i + 2);
+        }
+    }
+
+    // from https://www.khronos.org/opengl/wiki/Primitive:
+    // GL_TRIANGLE_STRIP:
+    // Indices:     0 1 2 3 4 5 ... (6 total indices)
+    // Triangles:  {0 1 2}
+    //               {1 2 3}  drawing order is (2 1 3) to maintain proper winding
+    //                 {2 3 4}
+    //                   {3 4 5}  drawing order is (4 3 5) to maintain proper winding (4 total triangles)
+    //
+    // GL_TRIANGLES:
+    // Indices:     0 1 2 3 4 5 ...
+    // Triangles:  {0 1 2}
+    //                   {3 4 5}
+    /// Adds indices to convert from GL_TRIANGLE_STRIP to GL_TRIANGLES
+    #[inline]
+    fn add_triangle_strip(indices: &mut Vec<u16>, first_vertex_index: u16, index_count: u16) {
+        let mut draw_order_winding = true; // true to draw in straight (0 1 2) order; false to draw in (1 0 2) order to maintain proper winding
+        for i in first_vertex_index..first_vertex_index + index_count - 2 {
+            if draw_order_winding {
+                indices.push(i);
+                indices.push(i + 1);
+            } else {
+                indices.push(i + 1);
+                indices.push(i);
+            }
+            draw_order_winding = !draw_order_winding;
+            indices.push(i + 2);
+        }
+    }
+
+    fn convex_fill(&mut self, images: &ImageStore<GlTexture>, cmd: &Command, gpu_paint: &Params) {
+        let mut indices = Vec::new();
+        for drawable in &cmd.drawables {
+            if let Some((start, count)) = drawable.fill_verts {
+                Self::add_triangle_fan(&mut indices, start as u16, count as u16);
+            }
+
+            if let Some((start, count)) = drawable.stroke_verts {
+                Self::add_triangle_strip(&mut indices, start as u16, count as u16);
+            }
+        }
+
+        self.set_uniforms(images, gpu_paint, cmd.image, cmd.alpha_mask, &indices);
+        self.ctx.draw(0, indices.len() as i32, 1);
+        self.check_error("convex_fill");
+    }
+
+    fn concave_fill(
+        &mut self,
+        images: &ImageStore<GlTexture>,
+        cmd: &Command,
+        stencil_paint: &Params,
+        fill_paint: &Params,
+    ) {
+        let mut stencil_state = mq::StencilState {
+            front: mq::StencilFaceState {
+                fail_op: mq::StencilOp::Keep,
+                depth_fail_op: mq::StencilOp::Keep,
+                pass_op: mq::StencilOp::IncrementWrap,
+                test_func: mq::CompareFunc::Always,
+                test_ref: 0,
+                test_mask: 0xff,
+                write_mask: 0xff,
+            },
+            back: mq::StencilFaceState {
+                fail_op: mq::StencilOp::Keep,
+                depth_fail_op: mq::StencilOp::Keep,
+                pass_op: mq::StencilOp::DecrementWrap,
+                test_func: mq::CompareFunc::Always,
+                test_ref: 0,
+                test_mask: 0xff,
+                write_mask: 0xff,
+            },
+        };
+
+        self.ctx.set_stencil(Some(stencil_state));
+        self.ctx.set_color_write((false, false, false, false));
+
+        self.ctx.set_cull_face(mq::CullFace::Nothing);
+
+        let mut indices = Vec::new();
+        for drawable in &cmd.drawables {
+            if let Some((start, count)) = drawable.fill_verts {
+                Self::add_triangle_fan(&mut indices, start as u16, count as u16);
+            }
+        }
+        self.set_uniforms(images, stencil_paint, None, None, &indices);
+        self.ctx.draw(0, indices.len() as i32, 1);
+
+        self.ctx.set_color_write((true, true, true, true));
+
+        if self.antialias {
+            match cmd.fill_rule {
+                FillRule::NonZero => {
+                    stencil_state.front.test_func = mq::CompareFunc::Equal;
+                    stencil_state.front.test_mask = 0xff;
+                    stencil_state.back.test_func = mq::CompareFunc::Equal;
+                    stencil_state.back.test_mask = 0xff;
+                }
+                FillRule::EvenOdd => {
+                    stencil_state.front.test_func = mq::CompareFunc::Equal;
+                    stencil_state.front.test_mask = 0x1;
+                    stencil_state.back.test_func = mq::CompareFunc::Equal;
+                    stencil_state.back.test_mask = 0x1;
+                }
+            }
+            stencil_state.front.pass_op = mq::StencilOp::Keep;
+            stencil_state.back.pass_op = mq::StencilOp::Keep;
+
+            self.ctx.set_stencil(Some(stencil_state));
+
+            // draw fringes
+            indices.clear();
+            for drawable in &cmd.drawables {
+                if let Some((start, count)) = drawable.stroke_verts {
+                    Self::add_triangle_strip(&mut indices, start as u16, count as u16);
+                }
+            }
+            self.set_uniforms(images, fill_paint, cmd.image, cmd.alpha_mask, &indices);
+            self.ctx.draw(0, indices.len() as i32, 1);
+        }
+
+        match cmd.fill_rule {
+            FillRule::NonZero => {
+                stencil_state.front.test_func = mq::CompareFunc::NotEqual;
+                stencil_state.front.test_mask = 0xff;
+                stencil_state.back.test_func = mq::CompareFunc::NotEqual;
+                stencil_state.back.test_mask = 0xff;
+            }
+            FillRule::EvenOdd => {
+                stencil_state.front.test_func = mq::CompareFunc::Equal;
+                stencil_state.front.test_mask = 0x1;
+                stencil_state.back.test_func = mq::CompareFunc::Equal;
+                stencil_state.back.test_mask = 0x1;
+            }
+        }
+        stencil_state.front.fail_op = mq::StencilOp::Zero;
+        stencil_state.front.depth_fail_op = mq::StencilOp::Zero;
+        stencil_state.front.pass_op = mq::StencilOp::Zero;
+        stencil_state.back.fail_op = mq::StencilOp::Zero;
+        stencil_state.back.depth_fail_op = mq::StencilOp::Zero;
+        stencil_state.back.pass_op = mq::StencilOp::Zero;
+
+        self.ctx.set_stencil(Some(stencil_state));
+
+        indices.clear();
+        if let Some((start, count)) = cmd.triangles_verts {
+            Self::add_triangle_strip(&mut indices, start as u16, count as u16);
+        }
+        self.set_uniforms(images, fill_paint, cmd.image, cmd.alpha_mask, &indices);
+        self.ctx.draw(0, indices.len() as i32, 1);
+
+        self.ctx.set_stencil(None);
+
+        self.check_error("concave_fill");
+    }
+
+    fn stroke(&mut self, images: &ImageStore<GlTexture>, cmd: &Command, paint: &Params) {
+        let mut indices = Vec::new();
+        for drawable in &cmd.drawables {
+            if let Some((start, count)) = drawable.stroke_verts {
+                Self::add_triangle_strip(&mut indices, start as u16, count as u16);
+            }
+        }
+
+        self.set_uniforms(images, paint, cmd.image, cmd.alpha_mask, &indices);
+        self.ctx.draw(0, indices.len() as i32, 1);
+        self.check_error("stroke");
+    }
+
+    fn stencil_stroke(&mut self, images: &ImageStore<GlTexture>, cmd: &Command, paint1: &Params, paint2: &Params) {
+        let mut stencil_state = mq::StencilState {
+            front: mq::StencilFaceState {
+                fail_op: mq::StencilOp::Keep,
+                depth_fail_op: mq::StencilOp::Keep,
+                pass_op: mq::StencilOp::IncrementClamp,
+                test_func: mq::CompareFunc::Equal,
+                test_ref: 0,
+                test_mask: 0xff,
+                write_mask: 0xff,
+            },
+            back: mq::StencilFaceState {
+                fail_op: mq::StencilOp::Keep,
+                depth_fail_op: mq::StencilOp::Keep,
+                pass_op: mq::StencilOp::IncrementClamp,
+                test_func: mq::CompareFunc::Equal,
+                test_ref: 0,
+                test_mask: 0xff,
+                write_mask: 0xff,
+            },
+        };
+
+        // Fill the stroke base without overlap
+        self.ctx.set_stencil(Some(stencil_state));
+
+        let mut indices = Vec::new();
+        for drawable in &cmd.drawables {
+            if let Some((start, count)) = drawable.stroke_verts {
+                Self::add_triangle_strip(&mut indices, start as u16, count as u16);
+            }
+        }
+
+        self.set_uniforms(images, paint2, cmd.image, cmd.alpha_mask, &indices);
+        self.ctx.draw(0, indices.len() as i32, 1);
+
+        // Draw anti-aliased pixels.
+        stencil_state.front.pass_op = mq::StencilOp::Keep;
+        stencil_state.back.pass_op = mq::StencilOp::Keep;
+        self.ctx.set_stencil(Some(stencil_state));
+
+        indices.clear();
+        for drawable in &cmd.drawables {
+            if let Some((start, count)) = drawable.stroke_verts {
+                Self::add_triangle_strip(&mut indices, start as u16, count as u16);
+            }
+        }
+
+        self.set_uniforms(images, paint1, cmd.image, cmd.alpha_mask, &indices);
+        self.ctx.draw(0, indices.len() as i32, 1);
+
+        // Clear stencil buffer.
+        self.ctx.set_color_write((false, false, false, false));
+        stencil_state.front.test_func = mq::CompareFunc::Always;
+        stencil_state.front.fail_op = mq::StencilOp::Zero;
+        stencil_state.front.depth_fail_op = mq::StencilOp::Zero;
+        stencil_state.front.pass_op = mq::StencilOp::Zero;
+        stencil_state.back.test_func = mq::CompareFunc::Always;
+        stencil_state.back.fail_op = mq::StencilOp::Zero;
+        stencil_state.back.depth_fail_op = mq::StencilOp::Zero;
+        stencil_state.back.pass_op = mq::StencilOp::Zero;
+
+        indices.clear();
+        for drawable in &cmd.drawables {
+            if let Some((start, count)) = drawable.stroke_verts {
+                Self::add_triangle_strip(&mut indices, start as u16, count as u16);
+            }
+        }
+
+        self.ctx.set_color_write((true, true, true, true));
+        self.ctx.set_stencil(None);
+
+        self.set_uniforms(images, paint1, cmd.image, cmd.alpha_mask, &indices);
+        self.ctx.draw(0, indices.len() as i32, 1);
+
+        self.check_error("stencil_stroke");
+    }
+
+    fn triangles(&mut self, images: &ImageStore<GlTexture>, cmd: &Command, paint: &Params) {
+        let mut indices = Vec::new();
+        if let Some((start, count)) = cmd.triangles_verts {
+            Self::add_triangles(&mut indices, start as u16, count as u16);
+        }
+
+        self.set_uniforms(images, paint, cmd.image, cmd.alpha_mask, &indices);
+        self.ctx.draw(0, indices.len() as i32, 1);
+        self.check_error("triangles");
+    }
+
+    fn set_uniforms(
+        &mut self,
+        images: &ImageStore<GlTexture>,
+        paint: &Params,
+        image_tex: Option<ImageId>,
+        alpha_tex: Option<ImageId>,
+        indices: &Vec<u16>,
+    ) {
+        let mut uniforms = shader::Uniforms::from(paint);
+        uniforms.view_size = self.view;
+        self.ctx.apply_uniforms(&uniforms);
+        self.check_error("set_uniforms uniforms");
+
+        let tex = image_tex.and_then(|id| images.get(id)).unwrap_or(&self.empty_texture);
+        self.bindings.images[0] = *tex;
+
+        let masktex = alpha_tex.and_then(|id| images.get(id)).unwrap_or(&self.empty_texture);
+        self.bindings.images[1] = *masktex;
+
+        self.bindings.index_buffer.update(&mut self.ctx, indices);
+        self.ctx.apply_bindings(&mut self.bindings);
+        self.check_error("set_uniforms texture");
+    }
+
+    fn clear_rect(&mut self, x: u32, y: u32, width: u32, height: u32, color: Color) {
+        self.ctx.apply_scissor_rect(
+            x as i32,
+            self.view[1] as i32 - (height as i32 + y as i32),
+            width as i32,
+            height as i32,
+        );
+        self.ctx.clear(Some((color.r, color.g, color.b, color.a)), None, None);
+        let screen_size = self.ctx.screen_size();
+        self.ctx
+            .apply_scissor_rect(0, 0, screen_size.0 as i32, screen_size.1 as i32);
+    }
+
+    fn set_target(&mut self, images: &ImageStore<GlTexture>, target: RenderTarget) {
+        self.current_render_target = target;
+        match (target, None as Option<()> /*&self.screen_target*/) {
+            (RenderTarget::Screen, None) => {
+                // Framebuffer::unbind(&self.context);
+                self.view = self.screen_view;
+                self.ctx.apply_viewport(0, 0, self.view[0] as i32, self.view[1] as i32);
+            }
+            (RenderTarget::Screen, Some(framebuffer)) => {
+                todo!();
+                // framebuffer.bind();
+                // self.view = self.screen_view;
+                // unsafe {
+                //     self.context.viewport(0, 0, self.view[0] as i32, self.view[1] as i32);
+                // }
+            }
+            (RenderTarget::Image(id), _) => {
+                todo!();
+                // let context = self.context.clone();
+                // if let Some(texture) = images.get(id) {
+                //     if let Ok(fb) = self
+                //         .framebuffers
+                //         .entry(id)
+                //         .or_insert_with(|| Framebuffer::new(&context, texture))
+                //     {
+                //         fb.bind();
+
+                //         self.view[0] = texture.info().width() as f32;
+                //         self.view[1] = texture.info().height() as f32;
+
+                //         unsafe {
+                //             self.context
+                //                 .viewport(0, 0, texture.info().width() as i32, texture.info().height() as i32);
+                //         }
+                //     }
+                // }
+            }
+        }
+    }
+
+    /// Make the "Screen" RenderTarget actually render to a framebuffer object. This is useful when
+    /// embedding femtovg into another program where final composition is handled by an external task.
+    /// The given `framebuffer_object` must refer to a Framebuffer Object created on the current OpenGL
+    /// Context, and must have a depth & stencil attachment.
+    ///
+    /// Pass `None` to clear any previous Framebuffer Object ID that was passed and target rendering to
+    /// the default target (normally the window).
+    pub fn set_screen_target(&mut self, framebuffer_object: Option<<glow::Context as glow::HasContext>::Framebuffer>) {
+        todo!();
+        // match framebuffer_object {
+        //     Some(fbo_id) => self.screen_target = Some(Framebuffer::from_external(&self.context, fbo_id)),
+        //     None => self.screen_target = None,
+        // }
+    }
+
+    fn render_filtered_image(
+        &mut self,
+        images: &mut ImageStore<GlTexture>,
+        cmd: Command,
+        target_image: ImageId,
+        filter: ImageFilter,
+    ) {
+        match filter {
+            ImageFilter::GaussianBlur { sigma } => self.render_gaussian_blur(images, cmd, target_image, sigma),
+        }
+    }
+
+    fn render_gaussian_blur(
+        &mut self,
+        images: &mut ImageStore<GlTexture>,
+        mut cmd: Command,
+        target_image: ImageId,
+        sigma: f32,
+    ) {
+        todo!();
+        // let original_render_target = self.current_render_target;
+
+        // // The filtering happens in two passes, first a horizontal blur and then the vertial blur. The
+        // // first pass therefore renders into an intermediate, temporarily allocated texture.
+
+        // let source_image_info = images.get(cmd.image.unwrap()).unwrap().info();
+
+        // let image_paint = crate::Paint::image(
+        //     cmd.image.unwrap(),
+        //     0.,
+        //     0.,
+        //     source_image_info.width() as _,
+        //     source_image_info.height() as _,
+        //     0.,
+        //     1.,
+        // );
+        // let mut blur_params = Params::new(images, &image_paint, &Scissor::default(), 0., 0., 0.);
+        // blur_params.shader_type = ShaderType::FilterImage.to_f32();
+
+        // let gauss_coeff_x = 1. / ((2. * std::f32::consts::PI).sqrt() * sigma);
+        // let gauss_coeff_y = f32::exp(-0.5 / (sigma * sigma));
+        // let gauss_coeff_z = gauss_coeff_y * gauss_coeff_y;
+
+        // blur_params.image_blur_filter_coeff[0] = gauss_coeff_x;
+        // blur_params.image_blur_filter_coeff[1] = gauss_coeff_y;
+        // blur_params.image_blur_filter_coeff[2] = gauss_coeff_z;
+
+        // blur_params.image_blur_filter_direction = [1.0, 0.0];
+
+        // // GLES 2.0 does not allow non-constant loop indices, so limit the standard devitation to allow for a upper fixed limit
+        // // on the number of iterations in the fragment shader.
+        // blur_params.image_blur_filter_sigma = sigma.min(8.);
+
+        // let horizontal_blur_buffer = images.alloc(self, source_image_info).unwrap();
+        // self.set_target(images, RenderTarget::Image(horizontal_blur_buffer));
+        // self.main_program.set_view(self.view);
+
+        // self.clear_rect(
+        //     0,
+        //     0,
+        //     source_image_info.width() as _,
+        //     source_image_info.height() as _,
+        //     Color::rgbaf(0., 0., 0., 0.),
+        // );
+
+        // self.triangles(images, &cmd, &blur_params);
+
+        // self.set_target(images, RenderTarget::Image(target_image));
+        // self.main_program.set_view(self.view);
+
+        // self.clear_rect(
+        //     0,
+        //     0,
+        //     source_image_info.width() as _,
+        //     source_image_info.height() as _,
+        //     Color::rgbaf(0., 0., 0., 0.),
+        // );
+
+        // blur_params.image_blur_filter_direction = [0.0, 1.0];
+
+        // cmd.image = Some(horizontal_blur_buffer);
+
+        // self.triangles(images, &cmd, &blur_params);
+
+        // images.remove(self, horizontal_blur_buffer);
+
+        // // restore previous render target and view
+        // self.set_target(images, original_render_target);
+        // self.main_program.set_view(self.view);
+    }
+}
+
+pub fn femtovg_pixel_format_to_mq(format: PixelFormat) -> mq::TextureFormat {
+    match format {
+        PixelFormat::Rgb8 => mq::TextureFormat::RGB8,
+        PixelFormat::Rgba8 => mq::TextureFormat::RGBA8,
+        PixelFormat::Gray8 => mq::TextureFormat::Alpha,
+    }
+}
+
+impl Renderer for Miniquad {
+    type Image = GlTexture;
+
+    fn set_size(&mut self, width: u32, height: u32, _dpi: f32) {
+        self.view[0] = width as f32;
+        self.view[1] = height as f32;
+
+        self.screen_view = self.view;
+
+        self.ctx.apply_viewport(0, 0, width as i32, height as i32);
+    }
+
+    fn render(&mut self, images: &mut ImageStore<Self::Image>, verts: &[Vertex], commands: Vec<Command>) {
+        self.ctx.begin_default_pass(mq::PassAction::Nothing);
+        self.ctx.apply_pipeline(&self.pipeline);
+
+        // unsafe {
+        self.ctx.set_cull_face(mq::CullFace::Back);
+
+        //     self.context.cull_face(glow::BACK);
+        //     self.context.front_face(glow::CCW);
+        //     self.context.enable(glow::BLEND);
+        //     self.context.disable(glow::DEPTH_TEST);
+        //     self.context.disable(glow::SCISSOR_TEST);
+        //     self.context.color_mask(true, true, true, true);
+        //     self.context.stencil_mask(0xffff_ffff);
+        //     self.context.stencil_op(glow::KEEP, glow::KEEP, glow::KEEP);
+        //     self.context.stencil_func(glow::ALWAYS, 0, 0xffff_ffff);
+        //     self.context.active_texture(glow::TEXTURE0);
+        //     self.context.bind_texture(glow::TEXTURE_2D, None);
+        //     self.context.active_texture(glow::TEXTURE0 + 1);
+        //     self.context.bind_texture(glow::TEXTURE_2D, None);
+
+        self.ctx.apply_bindings(&self.bindings);
+        self.bindings.vertex_buffers[0].update(&mut self.ctx, verts);
+
+        self.check_error("render prepare");
+
+        for cmd in commands.into_iter() {
+            self.set_composite_operation(cmd.composite_operation);
+
+            match cmd.cmd_type {
+                CommandType::ConvexFill { ref params } => self.convex_fill(images, &cmd, params),
+                CommandType::ConcaveFill {
+                    ref stencil_params,
+                    ref fill_params,
+                } => self.concave_fill(images, &cmd, stencil_params, fill_params),
+                CommandType::Stroke { ref params } => self.stroke(images, &cmd, params),
+                CommandType::StencilStroke {
+                    ref params1,
+                    ref params2,
+                } => self.stencil_stroke(images, &cmd, params1, params2),
+                CommandType::Triangles { ref params } => self.triangles(images, &cmd, params),
+                CommandType::ClearRect {
+                    x,
+                    y,
+                    width,
+                    height,
+                    color,
+                } => {
+                    self.clear_rect(x, y, width, height, color);
+                }
+                CommandType::SetRenderTarget(target) => {
+                    self.set_target(images, target);
+                    // self.main_program.set_view(self.view);
+                }
+                CommandType::RenderFilteredImage { target_image, filter } => {
+                    self.render_filtered_image(images, cmd, target_image, filter)
+                }
+            }
+        }
+
+        // unsafe {
+        //     self.context.disable_vertex_attrib_array(0);
+        //     self.context.disable_vertex_attrib_array(1);
+        //     self.context.bind_vertex_array(None);
+
+        //     self.context.disable(glow::CULL_FACE);
+        //     self.context.bind_buffer(glow::ARRAY_BUFFER, None);
+        //     self.context.bind_texture(glow::TEXTURE_2D, None);
+        // }
+
+        self.ctx.end_render_pass();
+        self.ctx.commit_frame(); // FIXME: miniquad context should not be bound in self!
+
+        self.check_error("render done");
+    }
+
+    fn alloc_image(&mut self, info: ImageInfo) -> Result<Self::Image, ErrorKind> {
+        Ok(Self::Image::new_render_texture(
+            &mut self.ctx,
+            mq::TextureParams {
+                format: femtovg_pixel_format_to_mq(info.format()),
+                wrap: if info.flags().contains(ImageFlags::REPEAT_X | ImageFlags::REPEAT_Y) {
+                    mq::TextureWrap::Repeat
+                } else if info.flags().contains(ImageFlags::FLIP_Y) {
+                    mq::TextureWrap::Mirror
+                } else {
+                    mq::TextureWrap::Clamp
+                },
+                filter: if info.flags().contains(ImageFlags::NEAREST) {
+                    mq::FilterMode::Nearest
+                } else {
+                    mq::FilterMode::Linear
+                },
+                width: info.width() as u32,
+                height: info.height() as u32,
+            },
+        ))
+    }
+
+    fn update_image(&mut self, image: &mut Self::Image, src: ImageSource, x: usize, y: usize) -> Result<(), ErrorKind> {
+        let size = src.dimensions();
+
+        if x + size.0 > image.width as usize {
+            return Err(ErrorKind::ImageUpdateOutOfBounds);
+        }
+
+        if y + size.1 > image.height as usize {
+            return Err(ErrorKind::ImageUpdateOutOfBounds);
+        }
+
+        if image.format != femtovg_pixel_format_to_mq(src.format()) {
+            return Err(ErrorKind::ImageUpdateWithDifferentFormat);
+        }
+
+        match src {
+            ImageSource::Gray(data) => {
+                image.update_texture_part(
+                    &mut self.ctx,
+                    x as i32,
+                    y as i32,
+                    size.0 as i32,
+                    size.1 as i32,
+                    data.buf().iter().map(|c| **c).collect::<Vec<u8>>().as_slice(),
+                );
+            }
+            ImageSource::Rgb(data) => {
+                image.update_texture_part(
+                    &mut self.ctx,
+                    x as i32,
+                    y as i32,
+                    size.0 as i32,
+                    size.1 as i32,
+                    data.buf()
+                        .iter()
+                        .map(|c| [c.r, c.g, c.b])
+                        .flatten()
+                        .collect::<Vec<u8>>()
+                        .as_slice(),
+                );
+            }
+            ImageSource::Rgba(data) => {
+                image.update_texture_part(
+                    &mut self.ctx,
+                    x as i32,
+                    y as i32,
+                    size.0 as i32,
+                    size.1 as i32,
+                    data.buf()
+                        .iter()
+                        .map(|c| [c.r, c.g, c.b, c.a])
+                        .flatten()
+                        .collect::<Vec<u8>>()
+                        .as_slice(),
+                );
+            }
+            #[cfg(target_arch = "wasm32")]
+            ImageSource::HtmlImageElement(image_element) => unsafe {
+                self.context.tex_sub_image_2d_with_html_image(
+                    glow::TEXTURE_2D,
+                    0,
+                    x as i32,
+                    y as i32,
+                    glow::RGBA,
+                    glow::UNSIGNED_BYTE,
+                    image_element,
+                )
+            },
+        }
+
+        // if self.info.flags().contains(ImageFlags::GENERATE_MIPMAPS) {
+        //     unsafe {
+        //         self.context.generate_mipmap(glow::TEXTURE_2D);
+        //         //glow::TexParameteri(glow::TEXTURE_2D, glow::GENERATE_MIPMAP, glow::TRUE);
+        //     }
+        // }
+
+        // unsafe {
+        //     self.context.pixel_store_i32(glow::UNPACK_ALIGNMENT, 4);
+        //     if !opengles_2_0 {
+        //         self.context.pixel_store_i32(glow::UNPACK_ROW_LENGTH, 0);
+        //     }
+        //     //glow::PixelStorei(glow::UNPACK_SKIP_PIXELS, 0);
+        //     //glow::PixelStorei(glow::UNPACK_SKIP_ROWS, 0);
+        //     self.context.bind_texture(glow::TEXTURE_2D, None);
+        // }
+
+        Ok(())
+    }
+
+    fn delete_image(&mut self, image: Self::Image, image_id: ImageId) {
+        // self.framebuffers.remove(&image_id);
+        image.delete();
+    }
+
+    fn screenshot(&mut self) -> Result<ImgVec<RGBA8>, ErrorKind> {
+        todo!();
+        // //let mut image = image::RgbaImage::new(self.view[0] as u32, self.view[1] as u32);
+        // let w = self.view[0] as usize;
+        // let h = self.view[1] as usize;
+
+        // let mut image = ImgVec::new(
+        //     vec![
+        //         RGBA8 {
+        //             r: 255,
+        //             g: 255,
+        //             b: 255,
+        //             a: 255
+        //         };
+        //         w * h
+        //     ],
+        //     w,
+        //     h,
+        // );
+
+        // unsafe {
+        //     self.context.read_pixels(
+        //         0,
+        //         0,
+        //         self.view[0] as i32,
+        //         self.view[1] as i32,
+        //         glow::RGBA,
+        //         glow::UNSIGNED_BYTE,
+        //         glow::PixelPackData::Slice(image.buf_mut().align_to_mut().1),
+        //     );
+        // }
+
+        // let mut flipped = Vec::with_capacity(w * h);
+
+        // for row in image.rows().rev() {
+        //     flipped.extend_from_slice(row);
+        // }
+
+        // Ok(ImgVec::new(flipped, w, h))
+    }
+}
+
+impl Drop for Miniquad {
+    fn drop(&mut self) {
+        self.empty_texture.delete();
+    }
+}

--- a/src/renderer/opengl/main-fs.glsl
+++ b/src/renderer/opengl/main-fs.glsl
@@ -1,27 +1,23 @@
 
 precision highp float;
 
-#define UNIFORMARRAY_SIZE 14
-
-uniform vec4 frag[UNIFORMARRAY_SIZE];
-
-#define scissorMat mat3(frag[0].xyz, frag[1].xyz, frag[2].xyz)
-#define paintMat mat3(frag[3].xyz, frag[4].xyz, frag[5].xyz)
-#define innerCol frag[6]
-#define outerCol frag[7]
-#define scissorExt frag[8].xy
-#define scissorScale frag[8].zw
-#define extent frag[9].xy
-#define radius frag[9].z
-#define feather frag[9].w
-#define strokeMult frag[10].x
-#define strokeThr frag[10].y
-#define texType int(frag[10].z)
-#define shaderType int(frag[10].w)
-#define hasMask int(frag[11].x)
-#define imageBlurFilterDirection frag[11].yz
-#define imageBlurFilterSigma frag[11].w
-#define imageBlurFilterCoeff frag[12].xyz
+uniform mat4 scissorMat;
+uniform mat4 paintMat;
+uniform vec4 innerCol;
+uniform vec4 outerCol;
+uniform vec2 scissorExt;
+uniform vec2 scissorScale;
+uniform vec2 extent;
+uniform float radius;
+uniform float feather;
+uniform float strokeMult;
+uniform float strokeThr;
+uniform int texType;
+uniform int shaderType;
+uniform int hasMask;
+uniform vec2 imageBlurFilterDirection;
+uniform float imageBlurFilterSigma;
+uniform vec3 imageBlurFilterCoeff;
 
 uniform sampler2D tex;
 uniform sampler2D masktex;
@@ -38,7 +34,7 @@ float sdroundrect(vec2 pt, vec2 ext, float rad) {
 
 // Scissoring
 float scissorMask(vec2 p) {
-    vec2 sc = (abs((scissorMat * vec3(p,1.0)).xy) - scissorExt);
+    vec2 sc = (abs((mat3(scissorMat) * vec3(p,1.0)).xy) - scissorExt);
     sc = vec2(0.5,0.5) - sc * scissorScale;
     return clamp(sc.x,0.0,1.0) * clamp(sc.y,0.0,1.0);
 }
@@ -70,7 +66,7 @@ void main(void) {
         // Gradient
 
         // Calculate gradient color using box gradient
-        vec2 pt = (paintMat * vec3(fpos, 1.0)).xy;
+        vec2 pt = (mat3(paintMat) * vec3(fpos, 1.0)).xy;
 
         float d = clamp((sdroundrect(pt, extent, radius) + feather*0.5) / feather, 0.0, 1.0);
         vec4 color = mix(innerCol,outerCol,d);
@@ -80,7 +76,7 @@ void main(void) {
         // Image-based Gradient; sample a texture using the gradient position.
 
         // Calculate gradient color using box gradient
-        vec2 pt = (paintMat * vec3(fpos, 1.0)).xy;
+        vec2 pt = (mat3(paintMat) * vec3(fpos, 1.0)).xy;
 
         float d = clamp((sdroundrect(pt, extent, radius) + feather*0.5) / feather, 0.0, 1.0);
         vec4 color = texture2D(tex, vec2(d, 0.0));//mix(innerCol,outerCol,d);
@@ -90,7 +86,7 @@ void main(void) {
         // Image
 
         // Calculate color from texture
-        vec2 pt = (paintMat * vec3(fpos, 1.0)).xy / extent;
+        vec2 pt = (mat3(paintMat) * vec3(fpos, 1.0)).xy / extent;
 
         vec4 color = texture2D(tex, pt);
 
@@ -121,10 +117,10 @@ void main(void) {
             if (i >= sampleCount) {
                 break;
             }
-            color_sum += texture2D(tex, (fpos.xy - i * imageBlurFilterDirection) / extent) * gaussian_coeff.x;         
-            color_sum += texture2D(tex, (fpos.xy + i * imageBlurFilterDirection) / extent) * gaussian_coeff.x;         
+            color_sum += texture2D(tex, (fpos.xy - i * imageBlurFilterDirection) / extent) * gaussian_coeff.x;
+            color_sum += texture2D(tex, (fpos.xy + i * imageBlurFilterDirection) / extent) * gaussian_coeff.x;
             coefficient_sum += 2.0 * gaussian_coeff.x;
-            
+
             // Compute the coefficients incrementally:
             // https://developer.nvidia.com/gpugems/gpugems3/part-vi-gpu-computing/chapter-40-incremental-computation-gaussian
             gaussian_coeff.xy *= gaussian_coeff.yz;

--- a/src/renderer/opengl/main-fs.glsl
+++ b/src/renderer/opengl/main-fs.glsl
@@ -1,8 +1,14 @@
 
 precision highp float;
 
-uniform mat4 scissorMat;
-uniform mat4 paintMat;
+uniform vec3 scissorMat0;
+uniform vec3 scissorMat1;
+uniform vec3 scissorMat2;
+#define scissorMat mat3(scissorMat0, scissorMat1, scissorMat2)
+uniform vec3 paintMat0;
+uniform vec3 paintMat1;
+uniform vec3 paintMat2;
+#define paintMat mat3(paintMat0, paintMat1, paintMat2)
 uniform vec4 innerCol;
 uniform vec4 outerCol;
 uniform vec2 scissorExt;


### PR DESCRIPTION
Hello.
I am working on getting `femtovg` render using `miniquad`. Current state of development is in this PR.
Many thanks to @nokola for https://github.com/nokola/nonaquad renderer which my implementation takes crucial parts.

I have few questions before I move on:
1. Is this implementation desirable for merging to `femtovg`?
2. Should I keep reusing `renderer/opengl/*.glsl` shaders and `#ifdef` my changes?
3. Current implementation. where `miniquad::Context` is owned by canvas renderer. makes integrating the library in other application rendering pipeline very hard. I've solved this for `nonaquad` in https://github.com/nokola/nonaquad/pull/3 with an API change, where `ctx` is passed as a reference only for the render call. Is such change welcome in `femtovg` (as other PR)?