### PR TITLE
Demo: Path intersection automatically accounts for transforms.

### DIFF
--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -3,8 +3,18 @@ use std::f32::consts::PI;
 use resource::resource;
 
 use instant::Instant;
-use winit::event::{ElementState, Event, KeyboardInput, MouseButton, VirtualKeyCode, WindowEvent};
-use winit::event_loop::{ControlFlow, EventLoop};
+use winit::event::{
+    ElementState,
+    Event,
+    KeyboardInput,
+    MouseButton,
+    VirtualKeyCode,
+    WindowEvent,
+};
+use winit::event_loop::{
+    ControlFlow,
+    EventLoop,
+};
 use winit::window::WindowBuilder;
 //use glutin::{GlRequest, Api};
 


### PR DESCRIPTION
Paths are transformed with the current context so there's no need to convert the mouse position to the pre-transform coordinates before testing for intersection. This fixes #62 