### PR TITLE
Provide a safe way to initialize an OpenGl renderer via glutin.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ ouroboros = { version = "0.13" }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 glow = { version = "0.11.0", default-features = false }
+glutin = { version = "0.27.0", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 glow = { version = "0.11.0", default-features = false }
@@ -39,7 +40,7 @@ web_sys = { version = "0.3", package = "web-sys", features = ["WebGlContextAttri
 wasm-bindgen = { version = "0.2" }
 
 [features]
-default = ["image-loading"]
+default = ["image-loading", "glutin"]
 image-loading = ["image"]
 debug_inspector = []
 

--- a/examples/breakout.rs
+++ b/examples/breakout.rs
@@ -1251,7 +1251,7 @@ fn main() {
     let windowed_context = ContextBuilder::new().build_windowed(wb, &el).unwrap();
     let windowed_context = unsafe { windowed_context.make_current().unwrap() };
 
-    let renderer = OpenGl::new_glutin(&windowed_context).expect("Cannot create renderer");
+    let renderer = OpenGl::new_from_glutin_context(&windowed_context).expect("Cannot create renderer");
     let mut canvas = Canvas::new(renderer).expect("Cannot create canvas");
     canvas.set_size(
         window_size.width as u32,

--- a/examples/breakout.rs
+++ b/examples/breakout.rs
@@ -1251,7 +1251,7 @@ fn main() {
     let windowed_context = ContextBuilder::new().build_windowed(wb, &el).unwrap();
     let windowed_context = unsafe { windowed_context.make_current().unwrap() };
 
-    let renderer = OpenGl::new(|s| windowed_context.get_proc_address(s) as *const _).expect("Cannot create renderer");
+    let renderer = OpenGl::new_glutin(&windowed_context).expect("Cannot create renderer");
     let mut canvas = Canvas::new(renderer).expect("Cannot create canvas");
     canvas.set_size(
         window_size.width as u32,

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -58,7 +58,7 @@ fn main() {
         let windowed_context = ContextBuilder::new().with_vsync(false).build_windowed(wb, &el).unwrap();
         let windowed_context = unsafe { windowed_context.make_current().unwrap() };
 
-        let renderer = OpenGl::new_glutin(&windowed_context).expect("Cannot create renderer");
+        let renderer = OpenGl::new_from_glutin_context(&windowed_context).expect("Cannot create renderer");
 
         (renderer, windowed_context)
     };

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -58,8 +58,7 @@ fn main() {
         let windowed_context = ContextBuilder::new().with_vsync(false).build_windowed(wb, &el).unwrap();
         let windowed_context = unsafe { windowed_context.make_current().unwrap() };
 
-        let renderer =
-            OpenGl::new(|s| windowed_context.get_proc_address(s) as *const _).expect("Cannot create renderer");
+        let renderer = OpenGl::new_glutin(&windowed_context).expect("Cannot create renderer");
 
         (renderer, windowed_context)
     };

--- a/examples/gradients.rs
+++ b/examples/gradients.rs
@@ -20,7 +20,7 @@ fn main() {
     let windowed_context = ContextBuilder::new().build_windowed(wb, &el).unwrap();
     let windowed_context = unsafe { windowed_context.make_current().unwrap() };
 
-    let renderer = OpenGl::new_glutin(&windowed_context).expect("Cannot create renderer");
+    let renderer = OpenGl::new_from_glutin_context(&windowed_context).expect("Cannot create renderer");
     let mut canvas = Canvas::new(renderer).expect("Cannot create canvas");
     canvas.set_size(
         window_size.width as u32,

--- a/examples/gradients.rs
+++ b/examples/gradients.rs
@@ -20,7 +20,7 @@ fn main() {
     let windowed_context = ContextBuilder::new().build_windowed(wb, &el).unwrap();
     let windowed_context = unsafe { windowed_context.make_current().unwrap() };
 
-    let renderer = OpenGl::new(|s| windowed_context.get_proc_address(s) as *const _).expect("Cannot create renderer");
+    let renderer = OpenGl::new_glutin(&windowed_context).expect("Cannot create renderer");
     let mut canvas = Canvas::new(renderer).expect("Cannot create canvas");
     canvas.set_size(
         window_size.width as u32,

--- a/examples/paint_filter.rs
+++ b/examples/paint_filter.rs
@@ -25,7 +25,7 @@ fn main() {
     let windowed_context = ContextBuilder::new().build_windowed(wb, &el).unwrap();
     let windowed_context = unsafe { windowed_context.make_current().unwrap() };
 
-    let renderer = OpenGl::new_glutin(&windowed_context).expect("Cannot create renderer");
+    let renderer = OpenGl::new_from_glutin_context(&windowed_context).expect("Cannot create renderer");
     let mut canvas = Canvas::new(renderer).expect("Cannot create canvas");
     canvas.set_size(
         window_size.width as u32,

--- a/examples/paint_filter.rs
+++ b/examples/paint_filter.rs
@@ -25,7 +25,7 @@ fn main() {
     let windowed_context = ContextBuilder::new().build_windowed(wb, &el).unwrap();
     let windowed_context = unsafe { windowed_context.make_current().unwrap() };
 
-    let renderer = OpenGl::new(|s| windowed_context.get_proc_address(s) as *const _).expect("Cannot create renderer");
+    let renderer = OpenGl::new_glutin(&windowed_context).expect("Cannot create renderer");
     let mut canvas = Canvas::new(renderer).expect("Cannot create canvas");
     canvas.set_size(
         window_size.width as u32,

--- a/examples/paint_image.rs
+++ b/examples/paint_image.rs
@@ -34,7 +34,7 @@ fn main() {
     let windowed_context = ContextBuilder::new().build_windowed(wb, &el).unwrap();
     let windowed_context = unsafe { windowed_context.make_current().unwrap() };
 
-    let renderer = OpenGl::new_glutin(&windowed_context).expect("Cannot create renderer");
+    let renderer = OpenGl::new_from_glutin_context(&windowed_context).expect("Cannot create renderer");
     let mut canvas = Canvas::new(renderer).expect("Cannot create canvas");
     canvas.set_size(
         window_size.width as u32,

--- a/examples/paint_image.rs
+++ b/examples/paint_image.rs
@@ -34,7 +34,7 @@ fn main() {
     let windowed_context = ContextBuilder::new().build_windowed(wb, &el).unwrap();
     let windowed_context = unsafe { windowed_context.make_current().unwrap() };
 
-    let renderer = OpenGl::new(|s| windowed_context.get_proc_address(s) as *const _).expect("Cannot create renderer");
+    let renderer = OpenGl::new_glutin(&windowed_context).expect("Cannot create renderer");
     let mut canvas = Canvas::new(renderer).expect("Cannot create canvas");
     canvas.set_size(
         window_size.width as u32,

--- a/examples/svg.rs
+++ b/examples/svg.rs
@@ -16,7 +16,7 @@ fn main() {
     let windowed_context = ContextBuilder::new().with_vsync(false).build_windowed(wb, &el).unwrap();
     let windowed_context = unsafe { windowed_context.make_current().unwrap() };
 
-    let renderer = OpenGl::new(|s| windowed_context.get_proc_address(s) as *const _).expect("Cannot create renderer");
+    let renderer = OpenGl::new_glutin(&windowed_context).expect("Cannot create renderer");
     let mut canvas = Canvas::new(renderer).expect("Cannot create canvas");
 
     let roboto_light = canvas

--- a/examples/svg.rs
+++ b/examples/svg.rs
@@ -16,7 +16,7 @@ fn main() {
     let windowed_context = ContextBuilder::new().with_vsync(false).build_windowed(wb, &el).unwrap();
     let windowed_context = unsafe { windowed_context.make_current().unwrap() };
 
-    let renderer = OpenGl::new_glutin(&windowed_context).expect("Cannot create renderer");
+    let renderer = OpenGl::new_from_glutin_context(&windowed_context).expect("Cannot create renderer");
     let mut canvas = Canvas::new(renderer).expect("Cannot create canvas");
 
     let roboto_light = canvas

--- a/examples/text.rs
+++ b/examples/text.rs
@@ -26,7 +26,7 @@ fn main() {
     let windowed_context = ContextBuilder::new().build_windowed(wb, &el).unwrap();
     let windowed_context = unsafe { windowed_context.make_current().unwrap() };
 
-    let renderer = OpenGl::new(|s| windowed_context.get_proc_address(s) as *const _).expect("Cannot create renderer");
+    let renderer = OpenGl::new_glutin(&windowed_context).expect("Cannot create renderer");
     let mut canvas = Canvas::new(renderer).expect("Cannot create canvas");
     canvas.set_size(
         window_size.width as u32,

--- a/examples/text.rs
+++ b/examples/text.rs
@@ -26,7 +26,7 @@ fn main() {
     let windowed_context = ContextBuilder::new().build_windowed(wb, &el).unwrap();
     let windowed_context = unsafe { windowed_context.make_current().unwrap() };
 
-    let renderer = OpenGl::new_glutin(&windowed_context).expect("Cannot create renderer");
+    let renderer = OpenGl::new_from_glutin_context(&windowed_context).expect("Cannot create renderer");
     let mut canvas = Canvas::new(renderer).expect("Cannot create canvas");
     canvas.set_size(
         window_size.width as u32,

--- a/src/renderer/opengl.rs
+++ b/src/renderer/opengl.rs
@@ -73,7 +73,9 @@ impl OpenGl {
     }
 
     #[cfg(all(feature = "glutin", not(target_arch = "wasm32")))]
-    pub fn new_glutin(windowed_context: &ContextWrapper<PossiblyCurrent, Window>) -> Result<Self, ErrorKind> {
+    pub fn new_from_glutin_context(
+        windowed_context: &ContextWrapper<PossiblyCurrent, Window>,
+    ) -> Result<Self, ErrorKind> {
         unsafe { OpenGl::new_from_function(|s| windowed_context.get_proc_address(s) as *const _) }
     }
 

--- a/src/renderer/opengl.rs
+++ b/src/renderer/opengl.rs
@@ -61,6 +61,7 @@ impl OpenGl {
         unsafe { Self::new_from_function(load_fn) }
     }
 
+    #[cfg(not(target_arch = "wasm32"))]
     pub unsafe fn new_from_function<F>(load_fn: F) -> Result<Self, ErrorKind>
     where
         F: FnMut(&str) -> *const c_void,

--- a/src/renderer/opengl.rs
+++ b/src/renderer/opengl.rs
@@ -52,7 +52,7 @@ impl OpenGl {
     #[cfg(not(target_arch = "wasm32"))]
     #[deprecated(
         since = "0.3",
-        note = "This function unsafe. Use OpenGl::new_from_function or OpenGl::new_glutin"
+        note = "This function unsafe. Use OpenGl::new_from_function or OpenGl::new_from_glutin_context"
     )]
     pub fn new<F>(load_fn: F) -> Result<Self, ErrorKind>
     where

--- a/src/renderer/opengl.rs
+++ b/src/renderer/opengl.rs
@@ -50,7 +50,18 @@ pub struct OpenGl {
 
 impl OpenGl {
     #[cfg(not(target_arch = "wasm32"))]
-    pub unsafe fn new<F>(load_fn: F) -> Result<Self, ErrorKind>
+    #[deprecated(
+        since = "0.3",
+        note = "This function unsafe. Use OpenGl::new_from_function or OpenGl::new_glutin"
+    )]
+    pub fn new<F>(load_fn: F) -> Result<Self, ErrorKind>
+    where
+        F: FnMut(&str) -> *const c_void,
+    {
+        unsafe { Self::new_from_function(load_fn) }
+    }
+
+    pub unsafe fn new_from_function<F>(load_fn: F) -> Result<Self, ErrorKind>
     where
         F: FnMut(&str) -> *const c_void,
     {
@@ -62,7 +73,7 @@ impl OpenGl {
 
     #[cfg(all(feature = "glutin", not(target_arch = "wasm32")))]
     pub fn new_glutin(windowed_context: &ContextWrapper<PossiblyCurrent, Window>) -> Result<Self, ErrorKind> {
-        unsafe { OpenGl::new(|s| windowed_context.get_proc_address(s) as *const _) }
+        unsafe { OpenGl::new_from_function(|s| windowed_context.get_proc_address(s) as *const _) }
     }
 
     #[cfg(target_arch = "wasm32")]


### PR DESCRIPTION
`OpenGl::new` is quite low-level and will segfault if used incorrectly. This PR introduces the `OpenGl::new_glutin` method which will safely produce an OpenGl renderer from a windowed context.

This PR also marks `OpenGl::new` as unsafe which completely breaks backwards compatibility. Maybe we should mark `OpenGl::new` as deprecated instead?