### PR TITLE
Expose the structures needed to implement your own renderer outside the crate

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,8 +37,7 @@ pub use text::{
 use text::{GlyphAtlas, TextContextImpl};
 
 mod image;
-use crate::image::ImageStore;
-pub use crate::image::{ImageFilter, ImageFlags, ImageId, ImageInfo, ImageSource, PixelFormat};
+pub use crate::image::{ImageFilter, ImageFlags, ImageId, ImageInfo, ImageSource, ImageStore, PixelFormat};
 
 mod color;
 pub use color::Color;

--- a/src/paint.rs
+++ b/src/paint.rs
@@ -225,7 +225,7 @@ impl PaintFlavor {
 }
 
 #[derive(Copy, Clone, Debug)]
-pub(crate) enum GlyphTexture {
+pub enum GlyphTexture {
     None,
     AlphaMask(ImageId),
     ColorTexture(ImageId),

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -19,8 +19,8 @@ pub(crate) use params::Params;
 
 #[derive(Copy, Clone, Default, Debug)]
 pub struct Drawable {
-    pub(crate) fill_verts: Option<(usize, usize)>,
-    pub(crate) stroke_verts: Option<(usize, usize)>,
+    pub fill_verts: Option<(usize, usize)>,
+    pub stroke_verts: Option<(usize, usize)>,
 }
 
 #[derive(Debug)]
@@ -57,13 +57,13 @@ pub enum CommandType {
 }
 
 pub struct Command {
-    pub(crate) cmd_type: CommandType,
-    pub(crate) drawables: Vec<Drawable>,
-    pub(crate) triangles_verts: Option<(usize, usize)>,
-    pub(crate) image: Option<ImageId>,
-    pub(crate) glyph_texture: GlyphTexture,
-    pub(crate) fill_rule: FillRule,
-    pub(crate) composite_operation: CompositeOperationState,
+    pub cmd_type: CommandType,
+    pub drawables: Vec<Drawable>,
+    pub triangles_verts: Option<(usize, usize)>,
+    pub image: Option<ImageId>,
+    pub glyph_texture: GlyphTexture,
+    pub fill_rule: FillRule,
+    pub composite_operation: CompositeOperationState,
 }
 
 impl Command {


### PR DESCRIPTION
I would like to implement my own Renderer, and to do so I would like these structures to be exposed outside the crate.