### PR TITLE
Temporary fix for #56

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ lru = { version = "0.6.5", default-features = false }
 image = { version = "0.23.6", optional = true, default-features = false }
 serde = { version = "1.0", optional = true, features = ["derive"] }
 ouroboros = { version = "0.12" }
+byteorder = "1.4.3"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 glow = { version = "0.11.0", default-features = false }

--- a/src/text.rs
+++ b/src/text.rs
@@ -23,6 +23,7 @@ use lru::LruCache;
 use unicode_bidi::BidiInfo;
 use unicode_segmentation::UnicodeSegmentation;
 
+use crate::utils::sync_typographic_metrics;
 use crate::{
     Canvas,
     Color,
@@ -357,7 +358,9 @@ impl TextContextImpl {
     pub fn add_font_mem_with_index(&mut self, data: &[u8], face_index: u32) -> Result<FontId, ErrorKind> {
         self.clear_caches();
 
-        let font = Font::new_with_data(data.to_owned(), face_index)?;
+        let mut data = data.to_owned();
+        sync_typographic_metrics(&mut data).expect("Failed to sync typographic metrics");
+        let font = Font::new_with_data(data, face_index)?;
         Ok(FontId(self.fonts.insert(font)))
     }
 
@@ -367,7 +370,8 @@ impl TextContextImpl {
         face_index: u32,
     ) -> Result<FontId, ErrorKind> {
         self.clear_caches();
-
+        let mut data = data.as_ref().to_owned();
+        sync_typographic_metrics(&mut data).expect("Failed to sync typographic metrics");
         let font = Font::new_with_data(data, face_index)?;
         Ok(FontId(self.fonts.insert(font)))
     }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,3 +1,7 @@
+use std::io::Seek;
+
+use byteorder::{BigEndian, ByteOrder, ReadBytesExt, WriteBytesExt};
+
 // TODO: Remove this when drain_filter comes to stable rust
 
 pub(crate) trait VecRetainMut<T> {
@@ -29,5 +33,58 @@ impl<T> VecRetainMut<T> for Vec<T> {
         if del > 0 {
             self.truncate(len - del);
         }
+    }
+}
+
+// Remove this when ttf-parser is updated from 0.12.3
+
+/// Changes the usWin* ascender/ descender values to match the usTypo* ascender/ descender values in a font file in memory
+/// 
+/// Due to a bug in the latest version of ttf-parser (0.12.3), which is depended on by RustyBuzz, the wrong ascender/ descender
+/// metrics are used for the entypo font file. This is a temporary fix until ttf-parser and RustyBuzz are updated.
+pub(crate) fn sync_typographic_metrics(mut font_data: &mut [u8]) -> Result<(), std::io::Error> {
+
+    let num_tables = (&font_data[4..6]).read_i16::<BigEndian>()?;
+    // Find the OS/2 table in the font file
+    let mut i = 12;
+    for _ in 0..num_tables {
+        let data = &font_data[i..i+16];
+        let tag = &data[0..4];
+        let checksum = (&data[4..8]).read_u32::<BigEndian>()?; 
+        let offset = (&data[8..12]).read_u32::<BigEndian>()? as usize;
+         
+        let length = (&data[12..16]).read_u32::<BigEndian>()? as usize;
+        i += 16;
+
+        // Locate the OS/2 table
+        if tag == &[0x4F, 0x53, 0x2F, 0x32] {
+            let os2 = &font_data[offset..offset+length];
+            let typo_ascender = (&os2[68..70]).read_i16::<BigEndian>()?;
+            let typo_descender = (&os2[70..72]).read_i16::<BigEndian>()?;
+            (&mut font_data[(offset + 74)..(offset + 76)]).write_i16::<BigEndian>(typo_ascender)?;
+            (&mut font_data[(offset + 76)..(offset + 78)]).write_i16::<BigEndian>(-typo_descender)?;
+            break;
+        }
+
+        
+    }
+    
+    
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+
+    static FONT_DATA: &[u8] = include_bytes!("../examples/assets/entypo.ttf");
+
+    #[test]
+    fn test_sync_typographic_metrics() {
+        let mut data = FONT_DATA.to_owned();
+        sync_typographic_metrics(&mut data);
+
+        std::fs::write("test_file.ttf", &data);
     }
 }


### PR DESCRIPTION
This is a temporary fix for #56 until RazrFalcon/ttf-parser@ab2375757d943f71c7de7def2fb8934c72093d9a is released on crates.io. This will sync the usWin* ascender and descender values to the usTypo* values which is necessary for the Entypo font used in the Demo example. This functionality should be removed when the ttf-parser fix is available on crates.io. Fixes #56.