### PR TITLE
Created a position type

### DIFF
--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -42,19 +42,6 @@ pub fn dist_pt_segment(x: f32, y: f32, px: f32, py: f32, qx: f32, qy: f32) -> f3
     dx * dx + dy * dy
 }
 
-// TODO: fix this.. move it to point
-pub fn normalize(x: &mut f32, y: &mut f32) -> f32 {
-    let d = ((*x) * (*x) + (*y) * (*y)).sqrt();
-
-    if d > 1e-6 {
-        let id = 1.0 / d;
-        *x *= id;
-        *y *= id;
-    }
-
-    d
-}
-
 /// 2×3 matrix (2 rows, 3 columns) used for 2D linear transformations. It can represent transformations such as translation, rotation, or scaling.
 #[derive(Copy, Clone, Debug, PartialEq, PartialOrd)]
 #[cfg_attr(feature = "serialization", derive(Serialize, Deserialize))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@ use std::rc::Rc;
 use imgref::ImgVec;
 use rgb::RGBA8;
 
-mod position;
+mod vector;
 
 mod utils;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,8 @@ use std::rc::Rc;
 use imgref::ImgVec;
 use rgb::RGBA8;
 
+mod position;
+
 mod utils;
 
 mod text;

--- a/src/paint.rs
+++ b/src/paint.rs
@@ -2,7 +2,7 @@
 // so that they are easier to find when autocompleting
 
 use crate::geometry::Transform2D;
-use crate::position::Position;
+use crate::vector::Vector;
 use crate::{Align, Baseline, Color, FillRule, FontId, ImageId, LineCap, LineJoin};
 
 #[derive(Copy, Clone, Debug, PartialEq, PartialOrd, Default)]
