### PR TITLE
Add basic support for emojis (color fonts)

### DIFF
--- a/examples/text.rs
+++ b/examples/text.rs
@@ -71,6 +71,8 @@ fn main() {
     // searching for fallbacks
     let _ = canvas.add_font("examples/assets/amiri-regular.ttf");
 
+    let supports_emojis = canvas.add_font("/System/Library/Fonts/Apple Color Emoji.ttc").is_ok();
+
     let flags = ImageFlags::GENERATE_MIPMAPS | ImageFlags::REPEAT_X | ImageFlags::REPEAT_Y;
     let image_id = canvas
         .load_image_file("examples/assets/pattern.jpg", flags)
@@ -169,7 +171,7 @@ fn main() {
 
                 perf.update(dt);
 
-                draw_baselines(&mut canvas, &fonts, 5.0, 50.0, font_size);
+                draw_baselines(&mut canvas, &fonts, 5.0, 50.0, font_size, supports_emojis);
                 draw_alignments(&mut canvas, &fonts, 120.0, 200.0, font_size);
                 draw_paragraph(&mut canvas, &fonts, x, y, font_size, LOREM_TEXT);
                 draw_inc_size(&mut canvas, &fonts, 300.0, 10.0);
@@ -223,12 +225,24 @@ fn main() {
     });
 }
 
