### PR TITLE
Update lru crate dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ rustybuzz = "0.4.0"
 unicode-bidi = "0.3.4"
 unicode-segmentation = "1.6.0"
 generational-arena = "0.2.8"
-lru = { version = "0.7.0", default-features = false }
+lru = { version = "0.7.1", default-features = false }
 image = { version = "0.23.14", optional = true, default-features = false }
 serde = { version = "1.0", optional = true, features = ["derive"] }
 ouroboros = { version = "0.13" }


### PR DESCRIPTION
The lru crate recently fixed a 'use after free bug' https://github.com/jeromefroe/lru-rs/issues/120.