@@ -96,19 +96,19 @@ pub(crate) enum PaintFlavor {
     #[cfg_attr(feature = "serde", serde(skip))]
     Image {
         id: ImageId,
-        center: Position,
+        center: Vector,
         width: f32,
         height: f32,
         angle: f32,
         alpha: f32,
     },
     LinearGradient {
-        start: Position,
-        end: Position,
+        start: Vector,
+        end: Vector,
         colors: GradientColors,
     },
     BoxGradient {
-        pos: Position,
+        pos: Vector,
         width: f32,
         height: f32,
         radius: f32,
@@ -116,7 +116,7 @@ pub(crate) enum PaintFlavor {
         colors: GradientColors,
     },
     RadialGradient {
-        center: Position,
+        center: Vector,
         in_radius: f32,
         out_radius: f32,
         colors: GradientColors,
@@ -252,7 +252,7 @@ impl Paint {
         let mut new = Self::default();
         new.flavor = PaintFlavor::Image {
             id,
-            center: Position { x: cx, y: cy },
+            center: Vector { x: cx, y: cy },
             width,
             height,
             angle,
@@ -287,8 +287,8 @@ impl Paint {
         let mut new = Self::default();
 
         new.flavor = PaintFlavor::LinearGradient {
-            start: Position { x: start_x, y: start_y },
-            end: Position { x: end_x, y: end_y },
+            start: Vector { x: start_x, y: start_y },
+            end: Vector { x: end_x, y: end_y },
             colors: GradientColors::TwoStop { start_color, end_color },
         };
 
@@ -319,8 +319,8 @@ impl Paint {
         let mut new = Self::default();
 
         new.flavor = PaintFlavor::LinearGradient {
-            start: Position { x: start_x, y: start_y },
-            end: Position { x: end_x, y: end_y },
+            start: Vector { x: start_x, y: start_y },
+            end: Vector { x: end_x, y: end_y },
             colors: GradientColors::from_stops(stops),
         };
 
@@ -369,7 +369,7 @@ impl Paint {
         let mut new = Self::default();
 
         new.flavor = PaintFlavor::BoxGradient {
-            pos: Position { x, y },
+            pos: Vector { x, y },
             width,
             height,
             radius,
@@ -419,7 +419,7 @@ impl Paint {
         let mut new = Self::default();
 
         new.flavor = PaintFlavor::RadialGradient {
-            center: Position { x: cx, y: cy },
+            center: Vector { x: cx, y: cy },
             in_radius,
             out_radius,
             colors: GradientColors::TwoStop {
@@ -465,7 +465,7 @@ impl Paint {
         let mut new = Self::default();
 
         new.flavor = PaintFlavor::RadialGradient {
-            center: Position { x: cx, y: cy },
+            center: Vector { x: cx, y: cy },
             in_radius,
             out_radius,
             colors: GradientColors::from_stops(stops),

--- a/src/paint.rs
+++ b/src/paint.rs
@@ -2,6 +2,7 @@
 // so that they are easier to find when autocompleting
 
 use crate::geometry::Transform2D;
+use crate::position::Position;
 use crate::{Align, Baseline, Color, FillRule, FontId, ImageId, LineCap, LineJoin};
 
 #[derive(Copy, Clone, Debug, PartialEq, PartialOrd, Default)]
@@ -95,23 +96,19 @@ pub(crate) enum PaintFlavor {
     #[cfg_attr(feature = "serde", serde(skip))]
     Image {
         id: ImageId,
-        cx: f32,
-        cy: f32,
+        center: Position,
         width: f32,
         height: f32,
         angle: f32,
         alpha: f32,
     },
     LinearGradient {
-        start_x: f32,
-        start_y: f32,
-        end_x: f32,
-        end_y: f32,
+        start: Position,
+        end: Position,
         colors: GradientColors,
     },
     BoxGradient {
-        x: f32,
-        y: f32,
+        pos: Position,
         width: f32,
         height: f32,
         radius: f32,
@@ -119,8 +116,7 @@ pub(crate) enum PaintFlavor {
         colors: GradientColors,
     },
     RadialGradient {
-        cx: f32,
-        cy: f32,
+        center: Position,
         in_radius: f32,
         out_radius: f32,
         colors: GradientColors,
@@ -256,8 +252,7 @@ impl Paint {
         let mut new = Self::default();
         new.flavor = PaintFlavor::Image {
             id,
-            cx,
-            cy,
+            center: Position { x: cx, y: cy },
             width,
             height,
             angle,
@@ -292,10 +287,8 @@ impl Paint {
         let mut new = Self::default();
 
         new.flavor = PaintFlavor::LinearGradient {
-            start_x,
-            start_y,
-            end_x,
-            end_y,
+            start: Position { x: start_x, y: start_y },
+            end: Position { x: end_x, y: end_y },
             colors: GradientColors::TwoStop { start_color, end_color },
         };
 
@@ -326,10 +319,8 @@ impl Paint {
         let mut new = Self::default();
 
         new.flavor = PaintFlavor::LinearGradient {
-            start_x,
-            start_y,
-            end_x,
-            end_y,
+            start: Position { x: start_x, y: start_y },
+            end: Position { x: end_x, y: end_y },
             colors: GradientColors::from_stops(stops),
         };
 
@@ -378,8 +369,7 @@ impl Paint {
         let mut new = Self::default();
 
         new.flavor = PaintFlavor::BoxGradient {
-            x,
-            y,
+            pos: Position { x, y },
             width,
             height,
             radius,
@@ -429,8 +419,7 @@ impl Paint {
         let mut new = Self::default();
 
         new.flavor = PaintFlavor::RadialGradient {
-            cx,
-            cy,
+            center: Position { x: cx, y: cy },
             in_radius,
             out_radius,
             colors: GradientColors::TwoStop {
@@ -476,8 +465,7 @@ impl Paint {
         let mut new = Self::default();
 
         new.flavor = PaintFlavor::RadialGradient {
-            cx,
-            cy,
+            center: Position { x: cx, y: cy },
             in_radius,
             out_radius,
             colors: GradientColors::from_stops(stops),

--- a/src/path.rs
+++ b/src/path.rs
@@ -270,10 +270,10 @@ impl Path {
         let mut dpos0 = pos0 - pos1;
         let mut dpos1 = pos2 - pos1;
 
-        geometry::normalize(&mut dpos0.x, &mut dpos0.y);
-        geometry::normalize(&mut dpos1.x, &mut dpos1.y);
+        dpos0.normalize();
+        dpos1.normalize();
 
-        let a = (dpos0.x * dpos1.x + dpos0.y * dpos1.y).acos();
+        let a = dpos0.dot(dpos1).acos();
         let d = radius / (a / 2.0).tan();
 
         if d > 10000.0 {

--- a/src/path/cache.rs
+++ b/src/path/cache.rs
@@ -4,7 +4,7 @@ use std::ops::Range;
 
 use bitflags::bitflags;
 
-use crate::geometry::{self, Bounds, Transform2D};
+use crate::geometry::{Bounds, Transform2D};
 use crate::position::Position;
 use crate::renderer::Vertex;
 use crate::utils::VecRetainMut;
@@ -253,9 +253,8 @@ impl PathCache {
                     points.get_mut(i - 1).unwrap()
                 };
 
-                p0.dpos.x = p1.pos.x - p0.pos.x;
-                p0.dpos.y = p1.pos.y - p0.pos.y;
-                p0.len = geometry::normalize(&mut p0.dpos.x, &mut p0.dpos.y);
+                p0.dpos = p1.pos - p0.pos;
+                p0.len = p0.dpos.normalize();
 
                 bounds.minx = bounds.minx.min(p0.pos.x);
                 bounds.miny = bounds.miny.min(p0.pos.y);

--- a/src/path/cache.rs
+++ b/src/path/cache.rs
@@ -944,8 +944,8 @@ fn round_join(verts: &mut Vec<Vertex>, p0: &Point, p1: &Point, lw: f32, rw: f32,
 
     if p1.flags.contains(PointFlags::LEFT) {
         let (lpos0, lpos1) = choose_bevel(p1.flags.contains(PointFlags::INNERBEVEL), p0, p1, lw);
-        a0 = (-dlpos0.y).atan2(-dlpos0.x);
-        a1 = (-dlpos1.y).atan2(-dlpos1.x);
+        a0 = (-dlpos0).angle();
+        a1 = (-dlpos1).angle();
 
         if a1 > a0 {
             a1 -= PI * 2.0;
@@ -969,8 +969,8 @@ fn round_join(verts: &mut Vec<Vertex>, p0: &Point, p1: &Point, lw: f32, rw: f32,
         verts.push(Vertex::pos(p1.pos - dlpos1 * rw, ru, 1.0));
     } else {
         let (rpos0, rpos1) = choose_bevel(p1.flags.contains(PointFlags::INNERBEVEL), p0, p1, -rw);
-        a0 = dlpos0.y.atan2(dlpos0.x);
-        a1 = dlpos1.y.atan2(dlpos1.x);
+        a0 = dlpos0.angle();
+        a1 = dlpos1.angle();
 
         if a1 < a0 {
             a1 += PI * 2.0;

--- a/src/path/cache.rs
+++ b/src/path/cache.rs
@@ -5,6 +5,7 @@ use std::ops::Range;
 use bitflags::bitflags;
 
 use crate::geometry::{self, Bounds, Transform2D};
+use crate::position::Position;
 use crate::renderer::Vertex;
 use crate::utils::VecRetainMut;
 use crate::{FillRule, LineCap, LineJoin, Solidity};
@@ -19,12 +20,6 @@ bitflags! {
         const BEVEL         = 0x04;
         const INNERBEVEL    = 0x08;
     }
-}
-
-#[derive(Copy, Clone, Debug, Default)]
-struct Position {
-    x: f32,
-    y: f32,
 }
 
 #[derive(Copy, Clone, Debug, Default)]

--- a/src/path/cache.rs
+++ b/src/path/cache.rs
@@ -5,9 +5,9 @@ use std::ops::Range;
 use bitflags::bitflags;
 
 use crate::geometry::{Bounds, Transform2D};
-use crate::position::Position;
 use crate::renderer::Vertex;
 use crate::utils::VecRetainMut;
+use crate::vector::Vector;
 use crate::{FillRule, LineCap, LineJoin, Solidity};
 
 use super::Verb;
@@ -24,29 +24,29 @@ bitflags! {
 
 #[derive(Copy, Clone, Debug, Default)]
 pub struct Point {
-    pos: Position,
-    dpos: Position,
+    pos: Vector,
+    dpos: Vector,
     len: f32,
-    dmpos: Position,
+    dmpos: Vector,
     flags: PointFlags,
 }
 
 impl Point {
     pub fn new(x: f32, y: f32, flags: PointFlags) -> Self {
         Self {
-            pos: Position { x, y },
+            pos: Vector { x, y },
             flags,
             ..Default::default()
         }
     }
 
     pub fn is_left(p0: &Self, p1: &Self, x: f32, y: f32) -> f32 {
-        let pos = Position { x, y };
+        let pos = Vector { x, y };
         (p1.pos - p0.pos).dot((pos - p0.pos).orthogonal())
     }
 
     pub fn approx_eq(&self, other: &Self, tolerance: f32) -> bool {
-        let Position { x: dx, y: dy } = other.pos - self.pos;
+        let Vector { x: dx, y: dy } = other.pos - self.pos;
 
         dx * dx + dy * dy < tolerance * tolerance
     }
@@ -899,7 +899,7 @@ fn round_cap_start(verts: &mut Vec<Vertex>, p0: &Point, p1: &Point, w: f32, ncap
 
     for i in 0..ncap {
         let a = i as f32 / (ncap as f32 - 1.0) * PI;
-        let apos = Position::from_angle(a) * w;
+        let apos = Vector::from_angle(a) * w;
 
         verts.push(Vertex::pos(ppos - dlpos * apos.x - p1.dpos * apos.y, u0, 1.0));
         verts.push(Vertex::pos(ppos, 0.5, 1.0));
@@ -918,14 +918,14 @@ fn round_cap_end(verts: &mut Vec<Vertex>, p0: &Point, p1: &Point, w: f32, ncap: 
 
     for i in 0..ncap {
         let a = i as f32 / (ncap as f32 - 1.0) * PI;
-        let apos = Position::from_angle(a) * w;
+        let apos = Vector::from_angle(a) * w;
 
         verts.push(Vertex::pos(ppos, 0.5, 1.0));
         verts.push(Vertex::pos(ppos - dlpos * apos.x + p1.dpos * apos.y, u0, 1.0));
     }
 }
 
-fn choose_bevel(bevel: bool, p0: &Point, p1: &Point, w: f32) -> (Position, Position) {
+fn choose_bevel(bevel: bool, p0: &Point, p1: &Point, w: f32) -> (Vector, Vector) {
     if bevel {
         (p1.pos + p0.dpos.orthogonal() * w, p1.pos + p1.dpos.orthogonal() * w)
     } else {
@@ -958,7 +958,7 @@ fn round_join(verts: &mut Vec<Vertex>, p0: &Point, p1: &Point, lw: f32, rw: f32,
         for i in 0..n {
             let u = i as f32 / (n - 1) as f32;
             let a = a0 + u * (a1 - a0);
-            let rpos = p1.pos + Position::from_angle(a) * rw;
+            let rpos = p1.pos + Vector::from_angle(a) * rw;
 
             verts.push(Vertex::pos(p1.pos, 0.5, 1.0));
             verts.push(Vertex::pos(rpos, ru, 1.0));
@@ -983,7 +983,7 @@ fn round_join(verts: &mut Vec<Vertex>, p0: &Point, p1: &Point, lw: f32, rw: f32,
         for i in 0..n {
             let u = i as f32 / (n - 1) as f32;
             let a = a0 + u * (a1 - a0);
-            let lpos = p1.pos + Position::from_angle(a) * lw;
+            let lpos = p1.pos + Vector::from_angle(a) * lw;
 
             verts.push(Vertex::pos(lpos, lu, 1.0));
             verts.push(Vertex::pos(p1.pos, 0.5, 1.0));

--- a/src/position.rs
+++ b/src/position.rs
@@ -1,5 +1,68 @@
+use std::ops::{Add, Mul, Sub};
+
 #[derive(Copy, Clone, Debug, Default)]
-pub struct Position {
+pub(crate) struct Position {
     pub x: f32,
     pub y: f32,
+}
+
+impl Position {
+    #[inline]
+    pub fn dot(self, other: Self) -> f32 {
+        self.x * other.x + self.y * other.y
+    }
+
+    #[inline]
+    pub fn mirror(self) -> Self {
+        Self { x: -self.x, y: self.y }
+    }
+
+    #[inline]
+    pub fn orthogonal(self) -> Self {
+        Self { x: self.y, y: -self.x }
+    }
+
+    #[inline]
+    pub fn from_angle(angle: f32) -> Self {
+        Self {
+            x: angle.cos(),
+            y: angle.sin(),
+        }
+    }
+}
+
+impl Add for Position {
+    type Output = Self;
+
+    #[inline]
+    fn add(self, other: Self) -> Self {
+        Self {
+            x: self.x + other.x,
+            y: self.y + other.y,
+        }
+    }
+}
+
+impl Sub for Position {
+    type Output = Self;
+
+    #[inline]
+    fn sub(self, other: Self) -> Self {
+        Self {
+            x: self.x - other.x,
+            y: self.y - other.y,
+        }
+    }
+}
+
+impl Mul<f32> for Position {
+    type Output = Self;
+
+    #[inline]
+    fn mul(self, other: f32) -> Self {
+        Self {
+            x: self.x * other,
+            y: self.y * other,
+        }
+    }
 }

--- a/src/position.rs
+++ b/src/position.rs
@@ -34,6 +34,18 @@ impl Position {
     pub fn angle(&self) -> f32 {
         self.y.atan2(self.x)
     }
+
+    pub fn normalize(&mut self) -> f32 {
+        let d = (self.x * self.x + self.y * self.y).sqrt();
+
+        if d > 1e-6 {
+            let id = 1.0 / d;
+            self.x *= id;
+            self.y *= id;
+        }
+
+        d
+    }
 }
 
 impl Add for Position {

--- a/src/position.rs
+++ b/src/position.rs
@@ -1,4 +1,4 @@
-use std::ops::{Add, Mul, Sub};
+use std::ops::{Add, Mul, Neg, Sub};
 
 #[derive(Copy, Clone, Debug, Default)]
 pub(crate) struct Position {
@@ -29,6 +29,11 @@ impl Position {
             y: angle.sin(),
         }
     }
+
+    #[inline]
+    pub fn angle(&self) -> f32 {
+        self.y.atan2(self.x)
+    }
 }
 
 impl Add for Position {
@@ -52,6 +57,15 @@ impl Sub for Position {
             x: self.x - other.x,
             y: self.y - other.y,
         }
+    }
+}
+
+impl Neg for Position {
+    type Output = Self;
+
+    #[inline]
+    fn neg(self) -> Self {
+        Self { x: -self.x, y: -self.y }
     }
 }
 

--- a/src/position.rs
+++ b/src/position.rs
@@ -1,0 +1,5 @@
+#[derive(Copy, Clone, Debug, Default)]
+pub struct Position {
+    pub x: f32,
+    pub y: f32,
+}

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -4,7 +4,7 @@ use imgref::ImgVec;
 use rgb::RGBA8;
 
 use crate::{
-    paint::GlyphTexture, position::Position, Color, CompositeOperationState, ErrorKind, FillRule, ImageFilter, ImageId,
+    paint::GlyphTexture, vector::Vector, Color, CompositeOperationState, ErrorKind, FillRule, ImageFilter, ImageId,
     ImageInfo, ImageSource, ImageStore,
 };
 
@@ -113,8 +113,8 @@ pub struct Vertex {
 }
 
 impl Vertex {
-    pub(crate) fn pos(position: Position, u: f32, v: f32) -> Self {
-        let Position { x, y } = position;
+    pub(crate) fn pos(position: Vector, u: f32, v: f32) -> Self {
+        let Vector { x, y } = position;
         Self { x, y, u, v }
     }
 

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -4,8 +4,8 @@ use imgref::ImgVec;
 use rgb::RGBA8;
 
 use crate::{
-    paint::GlyphTexture, Color, CompositeOperationState, ErrorKind, FillRule, ImageFilter, ImageId, ImageInfo,
-    ImageSource, ImageStore,
+    paint::GlyphTexture, position::Position, Color, CompositeOperationState, ErrorKind, FillRule, ImageFilter, ImageId,
+    ImageInfo, ImageSource, ImageStore,
 };
 
 mod opengl;
@@ -113,6 +113,11 @@ pub struct Vertex {
 }
 
 impl Vertex {
+    pub(crate) fn pos(position: Position, u: f32, v: f32) -> Self {
+        let Position { x, y } = position;
+        Self { x, y, u, v }
+    }
+
     pub fn new(x: f32, y: f32, u: f32, v: f32) -> Self {
         Self { x, y, u, v }
     }

--- a/src/renderer/params.rs
+++ b/src/renderer/params.rs
@@ -1,6 +1,6 @@
 use crate::{
     paint::{GlyphTexture, GradientColors},
-    position::Position,
+    vector::Vector,
     Color, ImageFlags, ImageStore, Paint, PaintFlavor, PixelFormat, Scissor, Transform2D,
 };
 
@@ -82,7 +82,7 @@ impl Params {
             }
             PaintFlavor::Image {
                 id,
-                center: Position { x: cx, y: cy },
+                center: Vector { x: cx, y: cy },
                 width,
                 height,
                 angle,
@@ -139,8 +139,8 @@ impl Params {
                 };
             }
             PaintFlavor::LinearGradient {
-                start: Position { x: start_x, y: start_y },
-                end: Position { x: end_x, y: end_y },
+                start: Vector { x: start_x, y: start_y },
+                end: Vector { x: end_x, y: end_y },
                 colors,
             } => {
                 let large = 1e5f32;
@@ -178,7 +178,7 @@ impl Params {
                 }
             }
             PaintFlavor::BoxGradient {
-                pos: Position { x, y },
+                pos: Vector { x, y },
                 width,
                 height,
                 radius,
@@ -205,7 +205,7 @@ impl Params {
                 }
             }
             PaintFlavor::RadialGradient {
-                center: Position { x: cx, y: cy },
+                center: Vector { x: cx, y: cy },
                 in_radius,
                 out_radius,
                 colors,

--- a/src/renderer/params.rs
+++ b/src/renderer/params.rs
@@ -1,5 +1,6 @@
 use crate::{
     paint::{GlyphTexture, GradientColors},
+    position::Position,
     Color, ImageFlags, ImageStore, Paint, PaintFlavor, PixelFormat, Scissor, Transform2D,
 };
 
@@ -81,8 +82,7 @@ impl Params {
             }
             PaintFlavor::Image {
                 id,
-                cx,
-                cy,
+                center: Position { x: cx, y: cy },
                 width,
                 height,
                 angle,
@@ -139,10 +139,8 @@ impl Params {
                 };
             }
             PaintFlavor::LinearGradient {
-                start_x,
-                start_y,
-                end_x,
-                end_y,
+                start: Position { x: start_x, y: start_y },
+                end: Position { x: end_x, y: end_y },
                 colors,
             } => {
                 let large = 1e5f32;
@@ -180,8 +178,7 @@ impl Params {
                 }
             }
             PaintFlavor::BoxGradient {
-                x,
-                y,
+                pos: Position { x, y },
                 width,
                 height,
                 radius,
@@ -208,8 +205,7 @@ impl Params {
                 }
             }
             PaintFlavor::RadialGradient {
-                cx,
-                cy,
+                center: Position { x: cx, y: cy },
                 in_radius,
                 out_radius,
                 colors,

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -1,12 +1,12 @@
 use std::ops::{Add, Mul, Neg, Sub};
 
 #[derive(Copy, Clone, Debug, Default)]
-pub(crate) struct Position {
+pub(crate) struct Vector {
     pub x: f32,
     pub y: f32,
 }
 
-impl Position {
+impl Vector {
     #[inline]
     pub fn dot(self, other: Self) -> f32 {
         self.x * other.x + self.y * other.y
@@ -48,7 +48,7 @@ impl Position {
     }
 }
 
-impl Add for Position {
+impl Add for Vector {
     type Output = Self;
 
     #[inline]
@@ -60,7 +60,7 @@ impl Add for Position {
     }
 }
 
-impl Sub for Position {
+impl Sub for Vector {
     type Output = Self;
 
     #[inline]
@@ -72,7 +72,7 @@ impl Sub for Position {
     }
 }
 
-impl Neg for Position {
+impl Neg for Vector {
     type Output = Self;
 
     #[inline]
@@ -81,7 +81,7 @@ impl Neg for Position {
     }
 }
 
-impl Mul<f32> for Position {
+impl Mul<f32> for Vector {
     type Output = Self;
 
     #[inline]


### PR DESCRIPTION
The new position type is a simple vector type, which only implements the most important operations.

This type is only used internally. The public API stays the same.

It's mostly used to simplify cases, where the same calculation is repeated for x and y.

To see, how the code is simplified, see commit b7a9bf6. You need a little extra knowledge about the position type, but it makes the code more compact and less redundant.
I also think, it's clearer what is done internally this way, for example when the normal of the vector is taken (see `orthogonal`).

If this should be merged, we might change some names:
* `Position` could also be called `Position2D`, `Vector` or `Vector2`
* `orthogonal` could also be called `normal`
* should `dot`, `angle` or `mirror` be dropped, since they are not used often?