### PR TITLE
Move scale for glyph commands to function argument

### DIFF
--- a/examples/external_text.rs
+++ b/examples/external_text.rs
@@ -258,7 +258,7 @@ fn run(
                 let cmds = cache
                     .fill_to_cmds(&FONT_SYSTEM, &mut canvas, &buffer, (0.0, 0.0))
                     .unwrap();
-                canvas.draw_glyph_cmds(cmds, &Paint::color(Color::black()));
+                canvas.draw_glyph_cmds(cmds, &Paint::color(Color::black()), 1.0);
 
                 canvas.flush();
                 #[cfg(not(target_arch = "wasm32"))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1319,17 +1319,17 @@ where
 
     /// Dispatch an explicit set of GlyphDrawCommands to the renderer. Use this only if you are
     /// using a custom font rasterizer/layout.
-    pub fn draw_glyph_cmds(&mut self, draw_commands: GlyphDrawCommands, paint: &Paint) {
+    pub fn draw_glyph_cmds(&mut self, draw_commands: GlyphDrawCommands, paint: &Paint, scale: f32) {
         let transform = self.state().transform;
-
+        let invscale = 1.0 / scale;
         let create_vertices = |quads: &Vec<text::Quad>| {
             let mut verts = Vec::with_capacity(quads.len() * 6);
 
             for quad in quads {
-                let (p0, p1) = transform.transform_point(quad.x0, quad.y0);
-                let (p2, p3) = transform.transform_point(quad.x1, quad.y0);
-                let (p4, p5) = transform.transform_point(quad.x1, quad.y1);
-                let (p6, p7) = transform.transform_point(quad.x0, quad.y1);
+                let (p0, p1) = transform.transform_point(quad.x0 * invscale, quad.y0 * invscale);
+                let (p2, p3) = transform.transform_point(quad.x1 * invscale, quad.y0 * invscale);
+                let (p4, p5) = transform.transform_point(quad.x1 * invscale, quad.y1 * invscale);
+                let (p6, p7) = transform.transform_point(quad.x0 * invscale, quad.y1 * invscale);
 
                 verts.push(Vertex::new(p0, p1, quad.s0, quad.t0));
                 verts.push(Vertex::new(p4, p5, quad.s1, quad.t1));
@@ -1421,7 +1421,7 @@ where
 
             let draw_commands =
                 atlas.render_atlas(self, &layout, text_settings.font_size, stroke.line_width, render_mode)?;
-            self.draw_glyph_cmds(draw_commands, paint);
+            self.draw_glyph_cmds(draw_commands, paint, scale);
         }
 
         layout.scale(invscale);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1320,18 +1320,16 @@ where
     /// Dispatch an explicit set of GlyphDrawCommands to the renderer. Use this only if you are
     /// using a custom font rasterizer/layout.
     pub fn draw_glyph_cmds(&mut self, draw_commands: GlyphDrawCommands, paint: &Paint) {
-        let scale = self.font_scale() * self.device_px_ratio;
-        let invscale = 1.0 / scale;
         let transform = self.state().transform;
 
         let create_vertices = |quads: &Vec<text::Quad>| {
             let mut verts = Vec::with_capacity(quads.len() * 6);
 
             for quad in quads {
-                let (p0, p1) = transform.transform_point(quad.x0 * invscale, quad.y0 * invscale);
-                let (p2, p3) = transform.transform_point(quad.x1 * invscale, quad.y0 * invscale);
-                let (p4, p5) = transform.transform_point(quad.x1 * invscale, quad.y1 * invscale);
-                let (p6, p7) = transform.transform_point(quad.x0 * invscale, quad.y1 * invscale);
+                let (p0, p1) = transform.transform_point(quad.x0, quad.y0);
+                let (p2, p3) = transform.transform_point(quad.x1, quad.y0);
+                let (p4, p5) = transform.transform_point(quad.x1, quad.y1);
+                let (p6, p7) = transform.transform_point(quad.x0, quad.y1);
 
                 verts.push(Vertex::new(p0, p1, quad.s0, quad.t0));
                 verts.push(Vertex::new(p4, p5, quad.s1, quad.t1));


### PR DESCRIPTION
Fixes a bug where text rendered with `draw_glyph_cmds`, but not with `draw_text`, would be incorrect when transformed. This change allows passing a custom scale to the function, which should be `1.0` when used externally.