### PR TITLE
Correctly parse fill and stroke colors in svg example.

### DIFF
--- a/examples/svg.rs
+++ b/examples/svg.rs
@@ -1,3 +1,4 @@
+use std::convert::TryInto;
 use std::ops::Deref;
 use std::time::Instant;
 
@@ -214,7 +215,7 @@ fn render_svg(svg: &str) -> Vec<(Path, Option<Paint>, Option<Paint>)> {
 
     for event in svg {
         match event {
-            SvgEvent::Tag(Path, _, attributes) => {
+            SvgEvent::Tag("path", _, attributes) => {
                 let data = attributes.get("d").unwrap();
                 let data = Data::parse(data).unwrap();
 
@@ -235,13 +236,37 @@ fn render_svg(svg: &str) -> Vec<(Path, Option<Paint>, Option<Paint>)> {
                 }
 
                 let fill = if let Some(fill) = attributes.get("fill") {
-                    Some(Paint::color(Color::hex(fill)))
+                    if fill.starts_with("rgba(") {
+                        let [r, g, b, a]: [u8; 4] = fill
+                            .split(',')
+                            .map(|k| k.trim_matches(|c| !char::is_numeric(c)).parse().unwrap())
+                            .collect::<Vec<u8>>()
+                            .try_into()
+                            .unwrap();
+                        Some(Paint::color(Color::rgba(r, g, b, a)))
+                    } else {
+                        Some(Paint::color(Color::hex(fill)))
+                    }
                 } else {
                     None
                 };
 
                 let stroke = if let Some(stroke) = attributes.get("stroke") {
-                    if "none" != stroke.deref() {
+                    if stroke.starts_with("rgba(") {
+                        let [r, g, b, a]: [u8; 4] = stroke
+                            .split(',')
+                            .map(|k| k.trim_matches(|c| !char::is_numeric(c)).parse().unwrap())
+                            .collect::<Vec<u8>>()
+                            .try_into()
+                            .unwrap();
+                        let mut stroke_paint = Paint::color(Color::rgba(r, g, b, a));
+
+                        if let Some(stroke_width) = attributes.get("stroke-width") {
+                            stroke_paint.set_line_width(stroke_width.parse().unwrap());
+                        }
+
+                        Some(stroke_paint)
+                    } else if "none" != stroke.deref() {
                         let mut stroke_paint = Paint::color(Color::hex(stroke));
 
                         if let Some(stroke_width) = attributes.get("stroke-width") {


### PR DESCRIPTION
This is just a temporary fix. A better solution would use the `Tree` from usvg.

Before:
![svg bad](https://user-images.githubusercontent.com/1443107/137885686-51458f62-04c6-4451-ab07-8632a4758858.png)

After:
![svg good](https://user-images.githubusercontent.com/1443107/137885710-94b652ec-bacf-44ad-a3ce-6c8c41064ed4.png)
