### PR TITLE
Fix rendering into FBOs with OpenGL ES 2.0

### DIFF
--- a/src/renderer/opengl/framebuffer.rs
+++ b/src/renderer/opengl/framebuffer.rs
@@ -29,75 +29,51 @@ impl Framebuffer {
         let width = texture.info().width() as u32;
         let height = texture.info().height() as u32;
 
-        let attach_texture = {
-            || unsafe {
-                context.framebuffer_texture_2d(
-                    glow::FRAMEBUFFER,
-                    glow::COLOR_ATTACHMENT0,
-                    glow::TEXTURE_2D,
-                    Some(texture.id()),
-                    0,
-                );
-            }
+        unsafe {
+            context.framebuffer_texture_2d(
+                glow::FRAMEBUFFER,
+                glow::COLOR_ATTACHMENT0,
+                glow::TEXTURE_2D,
+                Some(texture.id()),
+                0,
+            );
         };
-
-        attach_texture();
 
         let depth_stencil_rbo = unsafe { context.create_renderbuffer().unwrap() };
         unsafe {
             context.bind_renderbuffer(glow::RENDERBUFFER, Some(depth_stencil_rbo));
-            context.renderbuffer_storage(glow::RENDERBUFFER, glow::DEPTH24_STENCIL8, width as i32, height as i32);
+            context.renderbuffer_storage(glow::RENDERBUFFER, glow::STENCIL_INDEX8, width as i32, height as i32);
             context.bind_renderbuffer(glow::RENDERBUFFER, None);
-        }
 
-        let attach_stencil_rbo = {
-            || unsafe {
-                context.framebuffer_renderbuffer(
-                    glow::FRAMEBUFFER,
-                    glow::DEPTH_STENCIL_ATTACHMENT,
-                    glow::RENDERBUFFER,
-                    Some(depth_stencil_rbo),
-                );
-            }
-        };
-
-        unsafe {
-            attach_stencil_rbo();
+            context.framebuffer_renderbuffer(
+                glow::FRAMEBUFFER,
+                glow::STENCIL_ATTACHMENT,
+                glow::RENDERBUFFER,
+                Some(depth_stencil_rbo),
+            );
 
             let status = context.check_framebuffer_status(glow::FRAMEBUFFER);
 
             if status != glow::FRAMEBUFFER_COMPLETE {
-                // DEPTH24_STENCIL8 is not supported in WebGL 1, so fall back to the unsized DEPTH_STENCIL, a workaround
-                // that's in the WebGL 1.0 spec.
-                context.bind_renderbuffer(glow::RENDERBUFFER, Some(depth_stencil_rbo));
-                context.renderbuffer_storage(glow::RENDERBUFFER, glow::DEPTH_STENCIL, width as i32, height as i32);
-                context.bind_renderbuffer(glow::RENDERBUFFER, None);
-                attach_texture();
-                attach_stencil_rbo();
+                let reason = match status {
+                    glow::FRAMEBUFFER_INCOMPLETE_ATTACHMENT => {
+                        format!("({}) Framebuffer incomplete attachment", status)
+                    }
+                    //glow::FRAMEBUFFER_INCOMPLETE_DRAW_BUFFER => format!("({}) Framebuffer incomplete draw buffer", status),
+                    //glow::FRAMEBUFFER_INCOMPLETE_LAYER_TARGETS => format!("({}) Framebuffer incomplete layer targets", status),
+                    //FIXME: will be in next glow release: glow::FRAMEBUFFER_INCOMPLETE_DIMENSIONS => format!("({}) Framebuffer incomplete dimensions", status),
+                    glow::FRAMEBUFFER_INCOMPLETE_MISSING_ATTACHMENT => {
+                        format!("({}) Framebuffer incomplete missing attachment", status)
+                    }
+                    glow::FRAMEBUFFER_INCOMPLETE_MULTISAMPLE => {
+                        format!("({}) Framebuffer incomplete multisample", status)
+                    }
+                    //glow::FRAMEBUFFER_INCOMPLETE_READ_BUFFER => format!("({}) Framebuffer incomplete read buffer", status),
+                    glow::FRAMEBUFFER_UNSUPPORTED => format!("({}) Framebuffer unsupported", status),
+                    _ => format!("({}) Framebuffer not complete!", status),
+                };
 
-                let status = context.check_framebuffer_status(glow::FRAMEBUFFER);
-
-                if status != glow::FRAMEBUFFER_COMPLETE {
-                    let reason = match status {
-                        glow::FRAMEBUFFER_INCOMPLETE_ATTACHMENT => {
-                            format!("({}) Framebuffer incomplete attachment", status)
-                        }
-                        //glow::FRAMEBUFFER_INCOMPLETE_DRAW_BUFFER => format!("({}) Framebuffer incomplete draw buffer", status),
-                        //glow::FRAMEBUFFER_INCOMPLETE_LAYER_TARGETS => format!("({}) Framebuffer incomplete layer targets", status),
-                        //FIXME: will be in next glow release: glow::FRAMEBUFFER_INCOMPLETE_DIMENSIONS => format!("({}) Framebuffer incomplete dimensions", status),
-                        glow::FRAMEBUFFER_INCOMPLETE_MISSING_ATTACHMENT => {
-                            format!("({}) Framebuffer incomplete missing attachment", status)
-                        }
-                        glow::FRAMEBUFFER_INCOMPLETE_MULTISAMPLE => {
-                            format!("({}) Framebuffer incomplete multisample", status)
-                        }
-                        //glow::FRAMEBUFFER_INCOMPLETE_READ_BUFFER => format!("({}) Framebuffer incomplete read buffer", status),
-                        glow::FRAMEBUFFER_UNSUPPORTED => format!("({}) Framebuffer unsupported", status),
-                        _ => format!("({}) Framebuffer not complete!", status),
-                    };
-
-                    return Err(ErrorKind::RenderTargetError(reason));
-                }
+                return Err(ErrorKind::RenderTargetError(reason));
             }
 
             context.bind_framebuffer(glow::FRAMEBUFFER, None);


### PR DESCRIPTION
The stencil buffer attachment code on FBOs does not work with a pure GL
ES 2.0 context. The workaround of commit
141b1c079174b04de85e4153a6795bbe876ad9b0 for WebGL is specific to WebGL,
making the attachment work as stencil & depth attachment. However a
combination of both is not supported by pure GL ES 2.0 it seems.

However it appears that the easiest solution is to simply drop the depth
buffer. That appears to work well with desktop GL, a GL ES 2.0 context
(with mesa at least) and WebGL 1 (in Safari). Since femtovg doesn't use
depth testing, that seems like a reasonable compromise.