### PR TITLE
Fix a compile error on Linux

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ ouroboros = { version = "0.14" }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 glow = { version = "0.11.0", default-features = false }
-glutin = { version = "0.28.0", optional = true, default-features = false }
+glutin = { version = "0.28.0", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 glow = { version = "0.11.0", default-features = false }


### PR DESCRIPTION
Currently, if I try to use this crate on Linux, I will get a compilation error.

[The case of running the examples does not have this problem.](https://github.com/femtovg/femtovg/blob/c0b7c47606235da8ff96033c6a5ba4a7566ddbf1/Cargo.toml#L62)

```sh
error: Please select a feature to build for unix: `x11`, `wayland`
  --> /home/yakitori/.cargo/registry/src/github.com-1ecc6299db9ec823/winit-0.26.1/src/platform_impl/linux/mod.rs:10:1
   |
10 | compile_error!("Please select a feature to build for unix: `x11`, `wayland`");
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```
This PR will fix it.
