### PR TITLE
Re-export image, imgref, and rgb

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1439,3 +1439,10 @@ impl<T: Renderer> Drop for Canvas<T> {
         self.images.clear(&mut self.renderer);
     }
 }
+
+// re-exports
+#[cfg(feature = "image-loading")]
+pub use ::image as img;
+
+pub use imgref;
+pub use rgb;


### PR DESCRIPTION
Closes #88 

If you would prefer to have the image module renamed so the image re-export can keep its common name, I will do that :)