### PR TITLE
Fix image blit fast path

### DIFF
--- a/src/path.rs
+++ b/src/path.rs
@@ -326,7 +326,7 @@ impl Path {
                 let br = tr + voffset;
                 let bl = tl + voffset;
 
-                [tl, tr, br, bl]
+                [tl, bl, br, tr]
             },
         );
     }

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -56,6 +56,7 @@ pub enum CommandType {
     },
 }
 
+#[derive(Debug)]
 pub struct Command {
     pub(crate) cmd_type: CommandType,
     pub(crate) drawables: Vec<Drawable>,


### PR DESCRIPTION
The optimization introduced in 609bc2cdf3480d2226207bc502de0ba511b66ff6 relied on rect() to produce vertices in a specific order. Commit 9a021e4eb03319ef42c42a26a6bda60ce4324e35 accidentally changed that.

This patch restores the previous order and adds a test that this command is produce in at least one scenario.