### PR TITLE
Minimal rework of paint [WIP]

### DIFF
--- a/examples/breakout.rs
+++ b/examples/breakout.rs
@@ -509,7 +509,7 @@ impl Game {
             Color::rgb(90, 90, 90),
             Color::rgb(30, 30, 30),
         );
-        canvas.stroke_path(&mut path, paint);
+        canvas.stroke_path(&mut path, &paint);
 
         match self.state {
             State::TitleScreen => self.draw_title_screen(canvas),
@@ -525,17 +525,17 @@ impl Game {
         // curtain
         let mut path = Path::new();
         path.rect(0.0, 0.0, canvas.width(), canvas.height());
-        canvas.fill_path(&mut path, Paint::color(Color::rgba(0, 0, 0, 180)));
+        canvas.fill_path(&mut path, &Paint::color(Color::rgba(0, 0, 0, 180)));
 
         // rust logo
         let logo_pos = Point::new((canvas.width() / 2.0) - 50.0, (canvas.height() / 2.0) - 180.0);
         let logo_paint = Paint::image(self.logo_image_id, logo_pos.x, logo_pos.y, 100.0, 100.0, 0.0, 1.0);
         let mut path = Path::new();
         path.circle(logo_pos.x + 50.0, logo_pos.y + 50.0, 60.0);
-        //canvas.fill_path(&mut path, Paint::color(Color::rgba(200, 200, 200, 200)));
+        //canvas.fill_path(&mut path, &Paint::color(Color::rgba(200, 200, 200, 200)));
         let mut path = Path::new();
         path.rect(logo_pos.x, logo_pos.y, 100.0, 100.0);
-        canvas.fill_path(&mut path, logo_paint);
+        canvas.fill_path(&mut path, &logo_paint);
 
         // title
         let mut paint = Paint::color(Color::rgb(240, 240, 240));
@@ -544,10 +544,10 @@ impl Game {
         paint.set_font_size(80.0);
 
         paint.set_line_width(4.0);
-        let _ = canvas.stroke_text(canvas.width() / 2.0, canvas.height() / 2.0, "rsBREAKOUT", paint);
+        let _ = canvas.stroke_text(canvas.width() / 2.0, canvas.height() / 2.0, "rsBREAKOUT", &paint);
 
         paint.set_color(Color::rgb(143, 80, 49));
-        let _ = canvas.fill_text(canvas.width() / 2.0, canvas.height() / 2.0, "rsBREAKOUT", paint);
+        let _ = canvas.fill_text(canvas.width() / 2.0, canvas.height() / 2.0, "rsBREAKOUT", &paint);
 
         // Info
         let mut paint = Paint::color(Color::rgb(240, 240, 240));
@@ -555,7 +555,7 @@ impl Game {
         paint.set_font(&[self.fonts.regular]);
         paint.set_font_size(16.0);
         let text = "Click anywhere to START.";
-        let _ = canvas.fill_text(canvas.width() / 2.0, (canvas.height() / 2.0) + 40.0, text, paint);
+        let _ = canvas.fill_text(canvas.width() / 2.0, (canvas.height() / 2.0) + 40.0, text, &paint);
     }
 
     fn draw_game(&self, canvas: &mut Canvas) {
@@ -592,8 +592,8 @@ impl Game {
             self.paddle_rect.size.height / 2.0,
             0.0,
         );
-        canvas.fill_path(&mut path, Paint::color(Color::rgb(119, 123, 126)));
-        canvas.stroke_path(&mut path, highlight);
+        canvas.fill_path(&mut path, &Paint::color(Color::rgb(119, 123, 126)));
+        canvas.stroke_path(&mut path, &highlight);
 
         let mut path = Path::new();
         path.rect(
@@ -602,8 +602,8 @@ impl Game {
             self.paddle_rect.size.width - (side_size * 2.0) - 6.0,
             self.paddle_rect.size.height,
         );
-        canvas.fill_path(&mut path, Paint::color(Color::rgb(119, 123, 126)));
-        canvas.stroke_path(&mut path, highlight);
+        canvas.fill_path(&mut path, &Paint::color(Color::rgb(119, 123, 126)));
+        canvas.stroke_path(&mut path, &highlight);
 
         let mut path = Path::new();
         path.rounded_rect_varying(
@@ -617,13 +617,13 @@ impl Game {
             25.0,
         );
 
-        canvas.fill_path(&mut path, highlight);
+        canvas.fill_path(&mut path, &highlight);
 
         // Ball
         for ball in &self.balls {
             let mut path = Path::new();
             path.circle(ball.position.x, ball.position.y, ball.radius);
-            canvas.fill_path(&mut path, Paint::color(Color::rgb(183, 65, 14)));
+            canvas.fill_path(&mut path, &Paint::color(Color::rgb(183, 65, 14)));
 
             let bg = Paint::linear_gradient(
                 ball.position.x,
@@ -636,7 +636,7 @@ impl Game {
 
             let mut path = Path::new();
             path.circle(ball.position.x, ball.position.y - ball.radius / 2.0, ball.radius / 2.0);
-            canvas.fill_path(&mut path, bg);
+            canvas.fill_path(&mut path, &bg);
         }
 
         // powerups
@@ -651,13 +651,13 @@ impl Game {
         paint.set_text_align(Align::Right);
         paint.set_font(&[self.fonts.bold]);
         paint.set_font_size(22.0);
-        let _ = canvas.fill_text(canvas.width() - 20.0, 25.0, &format!("Lives: {}", self.lives), paint);
+        let _ = canvas.fill_text(canvas.width() - 20.0, 25.0, &format!("Lives: {}", self.lives), &paint);
 
         // score
         let mut paint = Paint::color(Color::rgb(240, 240, 240));
         paint.set_font(&[self.fonts.bold]);
         paint.set_font_size(22.0);
-        let _ = canvas.fill_text(20.0, 25.0, &format!("Score: {}", self.score), paint);
+        let _ = canvas.fill_text(20.0, 25.0, &format!("Score: {}", self.score), &paint);
     }
 
     fn draw_round_info(&self, canvas: &mut Canvas) {
@@ -699,7 +699,7 @@ impl Game {
         // curtain
         let mut path = Path::new();
         path.rect(0.0, 0.0, canvas.width(), canvas.height());
-        canvas.fill_path(&mut path, Paint::color(Color::rgba(0, 0, 0, 32)));
+        canvas.fill_path(&mut path, &Paint::color(Color::rgba(0, 0, 0, 32)));
 
         // title
         let mut paint = Paint::color(Color::rgb(240, 240, 240));
@@ -710,10 +710,10 @@ impl Game {
         let offset = 30.0;
 
         paint.set_line_width(4.0);
-        let _ = canvas.stroke_text(canvas.width() / 2.0, (canvas.height() / 2.0) + offset, heading, paint);
+        let _ = canvas.stroke_text(canvas.width() / 2.0, (canvas.height() / 2.0) + offset, heading, &paint);
 
         paint.set_color(Color::rgb(143, 80, 49));
-        let _ = canvas.fill_text(canvas.width() / 2.0, (canvas.height() / 2.0) + offset, heading, paint);
+        let _ = canvas.fill_text(canvas.width() / 2.0, (canvas.height() / 2.0) + offset, heading, &paint);
 
         // Info
         let mut paint = Paint::color(Color::rgb(240, 240, 240));
@@ -724,7 +724,7 @@ impl Game {
             canvas.width() / 2.0,
             (canvas.height() / 2.0) + offset * 2.0,
             subtext,
-            paint,
+            &paint,
         );
     }
 }
@@ -769,7 +769,7 @@ impl Powerup {
             5.0,
         );
 
-        canvas.stroke_path(&mut path, Paint::color(Color::rgb(240, 240, 240)));
+        canvas.stroke_path(&mut path, &Paint::color(Color::rgb(240, 240, 240)));
 
         let mut text_paint = Paint::color(Color::rgb(240, 240, 240));
         text_paint.set_text_align(Align::Center);
@@ -780,7 +780,7 @@ impl Powerup {
             self.rect.center().x,
             self.rect.center().y,
             &format!("{:?}", self.ty),
-            text_paint,
+            &text_paint,
         );
     }
 }
@@ -857,8 +857,8 @@ impl Brick {
             },
         });
 
-        canvas.fill_path(&mut path, paint);
-        canvas.stroke_path(&mut path, Paint::color(Color::rgb(240, 240, 240)));
+        canvas.fill_path(&mut path, &paint);
+        canvas.stroke_path(&mut path, &Paint::color(Color::rgb(240, 240, 240)));
 
         let mut path = Path::new();
         path.rounded_rect_varying(
@@ -871,7 +871,7 @@ impl Brick {
             15.0,
             15.0,
         );
-        canvas.fill_path(&mut path, Paint::color(Color::rgba(255, 255, 255, 50)));
+        canvas.fill_path(&mut path, &Paint::color(Color::rgba(255, 255, 255, 50)));
     }
 }
 

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -326,8 +326,8 @@ fn main() {
 
                     let mut path = Path::new();
                     path.rect(x, y, 512.0, 512.0);
-                    canvas.fill_path(&mut path, paint);
-                    canvas.stroke_path(&mut path, Paint::color(Color::hex("454545")));
+                    canvas.fill_path(&mut path, &paint);
+                    canvas.stroke_path(&mut path, &Paint::color(Color::hex("454545")));
                 }
 
                 canvas.save_with(|canvas| {
@@ -371,10 +371,10 @@ fn draw_paragraph<T: Renderer>(
     let mut px;
     let mut caret_x;
 
-    let lines = canvas.break_text_vec(width, text, paint).expect("Cannot break text");
+    let lines = canvas.break_text_vec(width, text, &paint).expect("Cannot break text");
 
     for (line_num, line_range) in lines.into_iter().enumerate() {
-        if let Ok(res) = canvas.fill_text(x, y, &text[line_range], paint) {
+        if let Ok(res) = canvas.fill_text(x, y, &text[line_range], &paint) {
             let hit = mx > x && mx < (x + width) && my >= y && my < (y + res.height());
 
             if hit {
@@ -395,7 +395,7 @@ fn draw_paragraph<T: Renderer>(
 
                 let mut path = Path::new();
                 path.rect(caret_x, y, 1.0, res.height());
-                canvas.fill_path(&mut path, Paint::color(Color::rgba(255, 192, 0, 255)));
+                canvas.fill_path(&mut path, &Paint::color(Color::rgba(255, 192, 0, 255)));
 
                 gutter = line_num + 1;
 
@@ -415,7 +415,7 @@ fn draw_paragraph<T: Renderer>(
 
         let text = format!("{}", gutter);
 
-        if let Ok(res) = canvas.measure_text(x - 10.0, gutter_y, &text, paint) {
+        if let Ok(res) = canvas.measure_text(x - 10.0, gutter_y, &text, &paint) {
             let mut path = Path::new();
             path.rounded_rect(
                 res.x - 4.0,
@@ -424,10 +424,10 @@ fn draw_paragraph<T: Renderer>(
                 res.height() + 4.0,
                 (res.height() + 4.0) / 2.0 - 1.0,
             );
-            canvas.fill_path(&mut path, paint);
+            canvas.fill_path(&mut path, &paint);
 
             paint.set_color(Color::rgba(32, 32, 32, 255));
-            let _ = canvas.fill_text(x - 10.0, gutter_y, &text, paint);
+            let _ = canvas.fill_text(x - 10.0, gutter_y, &text, &paint);
         }
     }
 
@@ -455,7 +455,7 @@ fn draw_eyes<T: Renderer>(canvas: &mut Canvas<T>, x: f32, y: f32, w: f32, h: f32
     let mut path = Path::new();
     path.ellipse(lx + 3.0, ly + 16.0, ex, ey);
     path.ellipse(rx + 3.0, ry + 16.0, ex, ey);
-    canvas.fill_path(&mut path, bg);
+    canvas.fill_path(&mut path, &bg);
 
     let bg = Paint::linear_gradient(
         x,
@@ -468,7 +468,7 @@ fn draw_eyes<T: Renderer>(canvas: &mut Canvas<T>, x: f32, y: f32, w: f32, h: f32
     let mut path = Path::new();
     path.ellipse(lx, ly, ex, ey);
     path.ellipse(rx, ry, ex, ey);
-    canvas.fill_path(&mut path, bg);
+    canvas.fill_path(&mut path, &bg);
 
     let mut dx = (mx - rx) / (ex * 10.0);
     let mut dy = (my - ry) / (ey * 10.0);
@@ -482,7 +482,7 @@ fn draw_eyes<T: Renderer>(canvas: &mut Canvas<T>, x: f32, y: f32, w: f32, h: f32
     dy *= ey * 0.5;
     let mut path = Path::new();
     path.ellipse(lx + dx, ly + dy + ey * 0.25 * (1.0 - blink), br, br * blink);
-    canvas.fill_path(&mut path, Paint::color(Color::rgba(32, 32, 32, 255)));
+    canvas.fill_path(&mut path, &Paint::color(Color::rgba(32, 32, 32, 255)));
 
     let mut dx = (mx - rx) / (ex * 10.0);
     let mut dy = (my - ry) / (ey * 10.0);
@@ -496,7 +496,7 @@ fn draw_eyes<T: Renderer>(canvas: &mut Canvas<T>, x: f32, y: f32, w: f32, h: f32
     dy *= ey * 0.5;
     let mut path = Path::new();
     path.ellipse(rx + dx, ry + dy + ey * 0.25 * (1.0 - blink), br, br * blink);
-    canvas.fill_path(&mut path, Paint::color(Color::rgba(32, 32, 32, 255)));
+    canvas.fill_path(&mut path, &Paint::color(Color::rgba(32, 32, 32, 255)));
 
     let gloss = Paint::radial_gradient(
         lx - ex * 0.25,
@@ -508,7 +508,7 @@ fn draw_eyes<T: Renderer>(canvas: &mut Canvas<T>, x: f32, y: f32, w: f32, h: f32
     );
     let mut path = Path::new();
     path.ellipse(lx, ly, ex, ey);
-    canvas.fill_path(&mut path, gloss);
+    canvas.fill_path(&mut path, &gloss);
 
     let gloss = Paint::radial_gradient(
         rx - ex * 0.25,
@@ -520,7 +520,7 @@ fn draw_eyes<T: Renderer>(canvas: &mut Canvas<T>, x: f32, y: f32, w: f32, h: f32
     );
     let mut path = Path::new();
     path.ellipse(rx, ry, ex, ey);
-    canvas.fill_path(&mut path, gloss);
+    canvas.fill_path(&mut path, &gloss);
 }
 
 fn draw_graph<T: Renderer>(canvas: &mut Canvas<T>, x: f32, y: f32, w: f32, h: f32, t: f32) {
@@ -561,7 +561,7 @@ fn draw_graph<T: Renderer>(canvas: &mut Canvas<T>, x: f32, y: f32, w: f32, h: f3
 
     path.line_to(x + w, y + h);
     path.line_to(x, y + h);
-    canvas.fill_path(&mut path, bg);
+    canvas.fill_path(&mut path, &bg);
 
     // Graph line
     let mut path = Path::new();
@@ -573,7 +573,7 @@ fn draw_graph<T: Renderer>(canvas: &mut Canvas<T>, x: f32, y: f32, w: f32, h: f3
 
     let mut line = Paint::color(Color::rgba(0, 160, 192, 255));
     line.set_line_width(3.0);
-    canvas.stroke_path(&mut path, line);
+    canvas.stroke_path(&mut path, &line);
 
     // Graph sample pos
     for i in 0..6 {
@@ -587,20 +587,20 @@ fn draw_graph<T: Renderer>(canvas: &mut Canvas<T>, x: f32, y: f32, w: f32, h: f3
         );
         let mut path = Path::new();
         path.rect(sx[i] - 10.0, sy[i] - 10.0 + 2.0, 20.0, 20.0);
-        canvas.fill_path(&mut path, bg);
+        canvas.fill_path(&mut path, &bg);
     }
 
     let mut path = Path::new();
     for i in 0..6 {
         path.circle(sx[i], sy[i], 4.0);
     }
-    canvas.fill_path(&mut path, Paint::color(Color::rgba(0, 160, 192, 255)));
+    canvas.fill_path(&mut path, &Paint::color(Color::rgba(0, 160, 192, 255)));
 
     let mut path = Path::new();
     for i in 0..6 {
         path.circle(sx[i], sy[i], 2.0);
     }
-    canvas.fill_path(&mut path, Paint::color(Color::rgba(220, 220, 220, 255)));
+    canvas.fill_path(&mut path, &Paint::color(Color::rgba(220, 220, 220, 255)));
 }
 
 fn draw_window<T: Renderer>(canvas: &mut Canvas<T>, fonts: &Fonts, title: &str, x: f32, y: f32, w: f32, h: f32) {
@@ -611,7 +611,7 @@ fn draw_window<T: Renderer>(canvas: &mut Canvas<T>, fonts: &Fonts, title: &str, 
     // Window
     let mut path = Path::new();
     path.rounded_rect(x, y, w, h, corner_radius);
-    canvas.fill_path(&mut path, Paint::color(Color::rgba(28, 30, 34, 192)));
+    canvas.fill_path(&mut path, &Paint::color(Color::rgba(28, 30, 34, 192)));
 
     // Drop shadow
     let shadow_paint = Paint::box_gradient(
@@ -628,7 +628,7 @@ fn draw_window<T: Renderer>(canvas: &mut Canvas<T>, fonts: &Fonts, title: &str, 
     path.rect(x - 10.0, y - 10.0, w + 20.0, h + 30.0);
     path.rounded_rect(x, y, w, h, corner_radius);
     path.solidity(Solidity::Hole);
-    canvas.fill_path(&mut path, shadow_paint);
+    canvas.fill_path(&mut path, &shadow_paint);
 
     // Header
     let header_paint = Paint::linear_gradient(
@@ -641,12 +641,12 @@ fn draw_window<T: Renderer>(canvas: &mut Canvas<T>, fonts: &Fonts, title: &str, 
     );
     let mut path = Path::new();
     path.rounded_rect(x + 1.0, y + 1.0, w - 2.0, 30.0, corner_radius - 1.0);
-    canvas.fill_path(&mut path, header_paint);
+    canvas.fill_path(&mut path, &header_paint);
 
     let mut path = Path::new();
     path.move_to(x + 0.5, y + 0.5 + 30.0);
     path.line_to(x + 0.5 + w - 1.0, y + 0.5 + 30.0);
-    canvas.stroke_path(&mut path, Paint::color(Color::rgba(0, 0, 0, 32)));
+    canvas.stroke_path(&mut path, &Paint::color(Color::rgba(0, 0, 0, 32)));
 
     let mut text_paint = Paint::color(Color::rgba(0, 0, 0, 32));
     text_paint.set_font_size(16.0);
@@ -654,7 +654,7 @@ fn draw_window<T: Renderer>(canvas: &mut Canvas<T>, fonts: &Fonts, title: &str, 
     text_paint.set_text_align(Align::Center);
     text_paint.set_color(Color::rgba(220, 220, 220, 160));
 
-    let _ = canvas.fill_text(x + (w / 2.0), y + 19.0, title, text_paint);
+    let _ = canvas.fill_text(x + (w / 2.0), y + 19.0, title, &text_paint);
 
     canvas.restore();
 }
@@ -693,7 +693,7 @@ fn draw_colorwheel<T: Renderer>(canvas: &mut Canvas<T>, x: f32, y: f32, w: f32, 
             Color::hsla(a1 / (PI * 2.0), 1.0, 0.55, 1.0),
         );
 
-        canvas.fill_path(&mut path, paint);
+        canvas.fill_path(&mut path, &paint);
     }
 
     let mut path = Path::new();
@@ -701,7 +701,7 @@ fn draw_colorwheel<T: Renderer>(canvas: &mut Canvas<T>, x: f32, y: f32, w: f32, 
     path.circle(cx, cy, r1 + 0.5);
     let mut paint = Paint::color(Color::rgba(0, 0, 0, 64));
     paint.set_line_width(1.0);
-    canvas.stroke_path(&mut path, paint);
+    canvas.stroke_path(&mut path, &paint);
 
     // Selector
     canvas.save();
@@ -713,7 +713,7 @@ fn draw_colorwheel<T: Renderer>(canvas: &mut Canvas<T>, x: f32, y: f32, w: f32, 
     path.rect(r0 - 1.0, -3.0, r1 - r0 + 2.0, 6.0);
     paint = Paint::color(Color::rgba(255, 255, 255, 192));
     paint.set_line_width(2.0);
-    canvas.stroke_path(&mut path, paint);
+    canvas.stroke_path(&mut path, &paint);
 
     paint = Paint::box_gradient(
         r0 - 3.0,
@@ -729,7 +729,7 @@ fn draw_colorwheel<T: Renderer>(canvas: &mut Canvas<T>, x: f32, y: f32, w: f32, 
     path.rect(r0 - 2.0 - 10.0, -4.0 - 10.0, r1 - r0 + 4.0 + 20.0, 8.0 + 20.0);
     path.rect(r0 - 2.0, -4.0, r1 - r0 + 4.0, 8.0);
     path.solidity(Solidity::Hole);
-    canvas.fill_path(&mut path, paint);
+    canvas.fill_path(&mut path, &paint);
 
     // Center triangle
     let r = r0 - 6.0;
@@ -751,7 +751,7 @@ fn draw_colorwheel<T: Renderer>(canvas: &mut Canvas<T>, x: f32, y: f32, w: f32, 
         Color::hsla(hue, 1.0, 0.5, 1.0),
         Color::rgba(255, 255, 255, 255),
     );
-    canvas.fill_path(&mut path, paint);
+    canvas.fill_path(&mut path, &paint);
     paint = Paint::linear_gradient(
         (r + ax) * 0.5,
         ay * 0.5,
@@ -760,9 +760,9 @@ fn draw_colorwheel<T: Renderer>(canvas: &mut Canvas<T>, x: f32, y: f32, w: f32, 
         Color::rgba(0, 0, 0, 0),
         Color::rgba(0, 0, 0, 255),
     );
-    canvas.fill_path(&mut path, paint);
+    canvas.fill_path(&mut path, &paint);
     paint = Paint::color(Color::rgba(0, 0, 0, 64));
-    canvas.stroke_path(&mut path, paint);
+    canvas.stroke_path(&mut path, &paint);
 
     // Select circle on triangle
     let ax = (120.0 / 180.0 * PI).cos() * r * 0.3;
@@ -771,14 +771,14 @@ fn draw_colorwheel<T: Renderer>(canvas: &mut Canvas<T>, x: f32, y: f32, w: f32, 
     paint.set_line_width(2.0);
     let mut path = Path::new();
     path.circle(ax, ay, 5.0);
-    canvas.stroke_path(&mut path, paint);
+    canvas.stroke_path(&mut path, &paint);
 
     paint = Paint::radial_gradient(ax, ay, 7.0, 9.0, Color::rgba(0, 0, 0, 64), Color::rgba(0, 0, 0, 0));
     let mut path = Path::new();
     path.rect(ax - 20.0, ay - 20.0, 40.0, 40.0);
     path.circle(ax, ay, 7.0);
     path.solidity(Solidity::Hole);
-    canvas.fill_path(&mut path, paint);
+    canvas.fill_path(&mut path, &paint);
 
     canvas.restore();
 
@@ -800,28 +800,28 @@ fn draw_search_box<T: Renderer>(canvas: &mut Canvas<T>, fonts: &Fonts, title: &s
     );
     let mut path = Path::new();
     path.rounded_rect(x, y, w, h, corner_radius);
-    canvas.fill_path(&mut path, bg);
+    canvas.fill_path(&mut path, &bg);
 
     let mut text_paint = Paint::color(Color::rgba(255, 255, 255, 64));
     text_paint.set_font_size((h * 1.3).round());
     text_paint.set_font(&[fonts.icons]);
     text_paint.set_text_align(Align::Center);
     text_paint.set_text_baseline(Baseline::Middle);
-    let _ = canvas.fill_text(x + h * 0.55, y + h * 0.55, "\u{1F50D}", text_paint);
+    let _ = canvas.fill_text(x + h * 0.55, y + h * 0.55, "\u{1F50D}", &text_paint);
 
     let mut text_paint = Paint::color(Color::rgba(255, 255, 255, 32));
     text_paint.set_font_size(16.0);
     text_paint.set_font(&[fonts.regular]);
     text_paint.set_text_align(Align::Left);
     text_paint.set_text_baseline(Baseline::Middle);
-    let _ = canvas.fill_text(x + h, y + h * 0.5, title, text_paint);
+    let _ = canvas.fill_text(x + h, y + h * 0.5, title, &text_paint);
 
     let mut text_paint = Paint::color(Color::rgba(255, 255, 255, 32));
     text_paint.set_font_size((h * 1.3).round());
     text_paint.set_font(&[fonts.icons]);
     text_paint.set_text_align(Align::Center);
     text_paint.set_text_baseline(Baseline::Middle);
-    let _ = canvas.fill_text(x + w - h * 0.55, y + h * 0.45, "\u{2716}", text_paint);
+    let _ = canvas.fill_text(x + w - h * 0.55, y + h * 0.45, "\u{2716}", &text_paint);
 }
 
 fn draw_drop_down<T: Renderer>(canvas: &mut Canvas<T>, fonts: &Fonts, title: &str, x: f32, y: f32, w: f32, h: f32) {
@@ -830,25 +830,25 @@ fn draw_drop_down<T: Renderer>(canvas: &mut Canvas<T>, fonts: &Fonts, title: &st
     let bg = Paint::linear_gradient(x, y, x, y + h, Color::rgba(255, 255, 255, 16), Color::rgba(0, 0, 0, 16));
     let mut path = Path::new();
     path.rounded_rect(x + 1.0, y + 1.0, w - 2.0, h - 2.0, corner_radius);
-    canvas.fill_path(&mut path, bg);
+    canvas.fill_path(&mut path, &bg);
 
     let mut path = Path::new();
     path.rounded_rect(x + 0.5, y + 0.5, w - 1.0, h - 1.0, corner_radius - 0.5);
-    canvas.stroke_path(&mut path, Paint::color(Color::rgba(0, 0, 0, 48)));
+    canvas.stroke_path(&mut path, &Paint::color(Color::rgba(0, 0, 0, 48)));
 
     let mut text_paint = Paint::color(Color::rgba(255, 255, 255, 160));
     text_paint.set_font_size(16.0);
     text_paint.set_font(&[fonts.regular]);
     text_paint.set_text_align(Align::Left);
     text_paint.set_text_baseline(Baseline::Middle);
-    let _ = canvas.fill_text(x + h * 0.3, y + h * 0.5, title, text_paint);
+    let _ = canvas.fill_text(x + h * 0.3, y + h * 0.5, title, &text_paint);
 
     let mut text_paint = Paint::color(Color::rgba(255, 255, 255, 64));
     text_paint.set_font_size((h * 1.3).round());
     text_paint.set_font(&[fonts.icons]);
     text_paint.set_text_align(Align::Center);
     text_paint.set_text_baseline(Baseline::Middle);
-    let _ = canvas.fill_text(x + w - h * 0.5, y + h * 0.45, "\u{E75E}", text_paint);
+    let _ = canvas.fill_text(x + w - h * 0.5, y + h * 0.45, "\u{E75E}", &text_paint);
 }
 
 fn draw_label<T: Renderer>(canvas: &mut Canvas<T>, fonts: &Fonts, title: &str, x: f32, y: f32, _w: f32, h: f32) {
@@ -857,7 +857,7 @@ fn draw_label<T: Renderer>(canvas: &mut Canvas<T>, fonts: &Fonts, title: &str, x
     text_paint.set_font(&[fonts.regular]);
     text_paint.set_text_align(Align::Left);
     text_paint.set_text_baseline(Baseline::Middle);
-    let _ = canvas.fill_text(x, y + h * 0.5, title, text_paint);
+    let _ = canvas.fill_text(x, y + h * 0.5, title, &text_paint);
 }
 
 fn draw_edit_box_base<T: Renderer>(canvas: &mut Canvas<T>, x: f32, y: f32, w: f32, h: f32) {
@@ -874,11 +874,11 @@ fn draw_edit_box_base<T: Renderer>(canvas: &mut Canvas<T>, x: f32, y: f32, w: f3
 
     let mut path = Path::new();
     path.rounded_rect(x + 1.0, y + 1.0, w - 2.0, h - 2.0, 3.0);
-    canvas.fill_path(&mut path, paint);
+    canvas.fill_path(&mut path, &paint);
 
     let mut path = Path::new();
     path.rounded_rect(x + 0.5, y + 0.5, w - 1.0, h - 1.0, 3.5);
-    canvas.stroke_path(&mut path, Paint::color(Color::rgba(0, 0, 0, 48)));
+    canvas.stroke_path(&mut path, &Paint::color(Color::rgba(0, 0, 0, 48)));
 }
 
 fn draw_edit_box<T: Renderer>(canvas: &mut Canvas<T>, fonts: &Fonts, title: &str, x: f32, y: f32, w: f32, h: f32) {
@@ -889,7 +889,7 @@ fn draw_edit_box<T: Renderer>(canvas: &mut Canvas<T>, fonts: &Fonts, title: &str
     text_paint.set_font(&[fonts.regular]);
     text_paint.set_text_align(Align::Left);
     text_paint.set_text_baseline(Baseline::Middle);
-    let _ = canvas.fill_text(x + h * 0.5, y + h * 0.5, title, text_paint);
+    let _ = canvas.fill_text(x + h * 0.5, y + h * 0.5, title, &text_paint);
 }
 
 fn draw_edit_box_num<T: Renderer>(
@@ -910,13 +910,13 @@ fn draw_edit_box_num<T: Renderer>(
     paint.set_text_align(Align::Right);
     paint.set_text_baseline(Baseline::Middle);
 
-    if let Ok(layout) = canvas.measure_text(0.0, 0.0, units, paint) {
-        let _ = canvas.fill_text(x + w - h * 0.3, y + h * 0.5, units, paint);
+    if let Ok(layout) = canvas.measure_text(0.0, 0.0, units, &paint) {
+        let _ = canvas.fill_text(x + w - h * 0.3, y + h * 0.5, units, &paint);
 
         paint.set_font_size(16.0);
         paint.set_color(Color::rgba(255, 255, 255, 128));
 
-        let _ = canvas.fill_text(x + w - layout.width() - h * 0.5, y + h * 0.5, title, paint);
+        let _ = canvas.fill_text(x + w - layout.width() - h * 0.5, y + h * 0.5, title, &paint);
     }
 }
 
@@ -926,7 +926,7 @@ fn draw_check_box<T: Renderer>(canvas: &mut Canvas<T>, fonts: &Fonts, text: &str
     paint.set_font(&[fonts.regular]);
     paint.set_text_baseline(Baseline::Middle);
 
-    let _ = canvas.fill_text(x + 28.0, y + h * 0.5, text, paint);
+    let _ = canvas.fill_text(x + 28.0, y + h * 0.5, text, &paint);
 
     paint = Paint::box_gradient(
         x + 1.0,
@@ -940,14 +940,14 @@ fn draw_check_box<T: Renderer>(canvas: &mut Canvas<T>, fonts: &Fonts, text: &str
     );
     let mut path = Path::new();
     path.rounded_rect(x + 1.0, y + (h * 0.5).floor() - 9.0, 18.0, 18.0, 3.0);
-    canvas.fill_path(&mut path, paint);
+    canvas.fill_path(&mut path, &paint);
 
     paint = Paint::color(Color::rgba(255, 255, 255, 128));
     paint.set_font_size(36.0);
     paint.set_font(&[fonts.icons]);
     paint.set_text_align(Align::Center);
     paint.set_text_baseline(Baseline::Middle);
-    let _ = canvas.fill_text(x + 9.0 + 2.0, y + h * 0.5, "\u{2713}", paint);
+    let _ = canvas.fill_text(x + 9.0 + 2.0, y + h * 0.5, "\u{2713}", &paint);
 }
 
 fn draw_button<T: Renderer>(
@@ -971,14 +971,14 @@ fn draw_button<T: Renderer>(
     path.rounded_rect(x + 1.0, y + 1.0, w - 2.0, h - 2.0, corner_radius - 1.0);
 
     if !color.is_black() {
-        canvas.fill_path(&mut path, Paint::color(color));
+        canvas.fill_path(&mut path, &Paint::color(color));
     }
 
-    canvas.fill_path(&mut path, bg);
+    canvas.fill_path(&mut path, &bg);
 
     let mut path = Path::new();
     path.rounded_rect(x + 0.5, y + 0.5, w - 1.0, h - 1.0, corner_radius - 0.5);
-    canvas.stroke_path(&mut path, Paint::color(Color::rgba(0, 0, 0, 48)));
+    canvas.stroke_path(&mut path, &Paint::color(Color::rgba(0, 0, 0, 48)));
 
     let mut paint = Paint::color(Color::rgba(255, 255, 255, 96));
     paint.set_font_size(15.0);
@@ -986,7 +986,7 @@ fn draw_button<T: Renderer>(
     paint.set_text_align(Align::Left);
     paint.set_text_baseline(Baseline::Middle);
 
-    let tw = if let Ok(layout) = canvas.measure_text(0.0, 0.0, text, paint) {
+    let tw = if let Ok(layout) = canvas.measure_text(0.0, 0.0, text, &paint) {
         layout.width()
     } else {
         0.0
@@ -998,19 +998,19 @@ fn draw_button<T: Renderer>(
         paint.set_font(&[fonts.icons]);
         paint.set_font_size(h * 1.3);
 
-        if let Ok(layout) = canvas.measure_text(0.0, 0.0, icon, paint) {
+        if let Ok(layout) = canvas.measure_text(0.0, 0.0, icon, &paint) {
             iw = layout.width() + (h * 0.15);
         }
 
-        let _ = canvas.fill_text(x + w * 0.5 - tw * 0.5 - iw * 0.75, y + h * 0.5, icon, paint);
+        let _ = canvas.fill_text(x + w * 0.5 - tw * 0.5 - iw * 0.75, y + h * 0.5, icon, &paint);
     }
 
     paint.set_font_size(15.0);
     paint.set_font(&[fonts.regular]);
     paint.set_color(Color::rgba(0, 0, 0, 160));
-    let _ = canvas.fill_text(x + w * 0.5 - tw * 0.5 + iw * 0.25, y + h * 0.5 - 1.0, text, paint);
+    let _ = canvas.fill_text(x + w * 0.5 - tw * 0.5 + iw * 0.25, y + h * 0.5 - 1.0, text, &paint);
     paint.set_color(Color::rgba(255, 255, 255, 160));
-    let _ = canvas.fill_text(x + w * 0.5 - tw * 0.5 + iw * 0.25, y + h * 0.5, text, paint);
+    let _ = canvas.fill_text(x + w * 0.5 - tw * 0.5 + iw * 0.25, y + h * 0.5, text, &paint);
 }
 
 fn draw_slider<T: Renderer>(canvas: &mut Canvas<T>, pos: f32, x: f32, y: f32, w: f32, h: f32) {
@@ -1032,7 +1032,7 @@ fn draw_slider<T: Renderer>(canvas: &mut Canvas<T>, pos: f32, x: f32, y: f32, w:
     );
     let mut path = Path::new();
     path.rounded_rect(x, cy - 2.0, w, 4.0, 2.0);
-    canvas.fill_path(&mut path, bg);
+    canvas.fill_path(&mut path, &bg);
 
     // Knob Shadow
     bg = Paint::radial_gradient(
@@ -1052,7 +1052,7 @@ fn draw_slider<T: Renderer>(canvas: &mut Canvas<T>, pos: f32, x: f32, y: f32, w:
     );
     path.circle(x + (pos * w).floor(), cy, kr);
     path.solidity(Solidity::Hole);
-    canvas.fill_path(&mut path, bg);
+    canvas.fill_path(&mut path, &bg);
 
     // Knob
     bg = Paint::linear_gradient(
@@ -1065,12 +1065,12 @@ fn draw_slider<T: Renderer>(canvas: &mut Canvas<T>, pos: f32, x: f32, y: f32, w:
     );
     let mut path = Path::new();
     path.circle(x + (pos * w).floor(), cy, kr - 1.0);
-    canvas.fill_path(&mut path, Paint::color(Color::rgba(40, 43, 48, 255)));
-    canvas.fill_path(&mut path, bg);
+    canvas.fill_path(&mut path, &Paint::color(Color::rgba(40, 43, 48, 255)));
+    canvas.fill_path(&mut path, &bg);
 
     let mut path = Path::new();
     path.circle(x + (pos * w).floor(), cy, kr - 0.5);
-    canvas.stroke_path(&mut path, Paint::color(Color::rgba(0, 0, 0, 92)));
+    canvas.stroke_path(&mut path, &Paint::color(Color::rgba(0, 0, 0, 92)));
 
     canvas.restore();
 }
@@ -1100,7 +1100,7 @@ fn draw_thumbnails<T: Renderer>(canvas: &mut Canvas<T>, x: f32, y: f32, w: f32, 
     path.rect(x - 10.0, y - 10.0, w + 20.0, h + 30.0);
     path.rounded_rect(x, y, w, h, corner_radius);
     path.solidity(Solidity::Hole);
-    canvas.fill_path(&mut path, shadow_paint);
+    canvas.fill_path(&mut path, &shadow_paint);
 
     // Window
     let mut path = Path::new();
@@ -1108,7 +1108,7 @@ fn draw_thumbnails<T: Renderer>(canvas: &mut Canvas<T>, x: f32, y: f32, w: f32, 
     path.move_to(x - 10.0, y + arry);
     path.line_to(x + 1.0, y + arry - 11.0);
     path.line_to(x + 1.0, y + arry + 11.0);
-    canvas.fill_path(&mut path, Paint::color(Color::rgba(200, 200, 200, 255)));
+    canvas.fill_path(&mut path, &Paint::color(Color::rgba(200, 200, 200, 255)));
 
     canvas.save();
     canvas.scissor(x, y, w, h);
@@ -1151,7 +1151,7 @@ fn draw_thumbnails<T: Renderer>(canvas: &mut Canvas<T>, x: f32, y: f32, w: f32, 
         let img_paint = Paint::image(*image, tx + ix, ty + iy, iw, ih, 0.0 / 180.0 * PI, a);
         let mut path = Path::new();
         path.rounded_rect(tx, ty, thumb, thumb, 5.0);
-        canvas.fill_path(&mut path, img_paint);
+        canvas.fill_path(&mut path, &img_paint);
 
         let shadow_paint = Paint::box_gradient(
             tx - 1.0,
@@ -1167,11 +1167,11 @@ fn draw_thumbnails<T: Renderer>(canvas: &mut Canvas<T>, x: f32, y: f32, w: f32, 
         path.rect(tx - 5.0, ty - 5.0, thumb + 10.0, thumb + 10.0);
         path.rounded_rect(tx, ty, thumb, thumb, 6.0);
         path.solidity(Solidity::Hole);
-        canvas.fill_path(&mut path, shadow_paint);
+        canvas.fill_path(&mut path, &shadow_paint);
 
         let mut path = Path::new();
         path.rounded_rect(tx + 0.5, ty + 0.5, thumb - 1.0, thumb - 1.0, 4.0 - 0.5);
-        canvas.stroke_path(&mut path, Paint::color(Color::rgba(255, 255, 255, 192)));
+        canvas.stroke_path(&mut path, &Paint::color(Color::rgba(255, 255, 255, 192)));
     }
 
     canvas.restore();
@@ -1187,7 +1187,7 @@ fn draw_thumbnails<T: Renderer>(canvas: &mut Canvas<T>, x: f32, y: f32, w: f32, 
     );
     let mut path = Path::new();
     path.rect(x + 4.0, y, w - 8.0, 6.0);
-    canvas.fill_path(&mut path, fade_paint);
+    canvas.fill_path(&mut path, &fade_paint);
 
     let fade_paint = Paint::linear_gradient(
         x,
@@ -1199,7 +1199,7 @@ fn draw_thumbnails<T: Renderer>(canvas: &mut Canvas<T>, x: f32, y: f32, w: f32, 
     );
     let mut path = Path::new();
     path.rect(x + 4.0, y + h - 6.0, w - 8.0, 6.0);
-    canvas.fill_path(&mut path, fade_paint);
+    canvas.fill_path(&mut path, &fade_paint);
 
     // Scroll bar
     let shadow_paint = Paint::box_gradient(
@@ -1214,7 +1214,7 @@ fn draw_thumbnails<T: Renderer>(canvas: &mut Canvas<T>, x: f32, y: f32, w: f32, 
     );
     let mut path = Path::new();
     path.rounded_rect(x + w - 12.0, y + 4.0, 8.0, h - 8.0, 3.0);
-    canvas.fill_path(&mut path, shadow_paint);
+    canvas.fill_path(&mut path, &shadow_paint);
 
     let scrollh = (h / stackh) * (h - 8.0);
     let shadow_paint = Paint::box_gradient(
@@ -1235,7 +1235,7 @@ fn draw_thumbnails<T: Renderer>(canvas: &mut Canvas<T>, x: f32, y: f32, w: f32, 
         scrollh - 2.0,
         2.0,
     );
-    canvas.fill_path(&mut path, shadow_paint);
+    canvas.fill_path(&mut path, &shadow_paint);
 
     canvas.restore();
 }
@@ -1274,7 +1274,7 @@ fn draw_lines<T: Renderer>(canvas: &mut Canvas<T>, x: f32, y: f32, w: f32, _h: f
             path.line_to(fx + pts[2], fy + pts[3]);
             path.line_to(fx + pts[4], fy + pts[5]);
             path.line_to(fx + pts[6], fy + pts[7]);
-            canvas.stroke_path(&mut path, paint);
+            canvas.stroke_path(&mut path, &paint);
 
             paint.set_line_cap(LineCap::Butt);
             paint.set_line_join(LineJoin::Bevel);
@@ -1286,7 +1286,7 @@ fn draw_lines<T: Renderer>(canvas: &mut Canvas<T>, x: f32, y: f32, w: f32, _h: f
             path.line_to(fx + pts[2], fy + pts[3]);
             path.line_to(fx + pts[4], fy + pts[5]);
             path.line_to(fx + pts[6], fy + pts[7]);
-            canvas.stroke_path(&mut path, paint);
+            canvas.stroke_path(&mut path, &paint);
         }
     }
 
@@ -1312,7 +1312,7 @@ fn draw_fills<T: Renderer>(canvas: &mut Canvas<T>, x: f32, y: f32, mousex: f32, 
         evenodd_fill.set_color(Color::rgb(220, 220, 220));
     }
 
-    canvas.fill_path(&mut path, evenodd_fill);
+    canvas.fill_path(&mut path, &evenodd_fill);
 
     canvas.translate(100.0, 0.0);
 
@@ -1331,7 +1331,7 @@ fn draw_fills<T: Renderer>(canvas: &mut Canvas<T>, x: f32, y: f32, mousex: f32, 
         nonzero_fill.set_color(Color::rgb(220, 220, 220));
     }
 
-    canvas.fill_path(&mut path, nonzero_fill);
+    canvas.fill_path(&mut path, &nonzero_fill);
 
     canvas.restore();
 }
@@ -1347,7 +1347,7 @@ fn draw_widths<T: Renderer>(canvas: &mut Canvas<T>, x: f32, mut y: f32, width: f
         let mut path = Path::new();
         path.move_to(x, y);
         path.line_to(x + width, y + width * 0.3);
-        canvas.stroke_path(&mut path, paint);
+        canvas.stroke_path(&mut path, &paint);
         y += 10.0;
     }
 
@@ -1362,11 +1362,11 @@ fn draw_caps<T: Renderer>(canvas: &mut Canvas<T>, x: f32, y: f32, width: f32) {
 
     let mut path = Path::new();
     path.rect(x - line_width / 2.0, y, width + line_width, 40.0);
-    canvas.fill_path(&mut path, Paint::color(Color::rgba(255, 255, 255, 32)));
+    canvas.fill_path(&mut path, &Paint::color(Color::rgba(255, 255, 255, 32)));
 
     let mut path = Path::new();
     path.rect(x, y, width, 40.0);
-    canvas.fill_path(&mut path, Paint::color(Color::rgba(255, 255, 255, 32)));
+    canvas.fill_path(&mut path, &Paint::color(Color::rgba(255, 255, 255, 32)));
 
     let mut paint = Paint::color(Color::rgba(0, 0, 0, 255));
     paint.set_line_width(line_width);
@@ -1376,7 +1376,7 @@ fn draw_caps<T: Renderer>(canvas: &mut Canvas<T>, x: f32, y: f32, width: f32) {
         let mut path = Path::new();
         path.move_to(x, y + i as f32 * 10.0 + 5.0);
         path.line_to(x + width, y + i as f32 * 10.0 + 5.0);
-        canvas.stroke_path(&mut path, paint);
+        canvas.stroke_path(&mut path, &paint);
     }
 
     canvas.restore();
@@ -1391,7 +1391,7 @@ fn draw_scissor<T: Renderer>(canvas: &mut Canvas<T>, x: f32, y: f32, t: f32) {
 
     let mut path = Path::new();
     path.rect(-20.0, -20.0, 60.0, 40.0);
-    canvas.fill_path(&mut path, Paint::color(Color::rgba(255, 0, 0, 255)));
+    canvas.fill_path(&mut path, &Paint::color(Color::rgba(255, 0, 0, 255)));
 
     canvas.scissor(-20.0, -20.0, 60.0, 40.0);
 
@@ -1404,13 +1404,13 @@ fn draw_scissor<T: Renderer>(canvas: &mut Canvas<T>, x: f32, y: f32, t: f32) {
     canvas.reset_scissor();
     let mut path = Path::new();
     path.rect(-20.0, -10.0, 60.0, 30.0);
-    canvas.fill_path(&mut path, Paint::color(Color::rgba(255, 128, 0, 64)));
+    canvas.fill_path(&mut path, &Paint::color(Color::rgba(255, 128, 0, 64)));
     canvas.restore();
 
     // Draw second rectangle with scissoring.
     //canvas.intersect_scissor(-20.0, -10.0, 60.0, 30.0);
     path.rect(-20.0, -10.0, 60.0, 30.0);
-    canvas.fill_path(&mut path, Paint::color(Color::rgba(255, 128, 0, 255)));
+    canvas.fill_path(&mut path, &Paint::color(Color::rgba(255, 128, 0, 255)));
 
     canvas.restore();
 }
@@ -1447,7 +1447,7 @@ impl PerfGraph {
 
         let mut path = Path::new();
         path.rect(x, y, w, h);
-        canvas.fill_path(&mut path, Paint::color(Color::rgba(0, 0, 0, 128)));
+        canvas.fill_path(&mut path, &Paint::color(Color::rgba(0, 0, 0, 128)));
 
         let mut path = Path::new();
         path.move_to(x, y + h);
@@ -1463,23 +1463,28 @@ impl PerfGraph {
         }
 
         path.line_to(x + w, y + h);
-        canvas.fill_path(&mut path, Paint::color(Color::rgba(255, 192, 0, 128)));
+        canvas.fill_path(&mut path, &Paint::color(Color::rgba(255, 192, 0, 128)));
 
         let mut text_paint = Paint::color(Color::rgba(240, 240, 240, 255));
         text_paint.set_font_size(12.0);
-        let _ = canvas.fill_text(x + 5.0, y + 13.0, "Frame time", text_paint);
+        let _ = canvas.fill_text(x + 5.0, y + 13.0, "Frame time", &text_paint);
 
         let mut text_paint = Paint::color(Color::rgba(240, 240, 240, 255));
         text_paint.set_font_size(14.0);
         text_paint.set_text_align(Align::Right);
         text_paint.set_text_baseline(Baseline::Top);
-        let _ = canvas.fill_text(x + w - 5.0, y, &format!("{:.2} FPS", 1.0 / avg), text_paint);
+        let _ = canvas.fill_text(x + w - 5.0, y, &format!("{:.2} FPS", 1.0 / avg), &text_paint);
 
         let mut text_paint = Paint::color(Color::rgba(240, 240, 240, 200));
         text_paint.set_font_size(12.0);
         text_paint.set_text_align(Align::Right);
         text_paint.set_text_baseline(Baseline::Alphabetic);
-        let _ = canvas.fill_text(x + w - 5.0, y + h - 5.0, &format!("{:.2} ms", avg * 1000.0), text_paint);
+        let _ = canvas.fill_text(
+            x + w - 5.0,
+            y + h - 5.0,
+            &format!("{:.2} ms", avg * 1000.0),
+            &text_paint,
+        );
     }
 }
 
@@ -1502,7 +1507,7 @@ fn draw_spinner<T: Renderer>(canvas: &mut Canvas<T>, cx: f32, cy: f32, r: f32, t
     let by = cy + a1.sin() * (r0 + r1) * 0.5;
 
     let paint = Paint::linear_gradient(ax, ay, bx, by, Color::rgba(0, 0, 0, 0), Color::rgba(0, 0, 0, 128));
-    canvas.fill_path(&mut path, paint);
+    canvas.fill_path(&mut path, &paint);
 
     canvas.restore();
 }

--- a/examples/gradients.rs
+++ b/examples/gradients.rs
@@ -80,11 +80,11 @@ fn draw_gradients<T: Renderer>(canvas: &mut Canvas<T>) {
         let mut p = Path::new();
         p.rect(0.0, 0.0, 100.0, 100.0);
         canvas.translate(x, y);
-        canvas.fill_path(&mut p, paint);
+        canvas.fill_path(&mut p, &paint);
         canvas.translate(-x, -y);
         let mut text_paint = Paint::color(Color::black());
         text_paint.set_font_size(14.0);
-        let _ = canvas.fill_text(x, y + 114.0, name, text_paint);
+        let _ = canvas.fill_text(x, y + 114.0, name, &text_paint);
     };
     // Various two stop gradients
     let mut x = 10.0;
@@ -814,7 +814,7 @@ impl PerfGraph {
 
         let mut path = Path::new();
         path.rect(x, y, w, h);
-        canvas.fill_path(&mut path, Paint::color(Color::rgba(0, 0, 0, 128)));
+        canvas.fill_path(&mut path, &Paint::color(Color::rgba(0, 0, 0, 128)));
 
         let mut path = Path::new();
         path.move_to(x, y + h);
@@ -830,22 +830,27 @@ impl PerfGraph {
         }
 
         path.line_to(x + w, y + h);
-        canvas.fill_path(&mut path, Paint::color(Color::rgba(255, 192, 0, 128)));
+        canvas.fill_path(&mut path, &Paint::color(Color::rgba(255, 192, 0, 128)));
 
         let mut text_paint = Paint::color(Color::rgba(240, 240, 240, 255));
         text_paint.set_font_size(12.0);
-        let _ = canvas.fill_text(x + 5.0, y + 13.0, "Frame time", text_paint);
+        let _ = canvas.fill_text(x + 5.0, y + 13.0, "Frame time", &text_paint);
 
         let mut text_paint = Paint::color(Color::rgba(240, 240, 240, 255));
         text_paint.set_font_size(14.0);
         text_paint.set_text_align(Align::Right);
         text_paint.set_text_baseline(Baseline::Top);
-        let _ = canvas.fill_text(x + w - 5.0, y, &format!("{:.2} FPS", 1.0 / avg), text_paint);
+        let _ = canvas.fill_text(x + w - 5.0, y, &format!("{:.2} FPS", 1.0 / avg), &text_paint);
 
         let mut text_paint = Paint::color(Color::rgba(240, 240, 240, 200));
         text_paint.set_font_size(12.0);
         text_paint.set_text_align(Align::Right);
         text_paint.set_text_baseline(Baseline::Alphabetic);
-        let _ = canvas.fill_text(x + w - 5.0, y + h - 5.0, &format!("{:.2} ms", avg * 1000.0), text_paint);
+        let _ = canvas.fill_text(
+            x + w - 5.0,
+            y + h - 5.0,
+            &format!("{:.2} ms", avg * 1000.0),
+            &text_paint,
+        );
     }
 }

--- a/examples/paint_filter.rs
+++ b/examples/paint_filter.rs
@@ -106,7 +106,7 @@ fn main() {
 
                     canvas.fill_path(
                         &mut path,
-                        Paint::image(filtered_image.unwrap(), a.0, a.1, b.0 - a.0, b.1 - a.1, 0f32, 1f32),
+                        &Paint::image(filtered_image.unwrap(), a.0, a.1, b.0 - a.0, b.1 - a.1, 0f32, 1f32),
                     );
                 }
 

--- a/examples/paint_image.rs
+++ b/examples/paint_image.rs
@@ -205,7 +205,7 @@ fn main() {
 
                     canvas.fill_path(
                         &mut path,
-                        Paint::image(image_id, a.0, a.1, b.0 - a.0, b.1 - a.1, 0f32, 1f32),
+                        &Paint::image(image_id, a.0, a.1, b.0 - a.0, b.1 - a.1, 0f32, 1f32),
                     );
                 }
 

--- a/examples/shader.rs
+++ b/examples/shader.rs
@@ -72,7 +72,7 @@ fn main() {
                 let paint = Paint::color(Color::rgbf(1., 0., 0.));
                 let mut path = Path::new();
                 path.rect(WINDOW_WIDTH / 2. - 25., WINDOW_HEIGHT / 2. - 25., 50., 50.);
-                canvas.fill_path(&mut path, paint);
+                canvas.fill_path(&mut path, &paint);
                 canvas.restore();
 
                 canvas.flush();

--- a/examples/svg.rs
+++ b/examples/svg.rs
@@ -136,18 +136,18 @@ fn main() {
                 for (path, fill, stroke) in &mut paths {
                     if let Some(fill) = fill {
                         fill.set_anti_alias(true);
-                        canvas.fill_path(path, *fill);
+                        canvas.fill_path(path, fill);
                     }
 
                     if let Some(stroke) = stroke {
                         stroke.set_anti_alias(true);
-                        canvas.stroke_path(path, *stroke);
+                        canvas.stroke_path(path, stroke);
                     }
 
                     if canvas.contains_point(path, mousex, mousey, FillRule::NonZero) {
                         let mut paint = Paint::color(Color::rgb(32, 240, 32));
                         paint.set_line_width(1.0);
-                        canvas.stroke_path(path, paint);
+                        canvas.stroke_path(path, &paint);
                     }
                 }
 
@@ -249,7 +249,7 @@ impl PerfGraph {
 
         let mut path = Path::new();
         path.rect(x, y, w, h);
-        //canvas.fill_path(&mut path, Paint::color(Color::rgba(0, 0, 0, 128)));
+        //canvas.fill_path(&mut path, &Paint::color(Color::rgba(0, 0, 0, 128)));
 
         let mut path = Path::new();
         path.move_to(x, y + h);
@@ -265,25 +265,30 @@ impl PerfGraph {
         }
 
         path.line_to(x + w, y + h);
-        canvas.fill_path(&mut path, Paint::color(Color::rgba(255, 192, 0, 128)));
+        canvas.fill_path(&mut path, &Paint::color(Color::rgba(255, 192, 0, 128)));
 
         let mut text_paint = Paint::color(Color::rgba(240, 240, 240, 255));
         text_paint.set_font_size(12.0);
         text_paint.set_font(&[light_font]);
-        let _ = canvas.fill_text(x + 5.0, y + 13.0, "Frame time", text_paint);
+        let _ = canvas.fill_text(x + 5.0, y + 13.0, "Frame time", &text_paint);
 
         let mut text_paint = Paint::color(Color::rgba(240, 240, 240, 255));
         text_paint.set_font_size(14.0);
         text_paint.set_font(&[regular_font]);
         text_paint.set_text_align(Align::Right);
         text_paint.set_text_baseline(Baseline::Top);
-        let _ = canvas.fill_text(x + w - 5.0, y, &format!("{:.2} FPS", 1.0 / avg), text_paint);
+        let _ = canvas.fill_text(x + w - 5.0, y, &format!("{:.2} FPS", 1.0 / avg), &text_paint);
 
         let mut text_paint = Paint::color(Color::rgba(240, 240, 240, 200));
         text_paint.set_font_size(12.0);
         text_paint.set_font(&[light_font]);
         text_paint.set_text_align(Align::Right);
         text_paint.set_text_baseline(Baseline::Alphabetic);
-        let _ = canvas.fill_text(x + w - 5.0, y + h - 5.0, &format!("{:.2} ms", avg * 1000.0), text_paint);
+        let _ = canvas.fill_text(
+            x + w - 5.0,
+            y + h - 5.0,
+            &format!("{:.2} ms", avg * 1000.0),
+            &text_paint,
+        );
     }
 }

--- a/examples/text.rs
+++ b/examples/text.rs
@@ -168,7 +168,7 @@ fn main() {
                     size.width as f32 - 10.0,
                     10.0,
                     format!("Scroll to increase / decrease font size. Current: {}", font_size),
-                    paint,
+                    &paint,
                 );
                 #[cfg(feature = "debug_inspector")]
                 let _ = canvas.fill_text(
@@ -228,16 +228,16 @@ fn draw_baselines<T: Renderer>(
         let mut path = Path::new();
         path.move_to(x, y + 0.5);
         path.line_to(x + 250., y + 0.5);
-        canvas.stroke_path(&mut path, Paint::color(Color::rgba(255, 32, 32, 128)));
+        canvas.stroke_path(&mut path, &Paint::color(Color::rgba(255, 32, 32, 128)));
 
         paint.set_text_baseline(*baseline);
 
-        if let Ok(res) = canvas.fill_text(x, y, format!("{} Baseline::{:?}", base_text, baseline), paint) {
-            //let res = canvas.fill_text(10.0, y, format!("d النص العربي جميل جدا {:?}", baseline), paint);
+        if let Ok(res) = canvas.fill_text(x, y, format!("{} Baseline::{:?}", base_text, baseline), &paint) {
+            //let res = canvas.fill_text(10.0, y, format!("d النص العربي جميل جدا {:?}", baseline), &paint);
 
             let mut path = Path::new();
             path.rect(res.x, res.y, res.width(), res.height());
-            canvas.stroke_path(&mut path, Paint::color(Color::rgba(100, 100, 100, 64)));
+            canvas.stroke_path(&mut path, &Paint::color(Color::rgba(100, 100, 100, 64)));
         }
     }
 }
@@ -248,7 +248,7 @@ fn draw_alignments<T: Renderer>(canvas: &mut Canvas<T>, fonts: &Fonts, x: f32, y
     let mut path = Path::new();
     path.move_to(x + 0.5, y - 20.);
     path.line_to(x + 0.5, y + 80.);
-    canvas.stroke_path(&mut path, Paint::color(Color::rgba(255, 32, 32, 128)));
+    canvas.stroke_path(&mut path, &Paint::color(Color::rgba(255, 32, 32, 128)));
 
     let mut paint = Paint::color(Color::black());
     paint.set_font(&[fonts.sans]);
@@ -257,10 +257,10 @@ fn draw_alignments<T: Renderer>(canvas: &mut Canvas<T>, fonts: &Fonts, x: f32, y
     for (i, alignment) in alignments.iter().enumerate() {
         paint.set_text_align(*alignment);
 
-        if let Ok(res) = canvas.fill_text(x, y + i as f32 * 30.0, format!("Align::{:?}", alignment), paint) {
+        if let Ok(res) = canvas.fill_text(x, y + i as f32 * 30.0, format!("Align::{:?}", alignment), &paint) {
             let mut path = Path::new();
             path.rect(res.x, res.y, res.width(), res.height());
-            canvas.stroke_path(&mut path, Paint::color(Color::rgba(100, 100, 100, 64)));
+            canvas.stroke_path(&mut path, &Paint::color(Color::rgba(100, 100, 100, 64)));
         }
     }
 }
@@ -271,17 +271,17 @@ fn draw_paragraph<T: Renderer>(canvas: &mut Canvas<T>, fonts: &Fonts, x: f32, y:
     //paint.set_text_align(Align::Right);
     paint.set_font_size(font_size);
 
-    let font_metrics = canvas.measure_font(paint).expect("Error measuring font");
+    let font_metrics = canvas.measure_font(&paint).expect("Error measuring font");
 
     let width = canvas.width();
     let mut y = y;
 
     let lines = canvas
-        .break_text_vec(width, text, paint)
+        .break_text_vec(width, text, &paint)
         .expect("Error while breaking text");
 
     for line_range in lines {
-        if let Ok(_res) = canvas.fill_text(x, y, &text[line_range], paint) {
+        if let Ok(_res) = canvas.fill_text(x, y, &text[line_range], &paint) {
             y += font_metrics.height();
         }
     }
@@ -291,8 +291,8 @@ fn draw_paragraph<T: Renderer>(canvas: &mut Canvas<T>, fonts: &Fonts, x: f32, y:
     // while start < text.len() {
     //     let substr = &text[start..];
 
-    //     if let Ok(index) = canvas.break_text(width, substr, paint) {
-    //         if let Ok(res) = canvas.fill_text(x, y, &substr[0..index], paint) {
+    //     if let Ok(index) = canvas.break_text(width, substr, &paint) {
+    //         if let Ok(res) = canvas.fill_text(x, y, &substr[0..index], &paint) {
     //             y += res.height;
     //         }
 
@@ -311,9 +311,9 @@ fn draw_inc_size<T: Renderer>(canvas: &mut Canvas<T>, fonts: &Fonts, x: f32, y: 
         paint.set_font(&[fonts.sans]);
         paint.set_font_size(i as f32);
 
-        let font_metrics = canvas.measure_font(paint).expect("Error measuring font");
+        let font_metrics = canvas.measure_font(&paint).expect("Error measuring font");
 
-        if let Ok(_res) = canvas.fill_text(x, cursor_y, "The quick brown fox jumps over the lazy dog", paint) {
+        if let Ok(_res) = canvas.fill_text(x, cursor_y, "The quick brown fox jumps over the lazy dog", &paint) {
             cursor_y += font_metrics.height();
         }
     }
@@ -324,18 +324,18 @@ fn draw_stroked<T: Renderer>(canvas: &mut Canvas<T>, fonts: &Fonts, x: f32, y: f
     paint.set_font(&[fonts.bold]);
     paint.set_line_width(12.0);
     paint.set_font_size(72.0);
-    let _ = canvas.stroke_text(x + 5.0, y + 5.0, "RUST", paint);
+    let _ = canvas.stroke_text(x + 5.0, y + 5.0, "RUST", &paint);
 
     paint.set_color(Color::black());
     paint.set_line_width(10.0);
-    let _ = canvas.stroke_text(x, y, "RUST", paint);
+    let _ = canvas.stroke_text(x, y, "RUST", &paint);
 
     paint.set_line_width(6.0);
     paint.set_color(Color::hex("#B7410E"));
-    let _ = canvas.stroke_text(x, y, "RUST", paint);
+    let _ = canvas.stroke_text(x, y, "RUST", &paint);
 
     paint.set_color(Color::white());
-    let _ = canvas.fill_text(x, y, "RUST", paint);
+    let _ = canvas.fill_text(x, y, "RUST", &paint);
 }
 
 fn draw_gradient_fill<T: Renderer>(canvas: &mut Canvas<T>, fonts: &Fonts, x: f32, y: f32) {
@@ -343,7 +343,7 @@ fn draw_gradient_fill<T: Renderer>(canvas: &mut Canvas<T>, fonts: &Fonts, x: f32
     paint.set_font(&[fonts.bold]);
     paint.set_line_width(6.0);
     paint.set_font_size(72.0);
-    let _ = canvas.stroke_text(x, y, "RUST", paint);
+    let _ = canvas.stroke_text(x, y, "RUST", &paint);
 
     let mut paint = Paint::linear_gradient(
         x,
@@ -355,7 +355,7 @@ fn draw_gradient_fill<T: Renderer>(canvas: &mut Canvas<T>, fonts: &Fonts, x: f32
     );
     paint.set_font(&[fonts.bold]);
     paint.set_font_size(72.0);
-    let _ = canvas.fill_text(x, y, "RUST", paint);
+    let _ = canvas.fill_text(x, y, "RUST", &paint);
 }
 
 fn draw_image_fill<T: Renderer>(canvas: &mut Canvas<T>, fonts: &Fonts, x: f32, y: f32, image_id: ImageId, t: f32) {
@@ -364,7 +364,7 @@ fn draw_image_fill<T: Renderer>(canvas: &mut Canvas<T>, fonts: &Fonts, x: f32, y
     let mut path = Path::new();
     path.move_to(x, y - 2.0);
     path.line_to(x + 180.0, y - 2.0);
-    canvas.stroke_path(&mut path, paint);
+    canvas.stroke_path(&mut path, &paint);
 
     let text = "RUST";
 
@@ -372,13 +372,13 @@ fn draw_image_fill<T: Renderer>(canvas: &mut Canvas<T>, fonts: &Fonts, x: f32, y
     paint.set_font(&[fonts.bold]);
     paint.set_line_width(4.0);
     paint.set_font_size(72.0);
-    let _ = canvas.stroke_text(x, y, text, paint);
+    let _ = canvas.stroke_text(x, y, text, &paint);
 
     let mut paint = Paint::image(image_id, x, y - t * 10.0, 120.0, 120.0, 0.0, 0.50);
     //let mut paint = Paint::image(image_id, x + 50.0, y - t*10.0, 120.0, 120.0, t.sin() / 10.0, 0.70);
     paint.set_font(&[fonts.bold]);
     paint.set_font_size(72.0);
-    let _ = canvas.fill_text(x, y, text, paint);
+    let _ = canvas.fill_text(x, y, text, &paint);
 }
 
 fn draw_complex<T: Renderer>(canvas: &mut Canvas<T>, x: f32, y: f32, font_size: f32) {
@@ -389,10 +389,10 @@ fn draw_complex<T: Renderer>(canvas: &mut Canvas<T>, x: f32, y: f32, font_size: 
         x,
         y,
         "Latin اللغة العربية Кирилица тест iiiiiiiiiiiiiiiiiiiiiiiiiiiii\nasdasd",
-        paint,
+        &paint,
     );
-    //let _ = canvas.fill_text(x, y, "اللغة العربية", paint);
-    //canvas.fill_text(x, y, "Traditionally, text is composed to create a readable, coherent, and visually satisfying", paint);
+    //let _ = canvas.fill_text(x, y, "اللغة العربية", &paint);
+    //canvas.fill_text(x, y, "Traditionally, text is composed to create a readable, coherent, and visually satisfying", &paint);
 }
 
 struct PerfGraph {
@@ -427,7 +427,7 @@ impl PerfGraph {
 
         let mut path = Path::new();
         path.rect(x, y, w, h);
-        canvas.fill_path(&mut path, Paint::color(Color::rgba(0, 0, 0, 128)));
+        canvas.fill_path(&mut path, &Paint::color(Color::rgba(0, 0, 0, 128)));
 
         let mut path = Path::new();
         path.move_to(x, y + h);
@@ -443,23 +443,28 @@ impl PerfGraph {
         }
 
         path.line_to(x + w, y + h);
-        canvas.fill_path(&mut path, Paint::color(Color::rgba(255, 192, 0, 128)));
+        canvas.fill_path(&mut path, &Paint::color(Color::rgba(255, 192, 0, 128)));
 
         let mut text_paint = Paint::color(Color::rgba(240, 240, 240, 255));
         text_paint.set_font_size(12.0);
-        let _ = canvas.fill_text(x + 5.0, y + 13.0, "Frame time", text_paint);
+        let _ = canvas.fill_text(x + 5.0, y + 13.0, "Frame time", &text_paint);
 
         let mut text_paint = Paint::color(Color::rgba(240, 240, 240, 255));
         text_paint.set_font_size(14.0);
         text_paint.set_text_align(Align::Right);
         text_paint.set_text_baseline(Baseline::Top);
-        let _ = canvas.fill_text(x + w - 5.0, y, &format!("{:.2} FPS", 1.0 / avg), text_paint);
+        let _ = canvas.fill_text(x + w - 5.0, y, &format!("{:.2} FPS", 1.0 / avg), &text_paint);
 
         let mut text_paint = Paint::color(Color::rgba(240, 240, 240, 200));
         text_paint.set_font_size(12.0);
         text_paint.set_text_align(Align::Right);
         text_paint.set_text_baseline(Baseline::Alphabetic);
-        let _ = canvas.fill_text(x + w - 5.0, y + h - 5.0, &format!("{:.2} ms", avg * 1000.0), text_paint);
+        let _ = canvas.fill_text(
+            x + w - 5.0,
+            y + h - 5.0,
+            &format!("{:.2} ms", avg * 1000.0),
+            &text_paint,
+        );
     }
 }
 

--- a/src/paint.rs
+++ b/src/paint.rs
@@ -180,10 +180,10 @@ impl Default for GlyphTexture {
 ///
 /// let mut path = Path::new();
 /// path.rounded_rect(10.0, 10.0, 100.0, 100.0, 20.0);
-/// canvas.fill_path(&mut path, fill_paint);
-/// canvas.stroke_path(&mut path, stroke_paint);
+/// canvas.fill_path(&mut path, &fill_paint);
+/// canvas.stroke_path(&mut path, &stroke_paint);
 /// ```
-#[derive(Copy, Clone, Debug)]
+#[derive(Clone, Debug)]
 #[cfg_attr(feature = "serialization", derive(Serialize, Deserialize))]
 pub struct Paint {
     pub(crate) flavor: PaintFlavor,
@@ -261,7 +261,7 @@ impl Paint {
     ///
     /// let mut path = Path::new();
     /// path.rect(10.0, 10.0, 85.0, 85.0);
-    /// canvas.fill_path(&mut path, fill_paint);
+    /// canvas.fill_path(&mut path, &fill_paint);
     /// ```
     pub fn image(id: ImageId, cx: f32, cy: f32, width: f32, height: f32, angle: f32, alpha: f32) -> Self {
         Paint::with_flavor(PaintFlavor::Image {
@@ -302,7 +302,7 @@ impl Paint {
     /// let bg = Paint::linear_gradient(0.0, 0.0, 0.0, 100.0, Color::rgba(255, 255, 255, 16), Color::rgba(0, 0, 0, 16));
     /// let mut path = Path::new();
     /// path.rounded_rect(0.0, 0.0, 100.0, 100.0, 5.0);
-    /// canvas.fill_path(&mut path, bg);
+    /// canvas.fill_path(&mut path, &bg);
     /// ```
     pub fn linear_gradient(
         start_x: f32,
@@ -341,7 +341,7 @@ impl Paint {
     ///    ]);
     /// let mut path = Path::new();
     /// path.rounded_rect(0.0, 0.0, 100.0, 100.0, 5.0);
-    /// canvas.fill_path(&mut path, bg);
+    /// canvas.fill_path(&mut path, &bg);
     /// ```
     pub fn linear_gradient_stops(start_x: f32, start_y: f32, end_x: f32, end_y: f32, stops: &[(f32, Color)]) -> Self {
         Paint::with_flavor(PaintFlavor::LinearGradient {
@@ -381,7 +381,7 @@ impl Paint {
     ///
     /// let mut path = Path::new();
     /// path.rounded_rect(0.0, 0.0, 100.0, 100.0, 5.0);
-    /// canvas.fill_path(&mut path, bg);
+    /// canvas.fill_path(&mut path, &bg);
     /// ```
     pub fn box_gradient(
         x: f32,
@@ -430,7 +430,7 @@ impl Paint {
     ///
     /// let mut path = Path::new();
     /// path.circle(50.0, 50.0, 20.0);
-    /// canvas.fill_path(&mut path, bg);
+    /// canvas.fill_path(&mut path, &bg);
     /// ```
     pub fn radial_gradient(
         cx: f32,
@@ -480,7 +480,7 @@ impl Paint {
     ///
     /// let mut path = Path::new();
     /// path.circle(50.0, 50.0, 20.0);
-    /// canvas.fill_path(&mut path, bg);
+    /// canvas.fill_path(&mut path, &bg);
     /// ```
     pub fn radial_gradient_stops(cx: f32, cy: f32, in_radius: f32, out_radius: f32, stops: &[(f32, Color)]) -> Self {
         Paint::with_flavor(PaintFlavor::RadialGradient {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -6,8 +6,8 @@ fn path_with_single_move_to() {
 
     let mut path = Path::new();
     path.move_to(10.0, 10.0);
-    canvas.fill_path(&mut path, Paint::color(Color::rgb(100, 100, 100)));
-    canvas.stroke_path(&mut path, Paint::color(Color::rgb(100, 100, 100)));
+    canvas.fill_path(&mut path, &Paint::color(Color::rgb(100, 100, 100)));
+    canvas.stroke_path(&mut path, &Paint::color(Color::rgb(100, 100, 100)));
 }
 
 #[test]
@@ -17,8 +17,8 @@ fn path_with_two_lines() {
     let mut path = Path::new();
     path.line_to(10.0, 10.0);
     path.line_to(10.0, 10.0);
-    canvas.fill_path(&mut path, Paint::color(Color::rgb(100, 100, 100)));
-    canvas.stroke_path(&mut path, Paint::color(Color::rgb(100, 100, 100)));
+    canvas.fill_path(&mut path, &Paint::color(Color::rgb(100, 100, 100)));
+    canvas.stroke_path(&mut path, &Paint::color(Color::rgb(100, 100, 100)));
 }
 
 #[test]
@@ -29,8 +29,8 @@ fn path_with_close_points() {
     path.move_to(10.0, 10.0);
     path.line_to(10.0001, 10.0);
     path.line_to(10.0001, 10.000001);
-    canvas.fill_path(&mut path, Paint::color(Color::rgb(100, 100, 100)));
-    canvas.stroke_path(&mut path, Paint::color(Color::rgb(100, 100, 100)));
+    canvas.fill_path(&mut path, &Paint::color(Color::rgb(100, 100, 100)));
+    canvas.stroke_path(&mut path, &Paint::color(Color::rgb(100, 100, 100)));
 }
 
 #[test]
@@ -54,8 +54,8 @@ fn path_with_points_at_limits() {
     );
     path.close();
 
-    canvas.fill_path(&mut path, Paint::color(Color::rgb(100, 100, 100)));
-    canvas.stroke_path(&mut path, Paint::color(Color::rgb(100, 100, 100)));
+    canvas.fill_path(&mut path, &Paint::color(Color::rgb(100, 100, 100)));
+    canvas.stroke_path(&mut path, &Paint::color(Color::rgb(100, 100, 100)));
 }
 
 #[test]
@@ -81,8 +81,8 @@ fn path_with_points_around_zero() {
 
     path.close();
 
-    canvas.fill_path(&mut path, Paint::color(Color::rgb(100, 100, 100)));
-    canvas.stroke_path(&mut path, Paint::color(Color::rgb(100, 100, 100)));
+    canvas.fill_path(&mut path, &Paint::color(Color::rgb(100, 100, 100)));
+    canvas.stroke_path(&mut path, &Paint::color(Color::rgb(100, 100, 100)));
 }
 
 #[test]
@@ -94,7 +94,7 @@ fn degenerate_stroke() {
     path.line_to(2., 2.);
     path.line_to(2., 2.);
     path.line_to(4., 2.);
-    canvas.stroke_path(&mut path, Paint::color(Color::rgb(100, 100, 100)));
+    canvas.stroke_path(&mut path, &Paint::color(Color::rgb(100, 100, 100)));
 }
 
 #[test]
@@ -104,8 +104,8 @@ fn degenerate_arc_to() {
     let mut path = Path::new();
     path.move_to(10.0, 10.0);
     path.arc_to(10.0, 10.0001, 10.0, 10.0001, 2.0);
-    canvas.fill_path(&mut path, Paint::color(Color::rgb(100, 100, 100)));
-    canvas.stroke_path(&mut path, Paint::color(Color::rgb(100, 100, 100)));
+    canvas.fill_path(&mut path, &Paint::color(Color::rgb(100, 100, 100)));
+    canvas.stroke_path(&mut path, &Paint::color(Color::rgb(100, 100, 100)));
 }
 
 #[test]
@@ -116,8 +116,8 @@ fn degenerate_arc() {
     path.move_to(10.0, 10.0);
     path.arc(10.0, 10.0, 10.0, 0.0, std::f32::MAX, Solidity::Hole);
 
-    canvas.fill_path(&mut path, Paint::color(Color::rgb(100, 100, 100)));
-    canvas.stroke_path(&mut path, Paint::color(Color::rgb(100, 100, 100)));
+    canvas.fill_path(&mut path, &Paint::color(Color::rgb(100, 100, 100)));
+    canvas.stroke_path(&mut path, &Paint::color(Color::rgb(100, 100, 100)));
 }
 
 #[test]
@@ -156,7 +156,7 @@ fn text_location_respects_scale() {
     paint.set_text_baseline(Baseline::Top);
     canvas.scale(5.0, 5.0);
 
-    let res = canvas.measure_text(100.0, 100.0, "Hello", paint).unwrap();
+    let res = canvas.measure_text(100.0, 100.0, "Hello", &paint).unwrap();
 
     assert_eq!(res.x, 100.0);
     assert_eq!(res.y, 100.0);
@@ -175,7 +175,7 @@ fn text_measure_without_canvas() {
     test_paint.set_font_size(16.);
 
     let metrics = text_context
-        .measure_text(0., 0., "Hello World", test_paint)
+        .measure_text(0., 0., "Hello World", &test_paint)
         .expect("text shaping failed unexpectedly");
 
     assert_eq!(metrics.width().ceil(), 83.);
@@ -195,7 +195,7 @@ fn font_measure_without_canvas() {
     test_paint.set_font_size(16.);
 
     let metrics = text_context
-        .measure_font(test_paint)
+        .measure_font(&test_paint)
         .expect("font measuring failed unexpectedly");
 
     assert_eq!(metrics.ascender().ceil(), 17.);
@@ -216,7 +216,7 @@ fn break_text_without_canvas() {
     let text = "Multiple Lines Broken";
 
     let breaks = text_context
-        .break_text_vec(60., text, test_paint)
+        .break_text_vec(60., text, &test_paint)
         .expect("text shaping failed unexpectedly");
 
     assert_eq!(


### PR DESCRIPTION
Clone is still used internally where necessary. I think before merging we should get rid of these, too.

This probably requires a bit more rework. Paint currently contains data, which is only used internally. These should not be stored there.

Instead of cloning the whole paint, it seems like a good start to only clone the parameters, which are modified internally, and pass the other fields as reference, maybe not even passing around the Paint struct directly.