### PR TITLE
Allow tinting image paints

### DIFF
--- a/src/paint.rs
+++ b/src/paint.rs
@@ -100,7 +100,7 @@ pub(crate) enum PaintFlavor {
         width: f32,
         height: f32,
         angle: f32,
-        alpha: f32,
+        tint: Color,
     },
     LinearGradient {
         start_x: f32,
@@ -261,7 +261,23 @@ impl Paint {
             width,
             height,
             angle,
-            alpha,
+            tint: Color::rgbaf(1.0, 1.0, 1.0, alpha),
+        };
+        new
+    }
+
+    /// Like `image`, but allows for adding a tint, or a color which will transform each pixel's
+    /// color via channel-wise multiplication.
+    pub fn image_tint(id: ImageId, cx: f32, cy: f32, width: f32, height: f32, angle: f32, tint: Color) -> Self {
+        let mut new = Self::default();
+        new.flavor = PaintFlavor::Image {
+            id,
+            cx,
+            cy,
+            width,
+            height,
+            angle,
+            tint,
         };
         new
     }
@@ -754,8 +770,8 @@ impl Paint {
             PaintFlavor::Color(color) => {
                 color.a *= a;
             }
-            PaintFlavor::Image { alpha, .. } => {
-                *alpha *= a;
+            PaintFlavor::Image { tint, .. } => {
+                tint.a *= a;
             }
             PaintFlavor::LinearGradient { colors, .. } => {
                 colors.mul_alpha(a);

--- a/src/renderer/params.rs
+++ b/src/renderer/params.rs
@@ -1,6 +1,6 @@
 use crate::{
     paint::{GlyphTexture, GradientColors},
-    Color, ImageFlags, ImageStore, Paint, PaintFlavor, PixelFormat, Scissor, Transform2D,
+    ImageFlags, ImageStore, Paint, PaintFlavor, PixelFormat, Scissor, Transform2D,
 };
 
 use super::ShaderType;
@@ -86,7 +86,7 @@ impl Params {
                 width,
                 height,
                 angle,
-                alpha,
+                tint,
             } => {
                 let image_info = match images.info(id) {
                     Some(info) => info,
@@ -96,7 +96,7 @@ impl Params {
                 params.extent[0] = width;
                 params.extent[1] = height;
 
-                let color = Color::rgbaf(1.0, 1.0, 1.0, alpha);
+                let color = tint;
 
                 params.inner_col = color.premultiplied().to_array();
                 params.outer_col = color.premultiplied().to_array();


### PR DESCRIPTION
The shader has logic in it for using a full tint instead of just an alpha tint, however, it was not exposed to the user. This adds an alternate image_tint constructor which allows providing a tint color instead of an alpha.