### PR TITLE
GL Performance Tweaks

### DIFF
--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -234,7 +234,7 @@ impl Rect {
     }
 
     pub fn contains_rect(&self, other: &Rect) -> bool {
-        (self.w <= 0. || self.h <= 0.)
+        (other.w <= 0. || other.h <= 0.)
             || (self.x <= other.x
                 && other.x + other.w <= self.x + self.w
                 && self.y <= other.y

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -232,6 +232,14 @@ impl Rect {
 
         Rect::new(minx, miny, 0.0f32.max(maxx - minx), 0.0f32.max(maxy - miny))
     }
+
+    pub fn contains_rect(&self, other: &Rect) -> bool {
+        (self.w <= 0. || self.h <= 0.)
+            || (self.x <= other.x
+                && other.x + other.w <= self.x + self.w
+                && self.y <= other.y
+                && other.y + other.h <= self.y + self.h)
+    }
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, PartialOrd)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1115,7 +1115,15 @@ where
         self.append_cmd(cmd);
     }
 
-    fn render_unclipped_image_blit(&mut self, post_transform_x: f32, post_transform_y: f32, width: f32, height: f32, image: ImageId, tint: Color) {
+    fn render_unclipped_image_blit(
+        &mut self,
+        post_transform_x: f32,
+        post_transform_y: f32,
+        width: f32,
+        height: f32,
+        image: ImageId,
+        tint: Color,
+    ) {
         let image_info = match self.images.info(image) {
             Some(info) => info,
             None => return,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -879,7 +879,9 @@ where
             paint.as_straight_tinted_image(),
         ) {
             (Some(path_rect), Some(scissor_rect), Some((image_id, image_width, image_height, image_tint)))
-                if scissor_rect.contains_rect(&path_rect) =>
+                if scissor_rect.contains_rect(&path_rect)
+                    && image_width == path_rect.w
+                    && image_height == path_rect.h =>
             {
                 self.render_unclipped_image_blit(
                     path_rect.x,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -878,7 +878,7 @@ where
             scissor.as_rect(canvas_width, canvas_height),
             paint.as_straight_tinted_image(),
         ) {
-            (Some(path_rect), Some(scissor_rect), Some((image_id, image_tint)))
+            (Some(path_rect), Some(scissor_rect), Some((image_id, image_width, image_height, image_tint)))
                 if scissor_rect.contains_rect(&path_rect) =>
             {
                 self.render_unclipped_image_blit(
@@ -887,6 +887,8 @@ where
                     path_rect.w,
                     path_rect.h,
                     image_id,
+                    image_width,
+                    image_height,
                     image_tint,
                 );
                 return;
@@ -1122,6 +1124,8 @@ where
         width: f32,
         height: f32,
         image: ImageId,
+        image_width: f32,
+        image_height: f32,
         tint: Color,
     ) {
         let image_info = match self.images.info(image) {
@@ -1156,8 +1160,8 @@ where
 
         let s0 = 0.;
         let mut t0 = 0.;
-        let s1 = 1.; // / width;
-        let mut t1 = 1.; // / height;
+        let s1 = image_width / image_info.width() as f32;
+        let mut t1 = image_height / image_info.height() as f32;
 
         if image_info.flags().contains(ImageFlags::FLIP_Y) {
             std::mem::swap(&mut t0, &mut t1);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1115,7 +1115,7 @@ where
         self.append_cmd(cmd);
     }
 
-    fn render_unclipped_image_blit(&mut self, x: f32, y: f32, width: f32, height: f32, image: ImageId, tint: Color) {
+    fn render_unclipped_image_blit(&mut self, post_transform_x: f32, post_transform_y: f32, width: f32, height: f32, image: ImageId, tint: Color) {
         let image_info = match self.images.info(image) {
             Some(info) => info,
             None => return,
@@ -1136,17 +1136,15 @@ where
         cmd.composite_operation = self.state().composite_operation;
         cmd.glyph_texture = paint.glyph_texture();
 
-        let transform = self.state().transform;
+        let x0 = post_transform_x;
+        let y0 = post_transform_y;
+        let x1 = post_transform_x + width;
+        let y1 = post_transform_y + height;
 
-        let x0 = x;
-        let y0 = y;
-        let x1 = x + width;
-        let y1 = y + height;
-
-        let (p0, p1) = transform.transform_point(x0, y0);
-        let (p2, p3) = transform.transform_point(x1, y0);
-        let (p4, p5) = transform.transform_point(x1, y1);
-        let (p6, p7) = transform.transform_point(x0, y1);
+        let (p0, p1) = (x0, y0);
+        let (p2, p3) = (x1, y0);
+        let (p4, p5) = (x1, y1);
+        let (p6, p7) = (x0, y1);
 
         let s0 = 0.;
         let mut t0 = 0.;

--- a/src/paint.rs
+++ b/src/paint.rs
@@ -785,19 +785,21 @@ impl Paint {
         }
     }
 
-    /// Returns the image id and associated tint if this paint is an untransformed
+    /// Returns the image id, width/height, and associated tint if this paint is an untransformed
     /// image paint without anti-aliasing at the edges in case of a fill
-    pub(crate) fn as_straight_tinted_image(&self) -> Option<(ImageId, Color)> {
+    pub(crate) fn as_straight_tinted_image(&self) -> Option<(ImageId, f32, f32, Color)> {
         match self.flavor {
             PaintFlavor::Image {
                 id: image_id,
                 cx,
                 cy,
-                width: _image_width,
-                height: _image_height,
+                width,
+                height,
                 angle,
                 tint,
-            } if cx == 0.0 && cy == 0.0 && angle == 0.0 && !self.shape_anti_alias => Some((image_id, tint)),
+            } if cx == 0.0 && cy == 0.0 && angle == 0.0 && !self.shape_anti_alias => {
+                Some((image_id, width, height, tint))
+            }
             _ => None,
         }
     }

--- a/src/paint.rs
+++ b/src/paint.rs
@@ -784,4 +784,21 @@ impl Paint {
             }
         }
     }
+
+    /// Returns the image id and associated tint if this paint is an untransformed
+    /// image paint without anti-aliasing at the edges in case of a fill
+    pub(crate) fn as_straight_tinted_image(&self) -> Option<(ImageId, Color)> {
+        match self.flavor {
+            PaintFlavor::Image {
+                id: image_id,
+                cx,
+                cy,
+                width: _image_width,
+                height: _image_height,
+                angle,
+                tint,
+            } if cx == 0.0 && cy == 0.0 && angle == 0.0 && !self.shape_anti_alias => Some((image_id, tint)),
+            _ => None,
+        }
+    }
 }

--- a/src/path/cache.rs
+++ b/src/path/cache.rs
@@ -884,6 +884,38 @@ impl PathCache {
             };
         }
     }
+
+    /// If this path is merely a rectangle, return it
+    pub(crate) fn path_fill_is_rect(&self) -> Option<crate::Rect> {
+        if self.contours.len() != 1 {
+            return None;
+        }
+
+        let vertices = &self.contours[0].fill;
+        if vertices.len() != 4 {
+            return None;
+        }
+
+        let maybe_top_left = vertices[0];
+        let maybe_bottom_left = vertices[1];
+        let maybe_bottom_right = vertices[2];
+        let maybe_top_right = vertices[3];
+
+        if maybe_top_left.x == maybe_bottom_left.x
+            && maybe_top_left.y == maybe_top_right.y
+            && maybe_bottom_right.x == maybe_top_right.x
+            && maybe_bottom_right.y == maybe_bottom_left.y
+        {
+            Some(crate::Rect::new(
+                maybe_top_left.x,
+                maybe_top_left.y,
+                maybe_top_right.x - maybe_top_left.x,
+                maybe_bottom_left.y - maybe_top_left.y,
+            ))
+        } else {
+            None
+        }
+    }
 }
 
 fn curve_divisions(radius: f32, arc: f32, tol: f32) -> u32 {

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -136,6 +136,7 @@ pub enum ShaderType {
     FillImageGradient,
     FilterImage,
     FillColor,
+    TextureCopyUnclipped,
 }
 
 impl Default for ShaderType {
@@ -153,6 +154,7 @@ impl ShaderType {
             Self::FillImageGradient => 3.0,
             Self::FilterImage => 4.0,
             Self::FillColor => 5.0,
+            Self::TextureCopyUnclipped => 6.0,
         }
     }
 }

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -135,6 +135,7 @@ pub enum ShaderType {
     Stencil,
     FillImageGradient,
     FilterImage,
+    FillColor,
 }
 
 impl Default for ShaderType {
@@ -151,6 +152,7 @@ impl ShaderType {
             Self::Stencil => 2.0,
             Self::FillImageGradient => 3.0,
             Self::FilterImage => 4.0,
+            Self::FillColor => 5.0,
         }
     }
 }

--- a/src/renderer/opengl/main-fs.glsl
+++ b/src/renderer/opengl/main-fs.glsl
@@ -101,6 +101,9 @@ void main(void) {
         color *= innerCol;
 
         result = color;
+    } else if (shaderType == 5) {
+        // Plain color fill
+        result = innerCol;
     } else if (shaderType == 2) {
         // Stencil fill
         result = vec4(1,1,1,1);

--- a/src/renderer/opengl/main-fs.glsl
+++ b/src/renderer/opengl/main-fs.glsl
@@ -56,12 +56,12 @@ float strokeMask() {
 void main(void) {
     vec4 result;
 
-    float scissor = scissorMask(fpos);
-
 #ifdef EDGE_AA
-    float strokeAlpha = strokeMask();
-
-    if (strokeAlpha < strokeThr) discard;
+    float strokeAlpha = 1.0;
+    if (shaderType != 6) {
+        strokeAlpha = strokeMask();
+        if (strokeAlpha < strokeThr) discard;
+    }
 #else
     float strokeAlpha = 1.0;
 #endif
@@ -104,6 +104,15 @@ void main(void) {
     } else if (shaderType == 5) {
         // Plain color fill
         result = innerCol;
+    } else if (shaderType == 6) {
+        // Plain texture copy, unclipped
+        vec4 color = texture2D(tex, ftcoord);
+        if (texType == 1) color = vec4(color.xyz * color.w, color.w);
+        if (texType == 2) color = vec4(color.x);
+        // Apply color tint and alpha.
+        color *= innerCol;
+        gl_FragColor = color;
+        return;        
     } else if (shaderType == 2) {
         // Stencil fill
         result = vec4(1,1,1,1);
@@ -140,6 +149,8 @@ void main(void) {
 
         result = color;
     }
+
+    float scissor = scissorMask(fpos);
 
     if (glyphTextureType > 0) {
         // Textured tris

--- a/src/renderer/params.rs
+++ b/src/renderer/params.rs
@@ -76,7 +76,7 @@ impl Params {
                 let color = color.premultiplied().to_array();
                 params.inner_col = color;
                 params.outer_col = color;
-                params.shader_type = ShaderType::FillGradient.to_f32();
+                params.shader_type = ShaderType::FillColor.to_f32();
                 inv_transform = paint.transform.inversed();
             }
             PaintFlavor::Image {


### PR DESCRIPTION
This merge requests provides two changes:

 * A faster code path for plain solid color fills
 * A detection of unclipped image blitting.

Especially the latter provides a speed up in a scene that I'm debugging that runs at 30FPS before and around 50FPS after this change.