-fn draw_baselines<T: Renderer>(canvas: &mut Canvas<T>, fonts: &Fonts, x: f32, y: f32, font_size: f32) {
+fn draw_baselines<T: Renderer>(
+    canvas: &mut Canvas<T>,
+    fonts: &Fonts,
+    x: f32,
+    y: f32,
+    font_size: f32,
+    supports_emojis: bool,
+) {
     let baselines = [Baseline::Top, Baseline::Middle, Baseline::Alphabetic, Baseline::Bottom];
 
     let mut paint = Paint::color(Color::black());
     paint.set_font(&[fonts.sans]);
     paint.set_font_size(font_size);
+
+    let mut base_text = "AbcpKjgF".to_string();
+    if supports_emojis {
+        base_text.push_str("🚀🌳");
+    }
 
     for (i, baseline) in baselines.iter().enumerate() {
         let y = y + i as f32 * 40.0;
@@ -240,7 +254,7 @@ fn draw_baselines<T: Renderer>(canvas: &mut Canvas<T>, fonts: &Fonts, x: f32, y:
 
         paint.set_text_baseline(*baseline);
 
-        if let Ok(res) = canvas.fill_text(x, y, format!("AbcpKjgF Baseline::{:?}", baseline), paint) {
+        if let Ok(res) = canvas.fill_text(x, y, format!("{} Baseline::{:?}", base_text, baseline), paint) {
             //let res = canvas.fill_text(10.0, y, format!("d النص العربي جميل جدا {:?}", baseline), paint);
 
             let mut path = Path::new();

--- a/src/paint.rs
+++ b/src/paint.rs
@@ -148,6 +148,19 @@ impl PaintFlavor {
     }
 }
 
+#[derive(Copy, Clone, Debug)]
+pub(crate) enum GlyphTexture {
+    None,
+    AlphaMask(ImageId),
+    ColorTexture(ImageId),
+}
+
+impl Default for GlyphTexture {
+    fn default() -> Self {
+        Self::None
+    }
+}
+
 /// Struct controlling how graphical shapes are rendered.
 ///
 /// The Paint struct is a relatively lightweight object which contains all the information needed to
@@ -179,7 +192,7 @@ pub struct Paint {
     pub(crate) flavor: PaintFlavor,
     pub(crate) transform: Transform2D,
     #[cfg_attr(feature = "serialization", serde(skip))]
-    pub(crate) alpha_mask: Option<ImageId>,
+    pub(crate) glyph_texture: GlyphTexture,
     pub(crate) shape_anti_alias: bool,
     pub(crate) stencil_strokes: bool,
     pub(crate) miter_limit: f32,
@@ -201,7 +214,7 @@ impl Default for Paint {
         Self {
             flavor: PaintFlavor::Color(Color::white()),
             transform: Default::default(),
-            alpha_mask: Default::default(),
+            glyph_texture: Default::default(),
             shape_anti_alias: true,
             stencil_strokes: true,
             miter_limit: 10.0,
@@ -487,16 +500,16 @@ impl Paint {
         self.flavor = PaintFlavor::Color(color);
     }
 
-    pub(crate) fn alpha_mask(&self) -> Option<ImageId> {
-        self.alpha_mask
+    pub(crate) fn glyph_texture(&self) -> GlyphTexture {
+        self.glyph_texture
     }
 
-    /// Set an alpha mask; this is only used by draw_triangles which is used for text.
+    /// Set an alpha mask or color glyph texture; this is only used by draw_triangles which is used for text.
     // This is scoped to crate visibility because fill_path and stroke_path don't propagate
     // the alpha mask (so nothing draws), and the texture coordinates are used for antialiasing
     // when path drawing.
-    pub(crate) fn set_alpha_mask(&mut self, image_id: Option<ImageId>) {
-        self.alpha_mask = image_id;
+    pub(crate) fn set_glyph_texture(&mut self, texture: GlyphTexture) {
+        self.glyph_texture = texture;
     }
 
     /// Returns boolean if the shapes drawn with this paint will be antialiased.

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -4,6 +4,7 @@ use imgref::ImgVec;
 use rgb::RGBA8;
 
 use crate::{
+    paint::GlyphTexture,
     Color,
     CompositeOperationState,
     ErrorKind,
@@ -68,7 +69,7 @@ pub struct Command {
     pub(crate) drawables: Vec<Drawable>,
     pub(crate) triangles_verts: Option<(usize, usize)>,
     pub(crate) image: Option<ImageId>,
-    pub(crate) alpha_mask: Option<ImageId>,
+    pub(crate) glyph_texture: GlyphTexture,
     pub(crate) fill_rule: FillRule,
     pub(crate) composite_operation: CompositeOperationState,
 }
@@ -80,7 +81,7 @@ impl Command {
             drawables: Default::default(),
             triangles_verts: Default::default(),
             image: Default::default(),
-            alpha_mask: Default::default(),
+            glyph_texture: Default::default(),
             fill_rule: Default::default(),
             composite_operation: Default::default(),
         }

--- a/src/renderer/opengl/main-fs.glsl
+++ b/src/renderer/opengl/main-fs.glsl
@@ -18,13 +18,13 @@ uniform vec4 frag[UNIFORMARRAY_SIZE];
 #define strokeThr frag[10].y
 #define texType int(frag[10].z)
 #define shaderType int(frag[10].w)
-#define hasMask int(frag[11].x)
+#define glyphTextureType int(frag[11].x)
 #define imageBlurFilterDirection frag[11].yz
 #define imageBlurFilterSigma frag[11].w
 #define imageBlurFilterCoeff frag[12].xyz
 
 uniform sampler2D tex;
-uniform sampler2D masktex;
+uniform sampler2D glyphtex;
 uniform vec2 viewSize;
 
 varying vec2 ftcoord;
@@ -138,13 +138,16 @@ void main(void) {
         result = color;
     }
 
-    if (hasMask == 1) {
+    if (glyphTextureType > 0) {
         // Textured tris
-        vec4 mask = texture2D(masktex, ftcoord);
-        mask = vec4(mask.x);
+        vec4 mask = texture2D(glyphtex, ftcoord);
 
-        //if (texType == 1) mask_color = vec4(mask_color.xyz * mask_color.w, mask_color.w);
-        //if (texType == 2) mask_color = vec4(mask_color.x);
+        if (glyphTextureType == 1) {
+            mask = vec4(mask.x);
+        } else {
+            result = vec4(1, 1, 1, 1);
+            mask = vec4(mask.xyz * mask.w, mask.w);
+        }
 
         mask *= scissor;
         result *= mask;

--- a/src/renderer/opengl/program.rs
+++ b/src/renderer/opengl/program.rs
@@ -134,7 +134,7 @@ pub struct MainProgram {
     program: Program,
     loc_viewsize: <glow::Context as glow::HasContext>::UniformLocation,
     loc_tex: <glow::Context as glow::HasContext>::UniformLocation,
-    loc_masktex: <glow::Context as glow::HasContext>::UniformLocation,
+    loc_glyphtex: <glow::Context as glow::HasContext>::UniformLocation,
     loc_frag: <glow::Context as glow::HasContext>::UniformLocation,
 }
 
@@ -151,7 +151,7 @@ impl MainProgram {
 
         let loc_viewsize = program.uniform_location("viewSize")?;
         let loc_tex = program.uniform_location("tex")?;
-        let loc_masktex = program.uniform_location("masktex")?;
+        let loc_glyphtex = program.uniform_location("glyphtex")?;
         let loc_frag = program.uniform_location("frag")?;
 
         Ok(Self {
@@ -159,7 +159,7 @@ impl MainProgram {
             program,
             loc_viewsize,
             loc_tex,
-            loc_masktex,
+            loc_glyphtex,
             loc_frag,
         })
     }
@@ -170,9 +170,9 @@ impl MainProgram {
         }
     }
 
-    pub(crate) fn set_masktex(&self, tex: i32) {
+    pub(crate) fn set_glyphtex(&self, tex: i32) {
         unsafe {
-            self.context.uniform_1_i32(Some(&self.loc_masktex), tex);
+            self.context.uniform_1_i32(Some(&self.loc_glyphtex), tex);
         }
     }
 

--- a/src/renderer/opengl/uniform_array.rs
+++ b/src/renderer/opengl/uniform_array.rs
@@ -71,8 +71,8 @@ impl UniformArray {
         self.0[43] = shader_type;
     }
 
-    pub fn set_has_mask(&mut self, has_mask: f32) {
-        self.0[44] = has_mask;
+    pub fn set_glyph_texture_type(&mut self, glyph_texture_type: f32) {
+        self.0[44] = glyph_texture_type;
     }
 
     pub fn set_image_blur_filter_direction(&mut self, direction: [f32; 2]) {
@@ -105,7 +105,7 @@ impl From<&Params> for UniformArray {
         arr.set_stroke_thr(params.stroke_thr);
         arr.set_shader_type(params.shader_type);
         arr.set_tex_type(params.tex_type);
-        arr.set_has_mask(params.has_mask);
+        arr.set_glyph_texture_type(params.glyph_texture_type);
         arr.set_image_blur_filter_direction(params.image_blur_filter_direction);
         arr.set_image_blur_filter_sigma(params.image_blur_filter_sigma);
         arr.set_image_blur_filter_coeff(params.image_blur_filter_coeff);

--- a/src/renderer/params.rs
+++ b/src/renderer/params.rs
@@ -1,5 +1,8 @@
 use crate::{
-    paint::GradientColors,
+    paint::{
+        GlyphTexture,
+        GradientColors,
+    },
     Color,
     ImageFlags,
     ImageStore,
@@ -27,7 +30,7 @@ pub struct Params {
     pub(crate) stroke_thr: f32,
     pub(crate) tex_type: f32,
     pub(crate) shader_type: f32,
-    pub(crate) has_mask: f32,
+    pub(crate) glyph_texture_type: f32, // 0 -> no glyph rendering, 1 -> alpha mask, 2 -> color texture
     pub(crate) image_blur_filter_direction: [f32; 2],
     pub(crate) image_blur_filter_sigma: f32,
     pub(crate) image_blur_filter_coeff: [f32; 3],
@@ -70,7 +73,11 @@ impl Params {
         params.stroke_mult = (stroke_width * 0.5 + fringe_width * 0.5) / fringe_width;
         params.stroke_thr = stroke_thr;
 
-        params.has_mask = if paint.alpha_mask().is_some() { 1.0 } else { 0.0 };
+        params.glyph_texture_type = match paint.glyph_texture() {
+            GlyphTexture::None => 0.0,
+            GlyphTexture::AlphaMask(_) => 1.0,
+            GlyphTexture::ColorTexture(_) => 2.0,
+        };
 
         let inv_transform;
 


### PR DESCRIPTION
This patch set includes some refactorings as well as the basic support for color fonts. When rendering emojis, color fonts are typically used. These are true type fonts with new tables that encode emojis as PNG images in various resolutions. ttf-parser is equipped with parsing these tables. So this patch set uses that API to extract the PNG images and renders them into the glyph texture atlas.

The glyph size handling isn't quite perfect yet, the glyphs are preferably scaled. It would be nice to change this in the future to use round to the next matching size and increase the overall text layout if the emojis supplied by the font are bigger than the text.

Screenshot that shows the result applied to [cargo-ui](https://github.com/sixtyfpsui/cargo-ui):

<img width="508" alt="Screenshot 2021-08-26 at 10 57 54" src="https://user-images.githubusercontent.com/1486/130933967-1ca99a57-cc25-4ec9-ae02-b0d8bd41763a.png">
