### PR TITLE
split fragment shader

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -897,7 +897,7 @@ where
         } else {
             let stencil_params = Params {
                 stroke_thr: -1.0,
-                shader_type: ShaderType::Stencil.to_f32(),
+                shader_type: ShaderType::Stencil,
                 ..Params::default()
             };
 
@@ -1109,7 +1109,7 @@ where
         let scissor = self.state().scissor;
 
         let mut params = Params::new(&self.images, &paint, &scissor, 0., 0., -1.0);
-        params.shader_type = ShaderType::TextureCopyUnclipped.to_f32();
+        params.shader_type = ShaderType::TextureCopyUnclipped;
 
         let mut cmd = Command::new(CommandType::Triangles { params });
         cmd.composite_operation = self.state().composite_operation;

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -146,15 +146,18 @@ impl Default for ShaderType {
 }
 
 impl ShaderType {
-    pub fn to_f32(self) -> f32 {
+    pub fn to_u8(self) -> u8 {
         match self {
-            Self::FillGradient => 0.0,
-            Self::FillImage => 1.0,
-            Self::Stencil => 2.0,
-            Self::FillImageGradient => 3.0,
-            Self::FilterImage => 4.0,
-            Self::FillColor => 5.0,
-            Self::TextureCopyUnclipped => 6.0,
+            Self::FillGradient => 0,
+            Self::FillImage => 1,
+            Self::Stencil => 2,
+            Self::FillImageGradient => 3,
+            Self::FilterImage => 4,
+            Self::FillColor => 5,
+            Self::TextureCopyUnclipped => 6,
         }
+    }
+    pub fn to_f32(self) -> f32 {
+        self.to_u8() as f32
     }
 }

--- a/src/renderer/opengl.rs
+++ b/src/renderer/opengl.rs
@@ -623,7 +623,7 @@ impl OpenGl {
         } else {
             &self.main_programs_without_glyph_texture
         };
-        &programs[self.current_program as usize]
+        programs[self.current_program as usize]
             .as_ref()
             .expect("internal error: invalid shader program selected for given paint")
     }

--- a/src/renderer/opengl/main-fs.glsl
+++ b/src/renderer/opengl/main-fs.glsl
@@ -165,7 +165,7 @@ void main(void) {
 #elif SELECT_SHADER == SHADER_TYPE_Stencil
     // Stencil fill
     result = vec4(1,1,1,1);
-#elif SELECT_SHADER == 4
+#elif SELECT_SHADER == SHADER_TYPE_FilterImage
     // Filter Image
     result = renderFilteredImage();
 #else

--- a/src/renderer/opengl/main-fs.glsl
+++ b/src/renderer/opengl/main-fs.glsl
@@ -170,26 +170,26 @@ void main(void) {
 
     float scissor = scissorMask(fpos);
 
-    if (glyphTextureType > 0) {
-        // Textured tris
-        vec4 mask = texture2D(glyphtex, ftcoord);
+#ifdef ENABLE_GLYPH_TEXTURE
+    // Textured tris
+    vec4 mask = texture2D(glyphtex, ftcoord);
 
-        if (glyphTextureType == 1) {
-            mask = vec4(mask.x);
-        } else {
-            result = vec4(1, 1, 1, 1);
-            mask = vec4(mask.xyz * mask.w, mask.w);
-        }
-
-        mask *= scissor;
-        result *= mask;
+    if (glyphTextureType == 1) {
+        mask = vec4(mask.x);
     } else {
+        result = vec4(1, 1, 1, 1);
+        mask = vec4(mask.xyz * mask.w, mask.w);
+    }
+
+    mask *= scissor;
+    result *= mask;
+#else
 #if SELECT_SHADER != 2 && SELECT_SHADER != 4        
         // Not stencil fill
         // Combine alpha
         result *= strokeAlpha * scissor;
 #endif
-    }
+#endif
 
     gl_FragColor = result;
 }

--- a/src/renderer/opengl/main-fs.glsl
+++ b/src/renderer/opengl/main-fs.glsl
@@ -149,31 +149,27 @@ void main(void) {
 #if SELECT_SHADER == SHADER_TYPE_FillGradient
     // Gradient
     result = renderGradient();
-#endif
-#if SELECT_SHADER == SHADER_TYPE_FillImageGradient
+#elif SELECT_SHADER == SHADER_TYPE_FillImageGradient
     // Image-based Gradient; sample a texture using the gradient position.
     result = renderImageGradient();
-#endif
-#if SELECT_SHADER == SHADER_TYPE_FillImage
+#elif SELECT_SHADER == SHADER_TYPE_FillImage
     // Image
     result = renderImage();
-#endif
-#if SELECT_SHADER == SHADER_TYPE_FillColor
+#elif SELECT_SHADER == SHADER_TYPE_FillColor
     // Plain color fill
     result = innerCol;
-#endif
-#if SELECT_SHADER == SHADER_TYPE_TextureCopyUnclipped
+#elif SELECT_SHADER == SHADER_TYPE_TextureCopyUnclipped
     // Plain texture copy, unclipped
     gl_FragColor = renderPlainTextureCopy();
     return;
-#endif
-#if SELECT_SHADER == SHADER_TYPE_Stencil
+#elif SELECT_SHADER == SHADER_TYPE_Stencil
     // Stencil fill
     result = vec4(1,1,1,1);
-#endif
-#if SELECT_SHADER == 4
+#elif SELECT_SHADER == 4
     // Filter Image
     result = renderFilteredImage();
+#else
+#error A shader variant must be selected with the SELECT_SHADER pre-processor variable
 #endif
 
     float scissor = scissorMask(fpos);

--- a/src/renderer/opengl/main-fs.glsl
+++ b/src/renderer/opengl/main-fs.glsl
@@ -58,15 +58,15 @@ void main(void) {
 
 #ifdef EDGE_AA
     float strokeAlpha = 1.0;
-    if (shaderType != 6) {
-        strokeAlpha = strokeMask();
-        if (strokeAlpha < strokeThr) discard;
-    }
+#if SELECT_SHADER != 6
+    strokeAlpha = strokeMask();
+    if (strokeAlpha < strokeThr) discard;
+#endif
 #else
     float strokeAlpha = 1.0;
 #endif
 
-    if (shaderType == 0) {
+#if SELECT_SHADER == 0
         // Gradient
 
         // Calculate gradient color using box gradient
@@ -76,7 +76,8 @@ void main(void) {
         vec4 color = mix(innerCol,outerCol,d);
 
         result = color;
-    } else if (shaderType == 3) {
+#endif
+#if SELECT_SHADER == 3
         // Image-based Gradient; sample a texture using the gradient position.
 
         // Calculate gradient color using box gradient
@@ -86,7 +87,8 @@ void main(void) {
         vec4 color = texture2D(tex, vec2(d, 0.0));//mix(innerCol,outerCol,d);
 
         result = color;
-    } else if (shaderType == 1) {
+#endif
+#if SELECT_SHADER == 1
         // Image
 
         // Calculate color from texture
@@ -101,10 +103,12 @@ void main(void) {
         color *= innerCol;
 
         result = color;
-    } else if (shaderType == 5) {
+#endif
+#if SELECT_SHADER == 5
         // Plain color fill
         result = innerCol;
-    } else if (shaderType == 6) {
+#endif
+#if SELECT_SHADER == 6
         // Plain texture copy, unclipped
         vec4 color = texture2D(tex, ftcoord);
         if (texType == 1) color = vec4(color.xyz * color.w, color.w);
@@ -112,11 +116,13 @@ void main(void) {
         // Apply color tint and alpha.
         color *= innerCol;
         gl_FragColor = color;
-        return;        
-    } else if (shaderType == 2) {
+        return;
+#endif
+#if SELECT_SHADER == 2
         // Stencil fill
         result = vec4(1,1,1,1);
-    } else if (shaderType == 4) {
+#endif
+#if SELECT_SHADER == 4
         // Filter Image
 
         float sampleCount = ceil(1.5 * imageBlurFilterSigma);
@@ -133,10 +139,10 @@ void main(void) {
             if (i >= sampleCount) {
                 break;
             }
-            color_sum += texture2D(tex, (fpos.xy - i * imageBlurFilterDirection) / extent) * gaussian_coeff.x;         
-            color_sum += texture2D(tex, (fpos.xy + i * imageBlurFilterDirection) / extent) * gaussian_coeff.x;         
+            color_sum += texture2D(tex, (fpos.xy - i * imageBlurFilterDirection) / extent) * gaussian_coeff.x;
+            color_sum += texture2D(tex, (fpos.xy + i * imageBlurFilterDirection) / extent) * gaussian_coeff.x;
             coefficient_sum += 2.0 * gaussian_coeff.x;
-            
+
             // Compute the coefficients incrementally:
             // https://developer.nvidia.com/gpugems/gpugems3/part-vi-gpu-computing/chapter-40-incremental-computation-gaussian
             gaussian_coeff.xy *= gaussian_coeff.yz;
@@ -148,7 +154,7 @@ void main(void) {
         if (texType == 2) color = vec4(color.x);
 
         result = color;
-    }
+#endif
 
     float scissor = scissorMask(fpos);
 
@@ -165,9 +171,12 @@ void main(void) {
 
         mask *= scissor;
         result *= mask;
-    } else if (shaderType != 2 && shaderType != 4) { // Not stencil fill
+    } else {
+#if SELECT_SHADER != 2 && SELECT_SHADER != 4        
+        // Not stencil fill
         // Combine alpha
         result *= strokeAlpha * scissor;
+#endif
     }
 
     gl_FragColor = result;

--- a/src/renderer/opengl/main-fs.glsl
+++ b/src/renderer/opengl/main-fs.glsl
@@ -30,6 +30,14 @@ uniform vec2 viewSize;
 varying vec2 ftcoord;
 varying vec2 fpos;
 
+ #define SHADER_TYPE_FillGradient 0
+ #define SHADER_TYPE_FillImage 1
+ #define SHADER_TYPE_Stencil 2
+ #define SHADER_TYPE_FillImageGradient 3
+ #define SHADER_TYPE_FilterImage 4
+ #define SHADER_TYPE_FillColor 5
+ #define SHADER_TYPE_TextureCopyUnclipped 6
+
 float sdroundrect(vec2 pt, vec2 ext, float rad) {
     vec2 ext2 = ext - vec2(rad,rad);
     vec2 d = abs(pt) - ext2;
@@ -138,28 +146,28 @@ void main(void) {
     float strokeAlpha = 1.0;
 #endif
 
-#if SELECT_SHADER == 0
+#if SELECT_SHADER == SHADER_TYPE_FillGradient
     // Gradient
     result = renderGradient();
 #endif
-#if SELECT_SHADER == 3
+#if SELECT_SHADER == SHADER_TYPE_FillImageGradient
     // Image-based Gradient; sample a texture using the gradient position.
     result = renderImageGradient();
 #endif
-#if SELECT_SHADER == 1
+#if SELECT_SHADER == SHADER_TYPE_FillImage
     // Image
     result = renderImage();
 #endif
-#if SELECT_SHADER == 5
+#if SELECT_SHADER == SHADER_TYPE_FillColor
     // Plain color fill
     result = innerCol;
 #endif
-#if SELECT_SHADER == 6
+#if SELECT_SHADER == SHADER_TYPE_TextureCopyUnclipped
     // Plain texture copy, unclipped
     gl_FragColor = renderPlainTextureCopy();
     return;
 #endif
-#if SELECT_SHADER == 2
+#if SELECT_SHADER == SHADER_TYPE_Stencil
     // Stencil fill
     result = vec4(1,1,1,1);
 #endif
@@ -184,7 +192,7 @@ void main(void) {
     mask *= scissor;
     result *= mask;
 #else
-#if SELECT_SHADER != 2 && SELECT_SHADER != 4        
+#if SELECT_SHADER != SHADER_TYPE_Stencil && SELECT_SHADER != SHADER_TYPE_FilterImage
         // Not stencil fill
         // Combine alpha
         result *= strokeAlpha * scissor;

--- a/src/renderer/opengl/program.rs
+++ b/src/renderer/opengl/program.rs
@@ -143,9 +143,18 @@ impl MainProgram {
         context: &Rc<glow::Context>,
         antialias: bool,
         shader_type: ShaderType,
+        with_glyph_texture: bool,
     ) -> Result<Self, ErrorKind> {
         let shader_defs = if antialias { "#define EDGE_AA 1" } else { "" };
-        let select_shader_type = format!("#define SELECT_SHADER {}", shader_type.to_u8());
+        let select_shader_type = format!(
+            "#define SELECT_SHADER {}\n{}",
+            shader_type.to_u8(),
+            if with_glyph_texture {
+                "#define ENABLE_GLYPH_TEXTURE"
+            } else {
+                ""
+            }
+        );
         let vert_shader_src = format!("{}\n{}\n{}", GLSL_VERSION, shader_defs, include_str!("main-vs.glsl"));
         let frag_shader_src = format!(
             "{}\n{}\n{}\n{}",

--- a/src/renderer/opengl/program.rs
+++ b/src/renderer/opengl/program.rs
@@ -135,7 +135,7 @@ pub struct MainProgram {
     loc_viewsize: <glow::Context as glow::HasContext>::UniformLocation,
     loc_tex: Option<<glow::Context as glow::HasContext>::UniformLocation>,
     loc_glyphtex: Option<<glow::Context as glow::HasContext>::UniformLocation>,
-    loc_frag: <glow::Context as glow::HasContext>::UniformLocation,
+    loc_frag: Option<<glow::Context as glow::HasContext>::UniformLocation>,
 }
 
 impl MainProgram {
@@ -172,7 +172,7 @@ impl MainProgram {
         let loc_viewsize = program.uniform_location("viewSize").unwrap();
         let loc_tex = program.uniform_location("tex");
         let loc_glyphtex = program.uniform_location("glyphtex");
-        let loc_frag = program.uniform_location("frag").unwrap();
+        let loc_frag = program.uniform_location("frag");
 
         Ok(Self {
             context: context.clone(),
@@ -204,7 +204,7 @@ impl MainProgram {
 
     pub(crate) fn set_config(&self, config: &[f32]) {
         unsafe {
-            self.context.uniform_4_f32_slice(Some(&self.loc_frag), config);
+            self.context.uniform_4_f32_slice(self.loc_frag.as_ref(), config);
         }
     }
 

--- a/src/renderer/opengl/uniform_array.rs
+++ b/src/renderer/opengl/uniform_array.rs
@@ -105,7 +105,7 @@ impl From<&Params> for UniformArray {
         arr.set_stroke_thr(params.stroke_thr);
         arr.set_shader_type(params.shader_type.to_f32());
         arr.set_tex_type(params.tex_type);
-        arr.set_glyph_texture_type(params.glyph_texture_type);
+        arr.set_glyph_texture_type(params.glyph_texture_type as f32);
         arr.set_image_blur_filter_direction(params.image_blur_filter_direction);
         arr.set_image_blur_filter_sigma(params.image_blur_filter_sigma);
         arr.set_image_blur_filter_coeff(params.image_blur_filter_coeff);

--- a/src/renderer/opengl/uniform_array.rs
+++ b/src/renderer/opengl/uniform_array.rs
@@ -103,7 +103,7 @@ impl From<&Params> for UniformArray {
         arr.set_feather(params.feather);
         arr.set_stroke_mult(params.stroke_mult);
         arr.set_stroke_thr(params.stroke_thr);
-        arr.set_shader_type(params.shader_type);
+        arr.set_shader_type(params.shader_type.to_f32());
         arr.set_tex_type(params.tex_type);
         arr.set_glyph_texture_type(params.glyph_texture_type);
         arr.set_image_blur_filter_direction(params.image_blur_filter_direction);

--- a/src/renderer/params.rs
+++ b/src/renderer/params.rs
@@ -242,4 +242,8 @@ impl Params {
 
         params
     }
+
+    pub(crate) fn uses_glyph_texture(self) -> bool {
+        self.glyph_texture_type != 0
+    }
 }

--- a/src/renderer/params.rs
+++ b/src/renderer/params.rs
@@ -20,7 +20,7 @@ pub struct Params {
     pub(crate) stroke_thr: f32,
     pub(crate) tex_type: f32,
     pub(crate) shader_type: ShaderType,
-    pub(crate) glyph_texture_type: f32, // 0 -> no glyph rendering, 1 -> alpha mask, 2 -> color texture
+    pub(crate) glyph_texture_type: u8, // 0 -> no glyph rendering, 1 -> alpha mask, 2 -> color texture
     pub(crate) image_blur_filter_direction: [f32; 2],
     pub(crate) image_blur_filter_sigma: f32,
     pub(crate) image_blur_filter_coeff: [f32; 3],
@@ -64,9 +64,9 @@ impl Params {
         params.stroke_thr = stroke_thr;
 
         params.glyph_texture_type = match paint.glyph_texture() {
-            GlyphTexture::None => 0.0,
-            GlyphTexture::AlphaMask(_) => 1.0,
-            GlyphTexture::ColorTexture(_) => 2.0,
+            GlyphTexture::None => 0,
+            GlyphTexture::AlphaMask(_) => 1,
+            GlyphTexture::ColorTexture(_) => 2,
         };
 
         let inv_transform;

--- a/src/renderer/params.rs
+++ b/src/renderer/params.rs
@@ -19,7 +19,7 @@ pub struct Params {
     pub(crate) stroke_mult: f32,
     pub(crate) stroke_thr: f32,
     pub(crate) tex_type: f32,
-    pub(crate) shader_type: f32,
+    pub(crate) shader_type: ShaderType,
     pub(crate) glyph_texture_type: f32, // 0 -> no glyph rendering, 1 -> alpha mask, 2 -> color texture
     pub(crate) image_blur_filter_direction: [f32; 2],
     pub(crate) image_blur_filter_sigma: f32,
@@ -76,7 +76,7 @@ impl Params {
                 let color = color.premultiplied().to_array();
                 params.inner_col = color;
                 params.outer_col = color;
-                params.shader_type = ShaderType::FillColor.to_f32();
+                params.shader_type = ShaderType::FillColor;
                 inv_transform = paint.transform.inversed();
             }
             PaintFlavor::Image {
@@ -124,7 +124,7 @@ impl Params {
                     inv_transform = transform.inversed();
                 }
 
-                params.shader_type = ShaderType::FillImage.to_f32();
+                params.shader_type = ShaderType::FillImage;
 
                 params.tex_type = match image_info.format() {
                     PixelFormat::Rgba8 => {
@@ -172,10 +172,10 @@ impl Params {
                     GradientColors::TwoStop { start_color, end_color } => {
                         params.inner_col = start_color.premultiplied().to_array();
                         params.outer_col = end_color.premultiplied().to_array();
-                        params.shader_type = ShaderType::FillGradient.to_f32();
+                        params.shader_type = ShaderType::FillGradient;
                     }
                     GradientColors::MultiStop { .. } => {
-                        params.shader_type = ShaderType::FillImageGradient.to_f32();
+                        params.shader_type = ShaderType::FillImageGradient;
                     }
                 }
             }
@@ -200,10 +200,10 @@ impl Params {
                     GradientColors::TwoStop { start_color, end_color } => {
                         params.inner_col = start_color.premultiplied().to_array();
                         params.outer_col = end_color.premultiplied().to_array();
-                        params.shader_type = ShaderType::FillGradient.to_f32();
+                        params.shader_type = ShaderType::FillGradient;
                     }
                     GradientColors::MultiStop { .. } => {
-                        params.shader_type = ShaderType::FillImageGradient.to_f32();
+                        params.shader_type = ShaderType::FillImageGradient;
                     }
                 }
             }
@@ -229,10 +229,10 @@ impl Params {
                     GradientColors::TwoStop { start_color, end_color } => {
                         params.inner_col = start_color.premultiplied().to_array();
                         params.outer_col = end_color.premultiplied().to_array();
-                        params.shader_type = ShaderType::FillGradient.to_f32();
+                        params.shader_type = ShaderType::FillGradient;
                     }
                     GradientColors::MultiStop { .. } => {
-                        params.shader_type = ShaderType::FillImageGradient.to_f32();
+                        params.shader_type = ShaderType::FillImageGradient;
                     }
                 }
             }


### PR DESCRIPTION
I think this makes it easier to add more variants to the shader in the future and on a GC7000UL it gives a ~15FPS performance bump on a moderately big scene.

The cost is technically increased memory usage due to the increased shader variants and more state changes. I think that given the actual shaders are relatively small and that the state change is unavoidable in the long term I think that this is a net win.

There might also be a way of batching primitives with the same shader types in the future, in the unlikely event that the penalty is noticeable.