### PR TITLE
Allow for variable length gradient stops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Changed
+
+ - Changed `linear_gradient_stops` and `radial_gradient_stops` to take an `IntoIterator`
+   instead of a slice slice for the color stops.
+
 ## [0.5.0] - 2022-02-06
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ unicode-segmentation = "1.6.0"
 generational-arena = "0.2.8"
 lru = { version = "0.9.0", default-features = false }
 image = { version = "0.24.0", optional = true, default-features = false }
-serde = { version = "1.0", optional = true, features = ["derive"] }
+serde = { version = "1.0", optional = true, features = ["derive", "rc"] }
 ouroboros = { version = "0.15" }
 glow = { version = "0.12.0", default-features = false }
 

--- a/examples/gradients.rs
+++ b/examples/gradients.rs
@@ -376,7 +376,7 @@ fn draw_gradients<T: Renderer>(canvas: &mut Canvas<T>) {
             0.0,
             100.0,
             0.0,
-            &[
+            [
                 (0.0, Color::rgba(255, 0, 0, 255)),
                 (0.5, Color::rgba(0, 255, 0, 255)),
                 (1.0, Color::rgba(0, 0, 255, 255)),
@@ -393,7 +393,7 @@ fn draw_gradients<T: Renderer>(canvas: &mut Canvas<T>) {
             0.0,
             0.0,
             100.0,
-            &[
+            [
                 (0.0, Color::rgba(255, 0, 0, 255)),
                 (0.5, Color::rgba(0, 255, 0, 255)),
                 (1.0, Color::rgba(0, 0, 255, 255)),
@@ -410,7 +410,7 @@ fn draw_gradients<T: Renderer>(canvas: &mut Canvas<T>) {
             0.0,
             100.0,
             100.0,
-            &[
+            [
                 (0.0, Color::rgba(255, 0, 0, 255)),
                 (0.5, Color::rgba(0, 255, 0, 255)),
                 (1.0, Color::rgba(0, 0, 255, 255)),
@@ -428,7 +428,7 @@ fn draw_gradients<T: Renderer>(canvas: &mut Canvas<T>) {
             0.0,
             100.0,
             0.0,
-            &[
+            [
                 (0.0, Color::rgba(255, 0, 0, 128)),
                 (0.5, Color::rgba(0, 255, 0, 128)),
                 (1.0, Color::rgba(0, 0, 255, 128)),
@@ -445,7 +445,7 @@ fn draw_gradients<T: Renderer>(canvas: &mut Canvas<T>) {
             0.0,
             0.0,
             100.0,
-            &[
+            [
                 (0.0, Color::rgba(255, 0, 0, 128)),
                 (0.5, Color::rgba(0, 255, 0, 128)),
                 (1.0, Color::rgba(0, 0, 255, 128)),
@@ -462,7 +462,7 @@ fn draw_gradients<T: Renderer>(canvas: &mut Canvas<T>) {
             0.0,
             100.0,
             100.0,
-            &[
+            [
                 (0.0, Color::rgba(255, 0, 0, 128)),
                 (0.5, Color::rgba(0, 255, 0, 128)),
                 (1.0, Color::rgba(0, 0, 255, 128)),
@@ -480,7 +480,7 @@ fn draw_gradients<T: Renderer>(canvas: &mut Canvas<T>) {
             0.0,
             100.0,
             0.0,
-            &[
+            [
                 (0.0, Color::rgba(255, 0, 0, 0)),
                 (0.5, Color::rgba(0, 255, 0, 255)),
                 (1.0, Color::rgba(0, 0, 255, 128)),
@@ -497,7 +497,7 @@ fn draw_gradients<T: Renderer>(canvas: &mut Canvas<T>) {
             0.0,
             0.0,
             100.0,
-            &[
+            [
                 (0.0, Color::rgba(255, 0, 0, 0)),
                 (0.5, Color::rgba(0, 255, 0, 255)),
                 (1.0, Color::rgba(0, 0, 255, 128)),
@@ -514,7 +514,7 @@ fn draw_gradients<T: Renderer>(canvas: &mut Canvas<T>) {
             0.0,
             100.0,
             100.0,
-            &[
+            [
                 (0.0, Color::rgba(255, 0, 0, 0)),
                 (0.5, Color::rgba(0, 255, 0, 255)),
                 (1.0, Color::rgba(0, 0, 255, 128)),
@@ -533,7 +533,7 @@ fn draw_gradients<T: Renderer>(canvas: &mut Canvas<T>) {
             50.0,
             0.0,
             50.0,
-            &[
+            [
                 (0.0, Color::rgba(255, 0, 0, 255)),
                 (0.5, Color::rgba(0, 255, 0, 255)),
                 (1.0, Color::rgba(0, 0, 255, 255)),
@@ -550,7 +550,7 @@ fn draw_gradients<T: Renderer>(canvas: &mut Canvas<T>) {
             0.0,
             0.0,
             100.0,
-            &[
+            [
                 (0.0, Color::rgba(255, 0, 0, 255)),
                 (0.5, Color::rgba(0, 255, 0, 255)),
                 (1.0, Color::rgba(0, 0, 255, 255)),
@@ -567,7 +567,7 @@ fn draw_gradients<T: Renderer>(canvas: &mut Canvas<T>) {
             50.0,
             25.0,
             75.0,
-            &[
+            [
                 (0.0, Color::rgba(255, 0, 0, 255)),
                 (0.5, Color::rgba(0, 255, 0, 255)),
                 (1.0, Color::rgba(0, 0, 255, 255)),
@@ -585,7 +585,7 @@ fn draw_gradients<T: Renderer>(canvas: &mut Canvas<T>) {
             50.0,
             0.0,
             50.0,
-            &[
+            [
                 (0.0, Color::rgba(255, 0, 0, 128)),
                 (0.5, Color::rgba(0, 255, 0, 128)),
                 (1.0, Color::rgba(0, 0, 255, 128)),
@@ -602,7 +602,7 @@ fn draw_gradients<T: Renderer>(canvas: &mut Canvas<T>) {
             0.0,
             0.0,
             100.0,
-            &[
+            [
                 (0.0, Color::rgba(255, 0, 0, 128)),
                 (0.5, Color::rgba(0, 255, 0, 128)),
                 (1.0, Color::rgba(0, 0, 255, 128)),
@@ -619,7 +619,7 @@ fn draw_gradients<T: Renderer>(canvas: &mut Canvas<T>) {
             50.0,
             25.0,
             75.0,
-            &[
+            [
                 (0.0, Color::rgba(255, 0, 0, 128)),
                 (0.5, Color::rgba(0, 255, 0, 128)),
                 (1.0, Color::rgba(0, 0, 255, 128)),
@@ -637,7 +637,7 @@ fn draw_gradients<T: Renderer>(canvas: &mut Canvas<T>) {
             50.0,
             0.0,
             50.0,
-            &[
+            [
                 (0.0, Color::rgba(255, 0, 0, 0)),
                 (0.5, Color::rgba(0, 255, 0, 255)),
                 (1.0, Color::rgba(0, 0, 255, 128)),
@@ -654,7 +654,7 @@ fn draw_gradients<T: Renderer>(canvas: &mut Canvas<T>) {
             0.0,
             0.0,
             100.0,
-            &[
+            [
                 (0.0, Color::rgba(255, 0, 0, 0)),
                 (0.5, Color::rgba(0, 255, 0, 255)),
                 (1.0, Color::rgba(0, 0, 255, 128)),
@@ -671,7 +671,7 @@ fn draw_gradients<T: Renderer>(canvas: &mut Canvas<T>) {
             50.0,
             25.0,
             75.0,
-            &[
+            [
                 (0.0, Color::rgba(255, 0, 0, 0)),
                 (0.5, Color::rgba(0, 255, 0, 255)),
                 (1.0, Color::rgba(0, 0, 255, 128)),
@@ -691,7 +691,7 @@ fn draw_gradients<T: Renderer>(canvas: &mut Canvas<T>) {
             0.0,
             100.0,
             0.0,
-            &[(0.5, Color::rgba(255, 0, 0, 255)), (1.0, Color::rgba(0, 0, 255, 255))],
+            [(0.5, Color::rgba(255, 0, 0, 255)), (1.0, Color::rgba(0, 0, 255, 255))],
         ),
     );
     x += 110.0;
@@ -704,7 +704,7 @@ fn draw_gradients<T: Renderer>(canvas: &mut Canvas<T>) {
             0.0,
             100.0,
             0.0,
-            &[(0.4, Color::rgba(255, 0, 0, 255)), (0.6, Color::rgba(0, 0, 255, 255))],
+            [(0.4, Color::rgba(255, 0, 0, 255)), (0.6, Color::rgba(0, 0, 255, 255))],
         ),
     );
     x += 110.0;
@@ -717,7 +717,7 @@ fn draw_gradients<T: Renderer>(canvas: &mut Canvas<T>) {
             0.0,
             100.0,
             0.0,
-            &[(0.0, Color::rgba(255, 0, 0, 255)), (0.5, Color::rgba(0, 0, 255, 255))],
+            [(0.0, Color::rgba(255, 0, 0, 255)), (0.5, Color::rgba(0, 0, 255, 255))],
         ),
     );
     x += 110.0;
@@ -730,7 +730,7 @@ fn draw_gradients<T: Renderer>(canvas: &mut Canvas<T>) {
             0.0,
             100.0,
             0.0,
-            &[(0.5, Color::rgba(255, 0, 0, 255)), (0.5, Color::rgba(0, 0, 255, 255))],
+            [(0.5, Color::rgba(255, 0, 0, 255)), (0.5, Color::rgba(0, 0, 255, 255))],
         ),
     );
     x += 110.0;
@@ -738,14 +738,14 @@ fn draw_gradients<T: Renderer>(canvas: &mut Canvas<T>) {
         x,
         y,
         "ms one stop",
-        Paint::linear_gradient_stops(0.0, 0.0, 100.0, 0.0, &[(0.5, Color::rgba(255, 0, 0, 255))]),
+        Paint::linear_gradient_stops(0.0, 0.0, 100.0, 0.0, [(0.5, Color::rgba(255, 0, 0, 255))]),
     );
     x += 110.0;
     r(
         x,
         y,
         "ms zero stops",
-        Paint::linear_gradient_stops(0.0, 0.0, 100.0, 0.0, &[]),
+        Paint::linear_gradient_stops(0.0, 0.0, 100.0, 0.0, []),
     );
     x += 110.0;
     r(
@@ -757,7 +757,7 @@ fn draw_gradients<T: Renderer>(canvas: &mut Canvas<T>) {
             0.0,
             100.0,
             0.0,
-            &[(0.5, Color::rgba(255, 0, 0, 255)), (0.0, Color::rgba(0, 0, 255, 255))],
+            [(0.5, Color::rgba(255, 0, 0, 255)), (0.0, Color::rgba(0, 0, 255, 255))],
         ),
     );
     x += 110.0;
@@ -770,7 +770,7 @@ fn draw_gradients<T: Renderer>(canvas: &mut Canvas<T>) {
             0.0,
             100.0,
             0.0,
-            &[(0.5, Color::rgba(255, 0, 0, 255)), (0.3, Color::rgba(0, 0, 255, 255))],
+            [(0.5, Color::rgba(255, 0, 0, 255)), (0.3, Color::rgba(0, 0, 255, 255))],
         ),
     );
     x += 110.0;
@@ -783,7 +783,7 @@ fn draw_gradients<T: Renderer>(canvas: &mut Canvas<T>) {
             0.0,
             100.0,
             0.0,
-            &[
+            [
                 (0.5, Color::rgba(255, 0, 0, 255)),
                 (0.6, Color::rgba(0, 255, 0, 255)),
                 (0.3, Color::rgba(0, 0, 255, 255)),

--- a/src/gradient_store.rs
+++ b/src/gradient_store.rs
@@ -1,8 +1,9 @@
 use std::collections::BTreeMap;
 
 use crate::{
-    image::ImageStore, paint::MultiStopGradient, Color, ErrorKind, ImageFlags, ImageId, ImageInfo, ImageSource,
-    Renderer,
+    image::ImageStore,
+    paint::{GradientStop, MultiStopGradient},
+    Color, ErrorKind, ImageFlags, ImageId, ImageInfo, ImageSource, Renderer,
 };
 
 /// GradientStore holds image ids for multi-stop gradients. The actual image/textures
@@ -125,12 +126,7 @@ fn linear_gradient_stops(gradient: &MultiStopGradient) -> imgref::Img<Vec<rgb::R
     // gradient. If the stop position is > 1.0 then we have exhausted the stops
     // and should break. As a special case, if the second stop is > 1.0 then we
     // fill the current color to the end of the gradient.
-    for stop in gradient.pairs() {
-        let s0 = stop[0].0;
-        let s1 = stop[1].0;
-        let color0 = stop[0].1;
-        let color1 = stop[1].1;
-
+    for [GradientStop(s0, color0), GradientStop(s1, color1)] in gradient.pairs() {
         // Catch the case where the last stop doesn't go all the way to 1.0 and
         // pad it.
         if s0 < 1.0 && s1 > 1.0 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -926,7 +926,7 @@ where
         } else if let Some(paint::GradientColors::MultiStop { stops }) = paint_flavor.gradient_colors() {
             cmd.image = self
                 .gradients
-                .lookup_or_add(*stops, &mut self.images, &mut self.renderer)
+                .lookup_or_add(stops, &mut self.images, &mut self.renderer)
                 .ok();
         }
 
@@ -1093,7 +1093,7 @@ where
         } else if let Some(paint::GradientColors::MultiStop { stops }) = paint_flavor.gradient_colors() {
             cmd.image = self
                 .gradients
-                .lookup_or_add(*stops, &mut self.images, &mut self.renderer)
+                .lookup_or_add(stops, &mut self.images, &mut self.renderer)
                 .ok();
         }
 
@@ -1430,7 +1430,7 @@ where
         } else if let Some(paint::GradientColors::MultiStop { stops }) = paint_flavor.gradient_colors() {
             cmd.image = self
                 .gradients
-                .lookup_or_add(*stops, &mut self.images, &mut self.renderer)
+                .lookup_or_add(stops, &mut self.images, &mut self.renderer)
                 .ok();
         }
 

--- a/src/renderer/params.rs
+++ b/src/renderer/params.rs
@@ -74,7 +74,7 @@ impl Params {
 
         let inv_transform;
 
-        match paint_flavor {
+        match &paint_flavor {
             PaintFlavor::Color(color) => {
                 let color = color.premultiplied().to_array();
                 params.inner_col = color;
@@ -90,13 +90,13 @@ impl Params {
                 angle,
                 tint,
             } => {
-                let image_info = match images.info(id) {
+                let image_info = match images.info(*id) {
                     Some(info) => info,
                     None => return params,
                 };
 
-                params.extent[0] = width;
-                params.extent[1] = height;
+                params.extent[0] = *width;
+                params.extent[1] = *height;
 
                 let color = tint;
 
@@ -104,8 +104,8 @@ impl Params {
                 params.outer_col = color.premultiplied().to_array();
 
                 let mut transform = Transform2D::identity();
-                transform.rotate(angle);
-                transform.translate(cx, cy);
+                transform.rotate(*angle);
+                transform.translate(*cx, *cy);
                 transform.multiply(global_transform);
 
                 if image_info.flags().contains(ImageFlags::FLIP_Y) {
@@ -193,8 +193,8 @@ impl Params {
 
                 params.extent[0] = width * 0.5;
                 params.extent[1] = height * 0.5;
-                params.radius = radius;
-                params.feather = feather;
+                params.radius = *radius;
+                params.feather = *feather;
                 match colors {
                     GradientColors::TwoStop { start_color, end_color } => {
                         params.inner_col = start_color.premultiplied().to_array();
@@ -215,7 +215,7 @@ impl Params {
                 let r = (in_radius + out_radius) * 0.5;
                 let f = out_radius - in_radius;
 
-                let mut transform = Transform2D::new_translation(cx, cy);
+                let mut transform = Transform2D::new_translation(*cx, *cy);
                 transform.multiply(global_transform);
                 inv_transform = transform.inversed();
 


### PR DESCRIPTION
`femtovg::Paint` is rather big, so silently copying it is not great API. By making it explicit it's easier to see on the user side when copies are made and this allows doing another change: The multi-stop gradients were previously hardcoded as array and they can (without Paint being Copy) be stored in an Rc-ed slice.

This is a breaking change, so if merged it'll also mean a semver major version bump.