### PR TITLE
Add support for device-pixel-ratio in examples.

### DIFF
--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -50,7 +50,7 @@ fn main() {
         use glutin::ContextBuilder;
 
         let wb = WindowBuilder::new()
-            .with_inner_size(winit::dpi::PhysicalSize::new(1000, 600))
+            .with_inner_size(winit::dpi::LogicalSize::new(1000, 600))
             .with_title("femtovg demo");
 
         //let windowed_context = ContextBuilder::new().with_gl(GlRequest::Specific(Api::OpenGlEs, (2, 0))).with_vsync(false).build_windowed(wb, &el).unwrap();
@@ -156,6 +156,13 @@ fn main() {
 
     let mut perf = PerfGraph::new();
 
+    {
+        #[cfg(not(target_arch = "wasm32"))]
+        let window = windowed_context.window();
+        let dpi_factor = window.scale_factor();
+        canvas.scale(dpi_factor as f32, dpi_factor as f32);
+    }
+
     el.run(move |event, _, control_flow| {
         #[cfg(not(target_arch = "wasm32"))]
         let window = windowed_context.window();
@@ -194,7 +201,14 @@ fn main() {
                         canvas.scale(1.0 + (y / 10.0), 1.0 + (y / 10.0));
                         canvas.translate(-pt.0, -pt.1);
                     }
-                    _ => (),
+                    winit::event::MouseScrollDelta::PixelDelta(pos) => {
+                        let y = pos.y as f32;
+                        let pt = canvas.transform().inversed().transform_point(mousex, mousey);
+                        let rate = 2000.0;
+                        canvas.translate(pt.0, pt.1);
+                        canvas.scale(1.0 + (y / rate), 1.0 + (y / rate));
+                        canvas.translate(-pt.0, -pt.1);
+                    }
                 },
                 WindowEvent::MouseInput {
                     button: MouseButton::Left,
@@ -239,8 +253,7 @@ fn main() {
                 canvas.set_size(size.width as u32, size.height as u32, dpi_factor as f32);
                 canvas.clear_rect(0, 0, size.width as u32, size.height as u32, Color::rgbf(0.3, 0.3, 0.32));
 
-                let height = size.height as f32;
-                let width = size.width as f32;
+                let winit::dpi::LogicalSize { width, height } = size.to_logical(dpi_factor);
 
                 let pt = canvas.transform().inversed().transform_point(mousex, mousey);
                 let rel_mousex = pt.0;
@@ -367,6 +380,7 @@ fn main() {
 
                 canvas.save_with(|canvas| {
                     canvas.reset();
+                    canvas.scale(dpi_factor as f32, dpi_factor as f32);
                     perf.render(canvas, 5.0, 5.0);
                 });
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1063,7 +1063,7 @@ where
 
     /// Returns information on how the provided text will be drawn with the specified paint.
     pub fn measure_text<S: AsRef<str>>(
-        &mut self,
+        &self,
         x: f32,
         y: f32,
         text: S,
@@ -1073,10 +1073,9 @@ where
 
         let text = text.as_ref();
         let scale = self.font_scale() * self.device_px_ratio;
-        let invscale = 1.0 / scale;
+        let invscale = scale.recip();
 
         self.text_context
-            .as_ref()
             .borrow_mut()
             .measure_text(x * scale, y * scale, text, paint)
             .map(|mut metrics| {
@@ -1086,10 +1085,10 @@ where
     }
 
     /// Returns font metrics for a particular Paint.
-    pub fn measure_font(&mut self, mut paint: Paint) -> Result<FontMetrics, ErrorKind> {
+    pub fn measure_font(&self, mut paint: Paint) -> Result<FontMetrics, ErrorKind> {
         self.transform_text_paint(&mut paint);
 
-        self.text_context.as_ref().borrow_mut().measure_font(paint)
+        self.text_context.borrow().measure_font(paint)
     }
 
     /// Returns the maximum index-th byte of text that will fit inside max_width.

--- a/src/text.rs
+++ b/src/text.rs
@@ -445,7 +445,7 @@ impl TextContextImpl {
         Ok(res)
     }
 
-    pub fn measure_font(&mut self, paint: Paint) -> Result<FontMetrics, ErrorKind> {
+    pub fn measure_font(&self, paint: Paint) -> Result<FontMetrics, ErrorKind> {
         if let Some(Some(id)) = paint.font_ids.get(0) {
             if let Some(font) = self.font(*id) {
                 return Ok(font.metrics(paint.font_size));


### PR DESCRIPTION
This PR also fixes a bug in `measure_font` which modified the result using the current transformation.