### PR TITLE
Remove ouroboros dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ All notable changes to this project will be documented in this file.
 
  - Changed `linear_gradient_stops` and `radial_gradient_stops` to take an `IntoIterator`
    instead of a slice slice for the color stops.
+ - Path drawing functions now take a `&Path` instead of a `&mut Path` and use interior mutability
+   for caching.
 
 ## [0.5.0] - 2022-02-06
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,6 @@ generational-arena = "0.2.8"
 lru = { version = "0.10.0", default-features = false }
 image = { version = "0.24.0", optional = true, default-features = false }
 serde = { version = "1.0", optional = true, features = ["derive", "rc"] }
-ouroboros = { version = "0.15" }
 glow = { version = "0.12.0", default-features = false }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/examples/breakout.rs
+++ b/examples/breakout.rs
@@ -516,7 +516,7 @@ impl Game {
             Color::rgb(90, 90, 90),
             Color::rgb(30, 30, 30),
         );
-        canvas.stroke_path(&mut path, &paint);
+        canvas.stroke_path(&path, &paint);
 
         match self.state {
             State::TitleScreen => self.draw_title_screen(canvas),
@@ -532,17 +532,17 @@ impl Game {
         // curtain
         let mut path = Path::new();
         path.rect(0.0, 0.0, canvas.width(), canvas.height());
-        canvas.fill_path(&mut path, &Paint::color(Color::rgba(0, 0, 0, 180)));
+        canvas.fill_path(&path, &Paint::color(Color::rgba(0, 0, 0, 180)));
 
         // rust logo
         let logo_pos = Point::new((canvas.width() / 2.0) - 50.0, (canvas.height() / 2.0) - 180.0);
         let logo_paint = Paint::image(self.logo_image_id, logo_pos.x, logo_pos.y, 100.0, 100.0, 0.0, 1.0);
         let mut path = Path::new();
         path.circle(logo_pos.x + 50.0, logo_pos.y + 50.0, 60.0);
-        //canvas.fill_path(&mut path, &Paint::color(Color::rgba(200, 200, 200, 200)));
+        //canvas.fill_path(&path, &Paint::color(Color::rgba(200, 200, 200, 200)));
         let mut path = Path::new();
         path.rect(logo_pos.x, logo_pos.y, 100.0, 100.0);
-        canvas.fill_path(&mut path, &logo_paint);
+        canvas.fill_path(&path, &logo_paint);
 
         // title
         let mut paint = Paint::color(Color::rgb(240, 240, 240));
@@ -599,8 +599,8 @@ impl Game {
             self.paddle_rect.size.height / 2.0,
             0.0,
         );
-        canvas.fill_path(&mut path, &Paint::color(Color::rgb(119, 123, 126)));
-        canvas.stroke_path(&mut path, &highlight);
+        canvas.fill_path(&path, &Paint::color(Color::rgb(119, 123, 126)));
+        canvas.stroke_path(&path, &highlight);
 
         let mut path = Path::new();
         path.rect(
@@ -609,8 +609,8 @@ impl Game {
             self.paddle_rect.size.width - (side_size * 2.0) - 6.0,
             self.paddle_rect.size.height,
         );
-        canvas.fill_path(&mut path, &Paint::color(Color::rgb(119, 123, 126)));
-        canvas.stroke_path(&mut path, &highlight);
+        canvas.fill_path(&path, &Paint::color(Color::rgb(119, 123, 126)));
+        canvas.stroke_path(&path, &highlight);
 
         let mut path = Path::new();
         path.rounded_rect_varying(
@@ -624,13 +624,13 @@ impl Game {
             25.0,
         );
 
-        canvas.fill_path(&mut path, &highlight);
+        canvas.fill_path(&path, &highlight);
 
         // Ball
         for ball in &self.balls {
             let mut path = Path::new();
             path.circle(ball.position.x, ball.position.y, ball.radius);
-            canvas.fill_path(&mut path, &Paint::color(Color::rgb(183, 65, 14)));
+            canvas.fill_path(&path, &Paint::color(Color::rgb(183, 65, 14)));
 
             let bg = Paint::linear_gradient(
                 ball.position.x,
@@ -643,7 +643,7 @@ impl Game {
 
             let mut path = Path::new();
             path.circle(ball.position.x, ball.position.y - ball.radius / 2.0, ball.radius / 2.0);
-            canvas.fill_path(&mut path, &bg);
+            canvas.fill_path(&path, &bg);
         }
 
         // powerups
@@ -706,7 +706,7 @@ impl Game {
         // curtain
         let mut path = Path::new();
         path.rect(0.0, 0.0, canvas.width(), canvas.height());
-        canvas.fill_path(&mut path, &Paint::color(Color::rgba(0, 0, 0, 32)));
+        canvas.fill_path(&path, &Paint::color(Color::rgba(0, 0, 0, 32)));
 
         // title
         let mut paint = Paint::color(Color::rgb(240, 240, 240));
@@ -776,7 +776,7 @@ impl Powerup {
             5.0,
         );
 
-        canvas.stroke_path(&mut path, &Paint::color(Color::rgb(240, 240, 240)));
+        canvas.stroke_path(&path, &Paint::color(Color::rgb(240, 240, 240)));
 
         let mut text_paint = Paint::color(Color::rgb(240, 240, 240));
         text_paint.set_text_align(Align::Center);
@@ -864,8 +864,8 @@ impl Brick {
             },
         });
 
-        canvas.fill_path(&mut path, &paint);
-        canvas.stroke_path(&mut path, &Paint::color(Color::rgb(240, 240, 240)));
+        canvas.fill_path(&path, &paint);
+        canvas.stroke_path(&path, &Paint::color(Color::rgb(240, 240, 240)));
 
         let mut path = Path::new();
         path.rounded_rect_varying(
@@ -878,7 +878,7 @@ impl Brick {
             15.0,
             15.0,
         );
-        canvas.fill_path(&mut path, &Paint::color(Color::rgba(255, 255, 255, 50)));
+        canvas.fill_path(&path, &Paint::color(Color::rgba(255, 255, 255, 50)));
     }
 }
 

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -298,8 +298,8 @@ fn run(
 
                     let mut path = Path::new();
                     path.rect(x, y, 512.0, 512.0);
-                    canvas.fill_path(&mut path, &paint);
-                    canvas.stroke_path(&mut path, &Paint::color(Color::hex("454545")));
+                    canvas.fill_path(&path, &paint);
+                    canvas.stroke_path(&path, &Paint::color(Color::hex("454545")));
                 }
 
                 canvas.save_with(|canvas| {
@@ -367,7 +367,7 @@ fn draw_paragraph<T: Renderer>(
 
                 let mut path = Path::new();
                 path.rect(caret_x, y, 1.0, res.height());
-                canvas.fill_path(&mut path, &Paint::color(Color::rgba(255, 192, 0, 255)));
+                canvas.fill_path(&path, &Paint::color(Color::rgba(255, 192, 0, 255)));
 
                 gutter = line_num + 1;
 
@@ -396,7 +396,7 @@ fn draw_paragraph<T: Renderer>(
                 res.height() + 4.0,
                 (res.height() + 4.0) / 2.0 - 1.0,
             );
-            canvas.fill_path(&mut path, &paint);
+            canvas.fill_path(&path, &paint);
 
             paint.set_color(Color::rgba(32, 32, 32, 255));
             let _ = canvas.fill_text(x - 10.0, gutter_y, &text, &paint);
@@ -427,7 +427,7 @@ fn draw_eyes<T: Renderer>(canvas: &mut Canvas<T>, x: f32, y: f32, w: f32, h: f32
     let mut path = Path::new();
     path.ellipse(lx + 3.0, ly + 16.0, ex, ey);
     path.ellipse(rx + 3.0, ry + 16.0, ex, ey);
-    canvas.fill_path(&mut path, &bg);
+    canvas.fill_path(&path, &bg);
 
     let bg = Paint::linear_gradient(
         x,
@@ -440,7 +440,7 @@ fn draw_eyes<T: Renderer>(canvas: &mut Canvas<T>, x: f32, y: f32, w: f32, h: f32
     let mut path = Path::new();
     path.ellipse(lx, ly, ex, ey);
     path.ellipse(rx, ry, ex, ey);
-    canvas.fill_path(&mut path, &bg);
+    canvas.fill_path(&path, &bg);
 
     let mut dx = (mx - rx) / (ex * 10.0);
     let mut dy = (my - ry) / (ey * 10.0);
@@ -454,7 +454,7 @@ fn draw_eyes<T: Renderer>(canvas: &mut Canvas<T>, x: f32, y: f32, w: f32, h: f32
     dy *= ey * 0.5;
     let mut path = Path::new();
     path.ellipse(lx + dx, ly + dy + ey * 0.25 * (1.0 - blink), br, br * blink);
-    canvas.fill_path(&mut path, &Paint::color(Color::rgba(32, 32, 32, 255)));
+    canvas.fill_path(&path, &Paint::color(Color::rgba(32, 32, 32, 255)));
 
     let mut dx = (mx - rx) / (ex * 10.0);
     let mut dy = (my - ry) / (ey * 10.0);
@@ -468,7 +468,7 @@ fn draw_eyes<T: Renderer>(canvas: &mut Canvas<T>, x: f32, y: f32, w: f32, h: f32
     dy *= ey * 0.5;
     let mut path = Path::new();
     path.ellipse(rx + dx, ry + dy + ey * 0.25 * (1.0 - blink), br, br * blink);
-    canvas.fill_path(&mut path, &Paint::color(Color::rgba(32, 32, 32, 255)));
+    canvas.fill_path(&path, &Paint::color(Color::rgba(32, 32, 32, 255)));
 
     let gloss = Paint::radial_gradient(
         lx - ex * 0.25,
@@ -480,7 +480,7 @@ fn draw_eyes<T: Renderer>(canvas: &mut Canvas<T>, x: f32, y: f32, w: f32, h: f32
     );
     let mut path = Path::new();
     path.ellipse(lx, ly, ex, ey);
-    canvas.fill_path(&mut path, &gloss);
+    canvas.fill_path(&path, &gloss);
 
     let gloss = Paint::radial_gradient(
         rx - ex * 0.25,
@@ -492,7 +492,7 @@ fn draw_eyes<T: Renderer>(canvas: &mut Canvas<T>, x: f32, y: f32, w: f32, h: f32
     );
     let mut path = Path::new();
     path.ellipse(rx, ry, ex, ey);
-    canvas.fill_path(&mut path, &gloss);
+    canvas.fill_path(&path, &gloss);
 }
 
 fn draw_graph<T: Renderer>(canvas: &mut Canvas<T>, x: f32, y: f32, w: f32, h: f32, t: f32) {
@@ -533,7 +533,7 @@ fn draw_graph<T: Renderer>(canvas: &mut Canvas<T>, x: f32, y: f32, w: f32, h: f3
 
     path.line_to(x + w, y + h);
     path.line_to(x, y + h);
-    canvas.fill_path(&mut path, &bg);
+    canvas.fill_path(&path, &bg);
 
     // Graph line
     let mut path = Path::new();
@@ -545,7 +545,7 @@ fn draw_graph<T: Renderer>(canvas: &mut Canvas<T>, x: f32, y: f32, w: f32, h: f3
 
     let mut line = Paint::color(Color::rgba(0, 160, 192, 255));
     line.set_line_width(3.0);
-    canvas.stroke_path(&mut path, &line);
+    canvas.stroke_path(&path, &line);
 
     // Graph sample pos
     for i in 0..6 {
@@ -559,20 +559,20 @@ fn draw_graph<T: Renderer>(canvas: &mut Canvas<T>, x: f32, y: f32, w: f32, h: f3
         );
         let mut path = Path::new();
         path.rect(sx[i] - 10.0, sy[i] - 10.0 + 2.0, 20.0, 20.0);
-        canvas.fill_path(&mut path, &bg);
+        canvas.fill_path(&path, &bg);
     }
 
     let mut path = Path::new();
     for i in 0..6 {
         path.circle(sx[i], sy[i], 4.0);
     }
-    canvas.fill_path(&mut path, &Paint::color(Color::rgba(0, 160, 192, 255)));
+    canvas.fill_path(&path, &Paint::color(Color::rgba(0, 160, 192, 255)));
 
     let mut path = Path::new();
     for i in 0..6 {
         path.circle(sx[i], sy[i], 2.0);
     }
-    canvas.fill_path(&mut path, &Paint::color(Color::rgba(220, 220, 220, 255)));
+    canvas.fill_path(&path, &Paint::color(Color::rgba(220, 220, 220, 255)));
 }
 
 fn draw_window<T: Renderer>(canvas: &mut Canvas<T>, fonts: &Fonts, title: &str, x: f32, y: f32, w: f32, h: f32) {
@@ -583,7 +583,7 @@ fn draw_window<T: Renderer>(canvas: &mut Canvas<T>, fonts: &Fonts, title: &str, 
     // Window
     let mut path = Path::new();
     path.rounded_rect(x, y, w, h, corner_radius);
-    canvas.fill_path(&mut path, &Paint::color(Color::rgba(28, 30, 34, 192)));
+    canvas.fill_path(&path, &Paint::color(Color::rgba(28, 30, 34, 192)));
 
     // Drop shadow
     let shadow_paint = Paint::box_gradient(
@@ -600,7 +600,7 @@ fn draw_window<T: Renderer>(canvas: &mut Canvas<T>, fonts: &Fonts, title: &str, 
     path.rect(x - 10.0, y - 10.0, w + 20.0, h + 30.0);
     path.rounded_rect(x, y, w, h, corner_radius);
     path.solidity(Solidity::Hole);
-    canvas.fill_path(&mut path, &shadow_paint);
+    canvas.fill_path(&path, &shadow_paint);
 
     // Header
     let header_paint = Paint::linear_gradient(
@@ -613,12 +613,12 @@ fn draw_window<T: Renderer>(canvas: &mut Canvas<T>, fonts: &Fonts, title: &str, 
     );
     let mut path = Path::new();
     path.rounded_rect(x + 1.0, y + 1.0, w - 2.0, 30.0, corner_radius - 1.0);
-    canvas.fill_path(&mut path, &header_paint);
+    canvas.fill_path(&path, &header_paint);
 
     let mut path = Path::new();
     path.move_to(x + 0.5, y + 0.5 + 30.0);
     path.line_to(x + 0.5 + w - 1.0, y + 0.5 + 30.0);
-    canvas.stroke_path(&mut path, &Paint::color(Color::rgba(0, 0, 0, 32)));
+    canvas.stroke_path(&path, &Paint::color(Color::rgba(0, 0, 0, 32)));
 
     let mut text_paint = Paint::color(Color::rgba(0, 0, 0, 32));
     text_paint.set_font_size(16.0);
@@ -665,7 +665,7 @@ fn draw_colorwheel<T: Renderer>(canvas: &mut Canvas<T>, x: f32, y: f32, w: f32, 
             Color::hsla(a1 / (PI * 2.0), 1.0, 0.55, 1.0),
         );
 
-        canvas.fill_path(&mut path, &paint);
+        canvas.fill_path(&path, &paint);
     }
 
     let mut path = Path::new();
@@ -673,7 +673,7 @@ fn draw_colorwheel<T: Renderer>(canvas: &mut Canvas<T>, x: f32, y: f32, w: f32, 
     path.circle(cx, cy, r1 + 0.5);
     let mut paint = Paint::color(Color::rgba(0, 0, 0, 64));
     paint.set_line_width(1.0);
-    canvas.stroke_path(&mut path, &paint);
+    canvas.stroke_path(&path, &paint);
 
     // Selector
     canvas.save();
@@ -685,7 +685,7 @@ fn draw_colorwheel<T: Renderer>(canvas: &mut Canvas<T>, x: f32, y: f32, w: f32, 
     path.rect(r0 - 1.0, -3.0, r1 - r0 + 2.0, 6.0);
     paint = Paint::color(Color::rgba(255, 255, 255, 192));
     paint.set_line_width(2.0);
-    canvas.stroke_path(&mut path, &paint);
+    canvas.stroke_path(&path, &paint);
 
     paint = Paint::box_gradient(
         r0 - 3.0,
@@ -701,7 +701,7 @@ fn draw_colorwheel<T: Renderer>(canvas: &mut Canvas<T>, x: f32, y: f32, w: f32, 
     path.rect(r0 - 2.0 - 10.0, -4.0 - 10.0, r1 - r0 + 4.0 + 20.0, 8.0 + 20.0);
     path.rect(r0 - 2.0, -4.0, r1 - r0 + 4.0, 8.0);
     path.solidity(Solidity::Hole);
-    canvas.fill_path(&mut path, &paint);
+    canvas.fill_path(&path, &paint);
 
     // Center triangle
     let r = r0 - 6.0;
@@ -723,7 +723,7 @@ fn draw_colorwheel<T: Renderer>(canvas: &mut Canvas<T>, x: f32, y: f32, w: f32, 
         Color::hsla(hue, 1.0, 0.5, 1.0),
         Color::rgba(255, 255, 255, 255),
     );
-    canvas.fill_path(&mut path, &paint);
+    canvas.fill_path(&path, &paint);
     paint = Paint::linear_gradient(
         (r + ax) * 0.5,
         ay * 0.5,
@@ -732,9 +732,9 @@ fn draw_colorwheel<T: Renderer>(canvas: &mut Canvas<T>, x: f32, y: f32, w: f32, 
         Color::rgba(0, 0, 0, 0),
         Color::rgba(0, 0, 0, 255),
     );
-    canvas.fill_path(&mut path, &paint);
+    canvas.fill_path(&path, &paint);
     paint = Paint::color(Color::rgba(0, 0, 0, 64));
-    canvas.stroke_path(&mut path, &paint);
+    canvas.stroke_path(&path, &paint);
 
     // Select circle on triangle
     let ax = (120.0 / 180.0 * PI).cos() * r * 0.3;
@@ -743,14 +743,14 @@ fn draw_colorwheel<T: Renderer>(canvas: &mut Canvas<T>, x: f32, y: f32, w: f32, 
     paint.set_line_width(2.0);
     let mut path = Path::new();
     path.circle(ax, ay, 5.0);
-    canvas.stroke_path(&mut path, &paint);
+    canvas.stroke_path(&path, &paint);
 
     paint = Paint::radial_gradient(ax, ay, 7.0, 9.0, Color::rgba(0, 0, 0, 64), Color::rgba(0, 0, 0, 0));
     let mut path = Path::new();
     path.rect(ax - 20.0, ay - 20.0, 40.0, 40.0);
     path.circle(ax, ay, 7.0);
     path.solidity(Solidity::Hole);
-    canvas.fill_path(&mut path, &paint);
+    canvas.fill_path(&path, &paint);
 
     canvas.restore();
 
@@ -772,7 +772,7 @@ fn draw_search_box<T: Renderer>(canvas: &mut Canvas<T>, fonts: &Fonts, title: &s
     );
     let mut path = Path::new();
     path.rounded_rect(x, y, w, h, corner_radius);
-    canvas.fill_path(&mut path, &bg);
+    canvas.fill_path(&path, &bg);
 
     let mut text_paint = Paint::color(Color::rgba(255, 255, 255, 64));
     text_paint.set_font_size((h * 1.3).round());
@@ -802,11 +802,11 @@ fn draw_drop_down<T: Renderer>(canvas: &mut Canvas<T>, fonts: &Fonts, title: &st
     let bg = Paint::linear_gradient(x, y, x, y + h, Color::rgba(255, 255, 255, 16), Color::rgba(0, 0, 0, 16));
     let mut path = Path::new();
     path.rounded_rect(x + 1.0, y + 1.0, w - 2.0, h - 2.0, corner_radius);
-    canvas.fill_path(&mut path, &bg);
+    canvas.fill_path(&path, &bg);
 
     let mut path = Path::new();
     path.rounded_rect(x + 0.5, y + 0.5, w - 1.0, h - 1.0, corner_radius - 0.5);
-    canvas.stroke_path(&mut path, &Paint::color(Color::rgba(0, 0, 0, 48)));
+    canvas.stroke_path(&path, &Paint::color(Color::rgba(0, 0, 0, 48)));
 
     let mut text_paint = Paint::color(Color::rgba(255, 255, 255, 160));
     text_paint.set_font_size(16.0);
@@ -846,11 +846,11 @@ fn draw_edit_box_base<T: Renderer>(canvas: &mut Canvas<T>, x: f32, y: f32, w: f3
 
     let mut path = Path::new();
     path.rounded_rect(x + 1.0, y + 1.0, w - 2.0, h - 2.0, 3.0);
-    canvas.fill_path(&mut path, &paint);
+    canvas.fill_path(&path, &paint);
 
     let mut path = Path::new();
     path.rounded_rect(x + 0.5, y + 0.5, w - 1.0, h - 1.0, 3.5);
-    canvas.stroke_path(&mut path, &Paint::color(Color::rgba(0, 0, 0, 48)));
+    canvas.stroke_path(&path, &Paint::color(Color::rgba(0, 0, 0, 48)));
 }
 
 fn draw_edit_box<T: Renderer>(canvas: &mut Canvas<T>, fonts: &Fonts, title: &str, x: f32, y: f32, w: f32, h: f32) {
@@ -912,7 +912,7 @@ fn draw_check_box<T: Renderer>(canvas: &mut Canvas<T>, fonts: &Fonts, text: &str
     );
     let mut path = Path::new();
     path.rounded_rect(x + 1.0, y + (h * 0.5).floor() - 9.0, 18.0, 18.0, 3.0);
-    canvas.fill_path(&mut path, &paint);
+    canvas.fill_path(&path, &paint);
 
     paint = Paint::color(Color::rgba(255, 255, 255, 128));
     paint.set_font_size(36.0);
@@ -943,14 +943,14 @@ fn draw_button<T: Renderer>(
     path.rounded_rect(x + 1.0, y + 1.0, w - 2.0, h - 2.0, corner_radius - 1.0);
 
     if !color.is_black() {
-        canvas.fill_path(&mut path, &Paint::color(color));
+        canvas.fill_path(&path, &Paint::color(color));
     }
 
-    canvas.fill_path(&mut path, &bg);
+    canvas.fill_path(&path, &bg);
 
     let mut path = Path::new();
     path.rounded_rect(x + 0.5, y + 0.5, w - 1.0, h - 1.0, corner_radius - 0.5);
-    canvas.stroke_path(&mut path, &Paint::color(Color::rgba(0, 0, 0, 48)));
+    canvas.stroke_path(&path, &Paint::color(Color::rgba(0, 0, 0, 48)));
 
     let mut paint = Paint::color(Color::rgba(255, 255, 255, 96));
     paint.set_font_size(15.0);
@@ -1004,7 +1004,7 @@ fn draw_slider<T: Renderer>(canvas: &mut Canvas<T>, pos: f32, x: f32, y: f32, w:
     );
     let mut path = Path::new();
     path.rounded_rect(x, cy - 2.0, w, 4.0, 2.0);
-    canvas.fill_path(&mut path, &bg);
+    canvas.fill_path(&path, &bg);
 
     // Knob Shadow
     bg = Paint::radial_gradient(
@@ -1024,7 +1024,7 @@ fn draw_slider<T: Renderer>(canvas: &mut Canvas<T>, pos: f32, x: f32, y: f32, w:
     );
     path.circle(x + (pos * w).floor(), cy, kr);
     path.solidity(Solidity::Hole);
-    canvas.fill_path(&mut path, &bg);
+    canvas.fill_path(&path, &bg);
 
     // Knob
     bg = Paint::linear_gradient(
@@ -1037,12 +1037,12 @@ fn draw_slider<T: Renderer>(canvas: &mut Canvas<T>, pos: f32, x: f32, y: f32, w:
     );
     let mut path = Path::new();
     path.circle(x + (pos * w).floor(), cy, kr - 1.0);
-    canvas.fill_path(&mut path, &Paint::color(Color::rgba(40, 43, 48, 255)));
-    canvas.fill_path(&mut path, &bg);
+    canvas.fill_path(&path, &Paint::color(Color::rgba(40, 43, 48, 255)));
+    canvas.fill_path(&path, &bg);
 
     let mut path = Path::new();
     path.circle(x + (pos * w).floor(), cy, kr - 0.5);
-    canvas.stroke_path(&mut path, &Paint::color(Color::rgba(0, 0, 0, 92)));
+    canvas.stroke_path(&path, &Paint::color(Color::rgba(0, 0, 0, 92)));
 
     canvas.restore();
 }
@@ -1072,7 +1072,7 @@ fn draw_thumbnails<T: Renderer>(canvas: &mut Canvas<T>, x: f32, y: f32, w: f32, 
     path.rect(x - 10.0, y - 10.0, w + 20.0, h + 30.0);
     path.rounded_rect(x, y, w, h, corner_radius);
     path.solidity(Solidity::Hole);
-    canvas.fill_path(&mut path, &shadow_paint);
+    canvas.fill_path(&path, &shadow_paint);
 
     // Window
     let mut path = Path::new();
@@ -1080,7 +1080,7 @@ fn draw_thumbnails<T: Renderer>(canvas: &mut Canvas<T>, x: f32, y: f32, w: f32, 
     path.move_to(x - 10.0, y + arry);
     path.line_to(x + 1.0, y + arry - 11.0);
     path.line_to(x + 1.0, y + arry + 11.0);
-    canvas.fill_path(&mut path, &Paint::color(Color::rgba(200, 200, 200, 255)));
+    canvas.fill_path(&path, &Paint::color(Color::rgba(200, 200, 200, 255)));
 
     canvas.save();
     canvas.scissor(x, y, w, h);
@@ -1123,7 +1123,7 @@ fn draw_thumbnails<T: Renderer>(canvas: &mut Canvas<T>, x: f32, y: f32, w: f32, 
         let img_paint = Paint::image(*image, tx + ix, ty + iy, iw, ih, 0.0 / 180.0 * PI, a);
         let mut path = Path::new();
         path.rounded_rect(tx, ty, thumb, thumb, 5.0);
-        canvas.fill_path(&mut path, &img_paint);
+        canvas.fill_path(&path, &img_paint);
 
         let shadow_paint = Paint::box_gradient(
             tx - 1.0,
@@ -1139,11 +1139,11 @@ fn draw_thumbnails<T: Renderer>(canvas: &mut Canvas<T>, x: f32, y: f32, w: f32, 
         path.rect(tx - 5.0, ty - 5.0, thumb + 10.0, thumb + 10.0);
         path.rounded_rect(tx, ty, thumb, thumb, 6.0);
         path.solidity(Solidity::Hole);
-        canvas.fill_path(&mut path, &shadow_paint);
+        canvas.fill_path(&path, &shadow_paint);
 
         let mut path = Path::new();
         path.rounded_rect(tx + 0.5, ty + 0.5, thumb - 1.0, thumb - 1.0, 4.0 - 0.5);
-        canvas.stroke_path(&mut path, &Paint::color(Color::rgba(255, 255, 255, 192)));
+        canvas.stroke_path(&path, &Paint::color(Color::rgba(255, 255, 255, 192)));
     }
 
     canvas.restore();
@@ -1159,7 +1159,7 @@ fn draw_thumbnails<T: Renderer>(canvas: &mut Canvas<T>, x: f32, y: f32, w: f32, 
     );
     let mut path = Path::new();
     path.rect(x + 4.0, y, w - 8.0, 6.0);
-    canvas.fill_path(&mut path, &fade_paint);
+    canvas.fill_path(&path, &fade_paint);
 
     let fade_paint = Paint::linear_gradient(
         x,
@@ -1171,7 +1171,7 @@ fn draw_thumbnails<T: Renderer>(canvas: &mut Canvas<T>, x: f32, y: f32, w: f32, 
     );
     let mut path = Path::new();
     path.rect(x + 4.0, y + h - 6.0, w - 8.0, 6.0);
-    canvas.fill_path(&mut path, &fade_paint);
+    canvas.fill_path(&path, &fade_paint);
 
     // Scroll bar
     let shadow_paint = Paint::box_gradient(
@@ -1186,7 +1186,7 @@ fn draw_thumbnails<T: Renderer>(canvas: &mut Canvas<T>, x: f32, y: f32, w: f32, 
     );
     let mut path = Path::new();
     path.rounded_rect(x + w - 12.0, y + 4.0, 8.0, h - 8.0, 3.0);
-    canvas.fill_path(&mut path, &shadow_paint);
+    canvas.fill_path(&path, &shadow_paint);
 
     let scrollh = (h / stackh) * (h - 8.0);
     let shadow_paint = Paint::box_gradient(
@@ -1207,7 +1207,7 @@ fn draw_thumbnails<T: Renderer>(canvas: &mut Canvas<T>, x: f32, y: f32, w: f32, 
         scrollh - 2.0,
         2.0,
     );
-    canvas.fill_path(&mut path, &shadow_paint);
+    canvas.fill_path(&path, &shadow_paint);
 
     canvas.restore();
 }
@@ -1246,7 +1246,7 @@ fn draw_lines<T: Renderer>(canvas: &mut Canvas<T>, x: f32, y: f32, w: f32, _h: f
             path.line_to(fx + pts[2], fy + pts[3]);
             path.line_to(fx + pts[4], fy + pts[5]);
             path.line_to(fx + pts[6], fy + pts[7]);
-            canvas.stroke_path(&mut path, &paint);
+            canvas.stroke_path(&path, &paint);
 
             paint.set_line_cap(LineCap::Butt);
             paint.set_line_join(LineJoin::Bevel);
@@ -1258,7 +1258,7 @@ fn draw_lines<T: Renderer>(canvas: &mut Canvas<T>, x: f32, y: f32, w: f32, _h: f
             path.line_to(fx + pts[2], fy + pts[3]);
             path.line_to(fx + pts[4], fy + pts[5]);
             path.line_to(fx + pts[6], fy + pts[7]);
-            canvas.stroke_path(&mut path, &paint);
+            canvas.stroke_path(&path, &paint);
         }
     }
 
@@ -1280,11 +1280,11 @@ fn draw_fills<T: Renderer>(canvas: &mut Canvas<T>, x: f32, y: f32, mousex: f32, 
     path.line_to(79.0, 90.0);
     path.close();
 
-    if canvas.contains_point(&mut path, mousex, mousey, FillRule::EvenOdd) {
+    if canvas.contains_point(&path, mousex, mousey, FillRule::EvenOdd) {
         evenodd_fill.set_color(Color::rgb(220, 220, 220));
     }
 
-    canvas.fill_path(&mut path, &evenodd_fill);
+    canvas.fill_path(&path, &evenodd_fill);
 
     canvas.translate(100.0, 0.0);
 
@@ -1299,11 +1299,11 @@ fn draw_fills<T: Renderer>(canvas: &mut Canvas<T>, x: f32, y: f32, mousex: f32, 
     path.line_to(79.0, 90.0);
     path.close();
 
-    if canvas.contains_point(&mut path, mousex, mousey, FillRule::NonZero) {
+    if canvas.contains_point(&path, mousex, mousey, FillRule::NonZero) {
         nonzero_fill.set_color(Color::rgb(220, 220, 220));
     }
 
-    canvas.fill_path(&mut path, &nonzero_fill);
+    canvas.fill_path(&path, &nonzero_fill);
 
     canvas.restore();
 }
@@ -1319,7 +1319,7 @@ fn draw_widths<T: Renderer>(canvas: &mut Canvas<T>, x: f32, mut y: f32, width: f
         let mut path = Path::new();
         path.move_to(x, y);
         path.line_to(x + width, y + width * 0.3);
-        canvas.stroke_path(&mut path, &paint);
+        canvas.stroke_path(&path, &paint);
         y += 10.0;
     }
 
@@ -1334,11 +1334,11 @@ fn draw_caps<T: Renderer>(canvas: &mut Canvas<T>, x: f32, y: f32, width: f32) {
 
     let mut path = Path::new();
     path.rect(x - line_width / 2.0, y, width + line_width, 40.0);
-    canvas.fill_path(&mut path, &Paint::color(Color::rgba(255, 255, 255, 32)));
+    canvas.fill_path(&path, &Paint::color(Color::rgba(255, 255, 255, 32)));
 
     let mut path = Path::new();
     path.rect(x, y, width, 40.0);
-    canvas.fill_path(&mut path, &Paint::color(Color::rgba(255, 255, 255, 32)));
+    canvas.fill_path(&path, &Paint::color(Color::rgba(255, 255, 255, 32)));
 
     let mut paint = Paint::color(Color::rgba(0, 0, 0, 255));
     paint.set_line_width(line_width);
@@ -1348,7 +1348,7 @@ fn draw_caps<T: Renderer>(canvas: &mut Canvas<T>, x: f32, y: f32, width: f32) {
         let mut path = Path::new();
         path.move_to(x, y + i as f32 * 10.0 + 5.0);
         path.line_to(x + width, y + i as f32 * 10.0 + 5.0);
-        canvas.stroke_path(&mut path, &paint);
+        canvas.stroke_path(&path, &paint);
     }
 
     canvas.restore();
@@ -1363,7 +1363,7 @@ fn draw_scissor<T: Renderer>(canvas: &mut Canvas<T>, x: f32, y: f32, t: f32) {
 
     let mut path = Path::new();
     path.rect(-20.0, -20.0, 60.0, 40.0);
-    canvas.fill_path(&mut path, &Paint::color(Color::rgba(255, 0, 0, 255)));
+    canvas.fill_path(&path, &Paint::color(Color::rgba(255, 0, 0, 255)));
 
     canvas.scissor(-20.0, -20.0, 60.0, 40.0);
 
@@ -1376,13 +1376,13 @@ fn draw_scissor<T: Renderer>(canvas: &mut Canvas<T>, x: f32, y: f32, t: f32) {
     canvas.reset_scissor();
     let mut path = Path::new();
     path.rect(-20.0, -10.0, 60.0, 30.0);
-    canvas.fill_path(&mut path, &Paint::color(Color::rgba(255, 128, 0, 64)));
+    canvas.fill_path(&path, &Paint::color(Color::rgba(255, 128, 0, 64)));
     canvas.restore();
 
     // Draw second rectangle with scissoring.
     //canvas.intersect_scissor(-20.0, -10.0, 60.0, 30.0);
     path.rect(-20.0, -10.0, 60.0, 30.0);
-    canvas.fill_path(&mut path, &Paint::color(Color::rgba(255, 128, 0, 255)));
+    canvas.fill_path(&path, &Paint::color(Color::rgba(255, 128, 0, 255)));
 
     canvas.restore();
 }
@@ -1406,7 +1406,7 @@ fn draw_spinner<T: Renderer>(canvas: &mut Canvas<T>, cx: f32, cy: f32, r: f32, t
     let by = cy + a1.sin() * (r0 + r1) * 0.5;
 
     let paint = Paint::linear_gradient(ax, ay, bx, by, Color::rgba(0, 0, 0, 0), Color::rgba(0, 0, 0, 128));
-    canvas.fill_path(&mut path, &paint);
+    canvas.fill_path(&path, &paint);
 
     canvas.restore();
 }

--- a/examples/helpers/perf_graph.rs
+++ b/examples/helpers/perf_graph.rs
@@ -34,7 +34,7 @@ impl PerfGraph {
 
         let mut path = Path::new();
         path.rect(x, y, w, h);
-        canvas.fill_path(&mut path, &Paint::color(Color::rgba(0, 0, 0, 128)));
+        canvas.fill_path(&path, &Paint::color(Color::rgba(0, 0, 0, 128)));
 
         let mut path = Path::new();
         path.move_to(x, y + h);
@@ -50,7 +50,7 @@ impl PerfGraph {
         }
 
         path.line_to(x + w, y + h);
-        canvas.fill_path(&mut path, &Paint::color(Color::rgba(255, 192, 0, 128)));
+        canvas.fill_path(&path, &Paint::color(Color::rgba(255, 192, 0, 128)));
 
         let mut text_paint = Paint::color(Color::rgba(240, 240, 240, 255));
         text_paint.set_font_size(12.0);

--- a/examples/paint_filter.rs
+++ b/examples/paint_filter.rs
@@ -98,7 +98,7 @@ fn run(
 
                     // Get the bounding box of the path so that we can stretch
                     // the paint to cover it exactly:
-                    let bbox = canvas.path_bbox(&mut path);
+                    let bbox = canvas.path_bbox(&path);
 
                     // Now we need to apply the current canvas transform
                     // to the path bbox:
@@ -106,7 +106,7 @@ fn run(
                     let b = canvas.transform().inversed().transform_point(bbox.maxx, bbox.maxy);
 
                     canvas.fill_path(
-                        &mut path,
+                        &path,
                         &Paint::image(filtered_image.unwrap(), a.0, a.1, b.0 - a.0, b.1 - a.1, 0f32, 1f32),
                     );
                 }

--- a/examples/paint_image.rs
+++ b/examples/paint_image.rs
@@ -196,7 +196,7 @@ fn run(
 
                     // Get the bounding box of the path so that we can stretch
                     // the paint to cover it exactly:
-                    let bbox = canvas.path_bbox(&mut path);
+                    let bbox = canvas.path_bbox(&path);
 
                     // Now we need to apply the current canvas transform
                     // to the path bbox:
@@ -204,7 +204,7 @@ fn run(
                     let b = canvas.transform().inversed().transform_point(bbox.maxx, bbox.maxy);
 
                     canvas.fill_path(
-                        &mut path,
+                        &path,
                         &Paint::image(image_id, a.0, a.1, b.0 - a.0, b.1 - a.1, 0f32, 1f32),
                     );
                 }

--- a/examples/shader.rs
+++ b/examples/shader.rs
@@ -133,7 +133,7 @@ fn main() {
                 let paint = Paint::color(Color::rgbf(1., 0., 0.));
                 let mut path = Path::new();
                 path.rect(WINDOW_WIDTH / 2. - 25., WINDOW_HEIGHT / 2. - 25., 50., 50.);
-                canvas.fill_path(&mut path, &paint);
+                canvas.fill_path(&path, &paint);
                 canvas.restore();
 
                 canvas.flush();

--- a/examples/svg.rs
+++ b/examples/svg.rs
@@ -53,7 +53,7 @@ fn run(
     let svg_data = include_str!("assets/Ghostscript_Tiger.svg").as_bytes();
     let tree = usvg::Tree::from_data(svg_data, &usvg::Options::default()).unwrap();
 
-    let mut paths = render_svg(tree);
+    let paths = render_svg(tree);
 
     // print memory usage
     let mut total_sisze_bytes = 0;
@@ -148,14 +148,12 @@ fn run(
                 canvas.save();
                 canvas.translate(200.0, 200.0);
 
-                for (path, fill, stroke) in &mut paths {
+                for (path, fill, stroke) in &paths {
                     if let Some(fill) = fill {
-                        fill.set_anti_alias(true);
                         canvas.fill_path(path, fill);
                     }
 
                     if let Some(stroke) = stroke {
-                        stroke.set_anti_alias(true);
                         canvas.stroke_path(path, stroke);
                     }
 
@@ -213,12 +211,13 @@ fn render_svg(svg: usvg::Tree) -> Vec<(Path, Option<Paint>, Option<Paint>)> {
                 .fill
                 .as_ref()
                 .and_then(|fill| to_femto_color(&fill.paint))
-                .map(Paint::color);
+                .map(|col| Paint::color(col).with_anti_alias(true));
 
             let stroke = svg_path.stroke.as_ref().and_then(|stroke| {
                 to_femto_color(&stroke.paint).map(|paint| {
                     let mut stroke_paint = Paint::color(paint);
                     stroke_paint.set_line_width(stroke.width.get() as f32);
+                    stroke_paint.set_anti_alias(true);
                     stroke_paint
                 })
             });

--- a/examples/text.rs
+++ b/examples/text.rs
@@ -239,7 +239,7 @@ fn draw_baselines<T: Renderer>(
         let mut path = Path::new();
         path.move_to(x, y + 0.5);
         path.line_to(x + 250., y + 0.5);
-        canvas.stroke_path(&mut path, &Paint::color(Color::rgba(255, 32, 32, 128)));
+        canvas.stroke_path(&path, &Paint::color(Color::rgba(255, 32, 32, 128)));
 
         paint.set_text_baseline(*baseline);
 
@@ -248,7 +248,7 @@ fn draw_baselines<T: Renderer>(
 
             let mut path = Path::new();
             path.rect(res.x, res.y, res.width(), res.height());
-            canvas.stroke_path(&mut path, &Paint::color(Color::rgba(100, 100, 100, 64)));
+            canvas.stroke_path(&path, &Paint::color(Color::rgba(100, 100, 100, 64)));
         }
     }
 }
@@ -259,7 +259,7 @@ fn draw_alignments<T: Renderer>(canvas: &mut Canvas<T>, fonts: &Fonts, x: f32, y
     let mut path = Path::new();
     path.move_to(x + 0.5, y - 20.);
     path.line_to(x + 0.5, y + 80.);
-    canvas.stroke_path(&mut path, &Paint::color(Color::rgba(255, 32, 32, 128)));
+    canvas.stroke_path(&path, &Paint::color(Color::rgba(255, 32, 32, 128)));
 
     let mut paint = Paint::color(Color::black());
     paint.set_font(&[fonts.sans]);
@@ -271,7 +271,7 @@ fn draw_alignments<T: Renderer>(canvas: &mut Canvas<T>, fonts: &Fonts, x: f32, y
         if let Ok(res) = canvas.fill_text(x, y + i as f32 * 30.0, format!("Align::{alignment:?}"), &paint) {
             let mut path = Path::new();
             path.rect(res.x, res.y, res.width(), res.height());
-            canvas.stroke_path(&mut path, &Paint::color(Color::rgba(100, 100, 100, 64)));
+            canvas.stroke_path(&path, &Paint::color(Color::rgba(100, 100, 100, 64)));
         }
     }
 }
@@ -375,7 +375,7 @@ fn draw_image_fill<T: Renderer>(canvas: &mut Canvas<T>, fonts: &Fonts, x: f32, y
     let mut path = Path::new();
     path.move_to(x, y - 2.0);
     path.line_to(x + 180.0, y - 2.0);
-    canvas.stroke_path(&mut path, &paint);
+    canvas.stroke_path(&path, &paint);
 
     let text = "RUST";
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -791,7 +791,7 @@ where
     // Paths
 
     /// Returns true if the specified point (x,y) is in the provided path, and false otherwise.
-    pub fn contains_point(&self, path: &mut Path, x: f32, y: f32, fill_rule: FillRule) -> bool {
+    pub fn contains_point(&self, path: &Path, x: f32, y: f32, fill_rule: FillRule) -> bool {
         let transform = self.state().transform;
 
         // The path cache saves a flattened and transformed version of the path.
@@ -810,7 +810,7 @@ where
     }
 
     /// Return the bounding box for a Path
-    pub fn path_bbox(&self, path: &mut Path) -> Bounds {
+    pub fn path_bbox(&self, path: &Path) -> Bounds {
         let transform = self.state().transform;
 
         // The path cache saves a flattened and transformed version of the path.
@@ -820,22 +820,16 @@ where
     }
 
     /// Fills the provided Path with the specified Paint.
-    pub fn fill_path(&mut self, path: &mut Path, paint: &Paint) {
+    pub fn fill_path(&mut self, path: &Path, paint: &Paint) {
         self.fill_path_internal(path, &paint.flavor, paint.shape_anti_alias, paint.fill_rule);
     }
 
-    fn fill_path_internal(
-        &mut self,
-        path: &mut Path,
-        paint_flavor: &PaintFlavor,
-        anti_alias: bool,
-        fill_rule: FillRule,
-    ) {
+    fn fill_path_internal(&mut self, path: &Path, paint_flavor: &PaintFlavor, anti_alias: bool, fill_rule: FillRule) {
         let mut paint_flavor = paint_flavor.clone();
         let transform = self.state().transform;
 
         // The path cache saves a flattened and transformed version of the path.
-        let path_cache = path.cache(&transform, self.tess_tol, self.dist_tol);
+        let mut path_cache = path.cache(&transform, self.tess_tol, self.dist_tol);
 
         let canvas_width = self.width();
         let canvas_height = self.height();
@@ -992,13 +986,13 @@ where
     }
 
     /// Strokes the provided Path with the specified Paint.
-    pub fn stroke_path(&mut self, path: &mut Path, paint: &Paint) {
+    pub fn stroke_path(&mut self, path: &Path, paint: &Paint) {
         self.stroke_path_internal(path, &paint.flavor, paint.shape_anti_alias, &paint.stroke);
     }
 
     fn stroke_path_internal(
         &mut self,
-        path: &mut Path,
+        path: &Path,
         paint_flavor: &PaintFlavor,
         anti_alias: bool,
         stroke: &StrokeSettings,
@@ -1007,7 +1001,7 @@ where
         let transform = self.state().transform;
 
         // The path cache saves a flattened and transformed version of the path.
-        let path_cache = path.cache(&transform, self.tess_tol, self.dist_tol);
+        let mut path_cache = path.cache(&transform, self.tess_tol, self.dist_tol);
 
         // Early out if path is outside the canvas bounds
         if path_cache.bounds.maxx < 0.0
@@ -1473,7 +1467,7 @@ where
             let height = size.1 as f32;
             let mut path = Path::new();
             path.rect(0f32, 0f32, width, height);
-            self.fill_path(&mut path, &Paint::image(id, 0f32, 0f32, width, height, 0f32, 1f32));
+            self.fill_path(&path, &Paint::image(id, 0f32, 0f32, width, height, 0f32, 1f32));
         }
     }
 }

--- a/src/paint.rs
+++ b/src/paint.rs
@@ -306,8 +306,8 @@ impl Default for TextSettings {
 ///
 /// let mut path = Path::new();
 /// path.rounded_rect(10.0, 10.0, 100.0, 100.0, 20.0);
-/// canvas.fill_path(&mut path, &fill_paint);
-/// canvas.stroke_path(&mut path, &stroke_paint);
+/// canvas.fill_path(&path, &fill_paint);
+/// canvas.stroke_path(&path, &stroke_paint);
 /// ```
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
@@ -363,7 +363,7 @@ impl Paint {
     ///
     /// let mut path = Path::new();
     /// path.rect(10.0, 10.0, 85.0, 85.0);
-    /// canvas.fill_path(&mut path, &fill_paint);
+    /// canvas.fill_path(&path, &fill_paint);
     /// ```
     pub fn image(id: ImageId, cx: f32, cy: f32, width: f32, height: f32, angle: f32, alpha: f32) -> Self {
         Paint::with_flavor(PaintFlavor::Image {
@@ -402,7 +402,7 @@ impl Paint {
     /// let bg = Paint::linear_gradient(0.0, 0.0, 0.0, 100.0, Color::rgba(255, 255, 255, 16), Color::rgba(0, 0, 0, 16));
     /// let mut path = Path::new();
     /// path.rounded_rect(0.0, 0.0, 100.0, 100.0, 5.0);
-    /// canvas.fill_path(&mut path, &bg);
+    /// canvas.fill_path(&path, &bg);
     /// ```
     pub fn linear_gradient(
         start_x: f32,
@@ -438,7 +438,7 @@ impl Paint {
     ///    ]);
     /// let mut path = Path::new();
     /// path.rounded_rect(0.0, 0.0, 100.0, 100.0, 5.0);
-    /// canvas.fill_path(&mut path, &bg);
+    /// canvas.fill_path(&path, &bg);
     /// ```
     pub fn linear_gradient_stops(
         start_x: f32,
@@ -482,7 +482,7 @@ impl Paint {
     ///
     /// let mut path = Path::new();
     /// path.rounded_rect(0.0, 0.0, 100.0, 100.0, 5.0);
-    /// canvas.fill_path(&mut path, &bg);
+    /// canvas.fill_path(&path, &bg);
     /// ```
     pub fn box_gradient(
         x: f32,
@@ -530,7 +530,7 @@ impl Paint {
     ///
     /// let mut path = Path::new();
     /// path.circle(50.0, 50.0, 20.0);
-    /// canvas.fill_path(&mut path, &bg);
+    /// canvas.fill_path(&path, &bg);
     /// ```
     pub fn radial_gradient(
         cx: f32,
@@ -578,7 +578,7 @@ impl Paint {
     ///
     /// let mut path = Path::new();
     /// path.circle(50.0, 50.0, 20.0);
-    /// canvas.fill_path(&mut path, &bg);
+    /// canvas.fill_path(&path, &bg);
     /// ```
     pub fn radial_gradient_stops(
         cx: f32,

--- a/src/text.rs
+++ b/src/text.rs
@@ -1,4 +1,5 @@
 use std::{
+    borrow::Borrow,
     cell::RefCell,
     ffi::OsStr,
     fs,
@@ -1278,7 +1279,7 @@ pub(crate) fn render_direct<T: Renderer>(
             GlyphRendering::RenderAsPath(path) => {
                 if mode == RenderMode::Stroke {
                     canvas.stroke_path_internal(
-                        path,
+                        path.borrow(),
                         paint_flavor,
                         anti_alias,
                         &StrokeSettings {
@@ -1287,7 +1288,7 @@ pub(crate) fn render_direct<T: Renderer>(
                         },
                     );
                 } else {
-                    canvas.fill_path_internal(path, paint_flavor, anti_alias, FillRule::EvenOdd);
+                    canvas.fill_path_internal(path.borrow(), paint_flavor, anti_alias, FillRule::EvenOdd);
                 }
             }
             #[cfg(feature = "image-loading")]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -6,8 +6,8 @@ fn path_with_single_move_to() {
 
     let mut path = Path::new();
     path.move_to(10.0, 10.0);
-    canvas.fill_path(&mut path, &Paint::color(Color::rgb(100, 100, 100)));
-    canvas.stroke_path(&mut path, &Paint::color(Color::rgb(100, 100, 100)));
+    canvas.fill_path(&path, &Paint::color(Color::rgb(100, 100, 100)));
+    canvas.stroke_path(&path, &Paint::color(Color::rgb(100, 100, 100)));
 }
 
 #[test]
@@ -17,8 +17,8 @@ fn path_with_two_lines() {
     let mut path = Path::new();
     path.line_to(10.0, 10.0);
     path.line_to(10.0, 10.0);
-    canvas.fill_path(&mut path, &Paint::color(Color::rgb(100, 100, 100)));
-    canvas.stroke_path(&mut path, &Paint::color(Color::rgb(100, 100, 100)));
+    canvas.fill_path(&path, &Paint::color(Color::rgb(100, 100, 100)));
+    canvas.stroke_path(&path, &Paint::color(Color::rgb(100, 100, 100)));
 }
 
 #[test]
@@ -29,8 +29,8 @@ fn path_with_close_points() {
     path.move_to(10.0, 10.0);
     path.line_to(10.0001, 10.0);
     path.line_to(10.0001, 10.000001);
-    canvas.fill_path(&mut path, &Paint::color(Color::rgb(100, 100, 100)));
-    canvas.stroke_path(&mut path, &Paint::color(Color::rgb(100, 100, 100)));
+    canvas.fill_path(&path, &Paint::color(Color::rgb(100, 100, 100)));
+    canvas.stroke_path(&path, &Paint::color(Color::rgb(100, 100, 100)));
 }
 
 #[test]
@@ -54,8 +54,8 @@ fn path_with_points_at_limits() {
     );
     path.close();
 
-    canvas.fill_path(&mut path, &Paint::color(Color::rgb(100, 100, 100)));
-    canvas.stroke_path(&mut path, &Paint::color(Color::rgb(100, 100, 100)));
+    canvas.fill_path(&path, &Paint::color(Color::rgb(100, 100, 100)));
+    canvas.stroke_path(&path, &Paint::color(Color::rgb(100, 100, 100)));
 }
 
 #[test]
@@ -81,8 +81,8 @@ fn path_with_points_around_zero() {
 
     path.close();
 
-    canvas.fill_path(&mut path, &Paint::color(Color::rgb(100, 100, 100)));
-    canvas.stroke_path(&mut path, &Paint::color(Color::rgb(100, 100, 100)));
+    canvas.fill_path(&path, &Paint::color(Color::rgb(100, 100, 100)));
+    canvas.stroke_path(&path, &Paint::color(Color::rgb(100, 100, 100)));
 }
 
 #[test]
@@ -94,7 +94,7 @@ fn degenerate_stroke() {
     path.line_to(2., 2.);
     path.line_to(2., 2.);
     path.line_to(4., 2.);
-    canvas.stroke_path(&mut path, &Paint::color(Color::rgb(100, 100, 100)));
+    canvas.stroke_path(&path, &Paint::color(Color::rgb(100, 100, 100)));
 }
 
 #[test]
@@ -104,8 +104,8 @@ fn degenerate_arc_to() {
     let mut path = Path::new();
     path.move_to(10.0, 10.0);
     path.arc_to(10.0, 10.0001, 10.0, 10.0001, 2.0);
-    canvas.fill_path(&mut path, &Paint::color(Color::rgb(100, 100, 100)));
-    canvas.stroke_path(&mut path, &Paint::color(Color::rgb(100, 100, 100)));
+    canvas.fill_path(&path, &Paint::color(Color::rgb(100, 100, 100)));
+    canvas.stroke_path(&path, &Paint::color(Color::rgb(100, 100, 100)));
 }
 
 #[test]
@@ -116,8 +116,8 @@ fn degenerate_arc() {
     path.move_to(10.0, 10.0);
     path.arc(10.0, 10.0, 10.0, 0.0, std::f32::MAX, Solidity::Hole);
 
-    canvas.fill_path(&mut path, &Paint::color(Color::rgb(100, 100, 100)));
-    canvas.stroke_path(&mut path, &Paint::color(Color::rgb(100, 100, 100)));
+    canvas.fill_path(&path, &Paint::color(Color::rgb(100, 100, 100)));
+    canvas.stroke_path(&path, &Paint::color(Color::rgb(100, 100, 100)));
 }
 
 #[test]
@@ -136,12 +136,12 @@ fn path_contains_point() {
     path.close();
 
     // Center of the star should be hollow for even-odd rule
-    assert!(!canvas.contains_point(&mut path, 50.0, 45.0, FillRule::EvenOdd));
-    assert!(canvas.contains_point(&mut path, 50.0, 5.0, FillRule::EvenOdd));
+    assert!(!canvas.contains_point(&path, 50.0, 45.0, FillRule::EvenOdd));
+    assert!(canvas.contains_point(&path, 50.0, 5.0, FillRule::EvenOdd));
 
     // Center of the star should be fill for NonZero rule
-    assert!(canvas.contains_point(&mut path, 50.0, 45.0, FillRule::NonZero));
-    assert!(canvas.contains_point(&mut path, 50.0, 5.0, FillRule::NonZero));
+    assert!(canvas.contains_point(&path, 50.0, 45.0, FillRule::NonZero));
+    assert!(canvas.contains_point(&path, 50.0, 5.0, FillRule::NonZero));
 }
 
 #[test]


### PR DESCRIPTION
With the two parent changes, it's now possible to hold a `&Font` and a
`rustybuzz::Face<'_>` that in turn references data from the `&Font`,
while populating the glyph cache at the same time, using interior
mutability. That way we can remove ouroboros and create the face on the
fly. For shaping it's crated once for all glyphs (faster), but for the
direct rendering we unfortunately have to create it once per glyph.
That's technically slower than the face that was cached in the `Font`
all time time, but it might be acceptable in exchange for a lighter
build and lower memory usage - especially in the light that direct
rendering is rather slow anyway (should be the exception).