### PR TITLE
Add method for retrieving the native texture of an image

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -16,7 +16,7 @@ pub enum ErrorKind {
     IoError(io::Error),
     FontParseError,
     NoFontFound,
-    FontInfoExtracionError,
+    FontInfoExtractionError,
     FontSizeTooLargeForAtlas,
     ShaderCompileError(String),
     ShaderLinkError(String),
@@ -24,7 +24,7 @@ pub enum ErrorKind {
     ImageIdNotFound,
     ImageUpdateOutOfBounds,
     ImageUpdateWithDifferentFormat,
-    UnsuportedImageFromat,
+    UnsupportedImageFormat,
 }
 
 impl Display for ErrorKind {

--- a/src/image.rs
+++ b/src/image.rs
@@ -118,7 +118,7 @@ impl<'a> TryFrom<&'a DynamicImage> for ImageSource<'a> {
             }
             // TODO: if format is not supported maybe we should convert it here,
             // But that is an expensive operation on the render thread that will remain hidden from the user
-            _ => Err(ErrorKind::UnsuportedImageFromat),
+            _ => Err(ErrorKind::UnsupportedImageFormat),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -551,9 +551,11 @@ where
         Ok(id)
     }
 
-    pub fn get_native_texture(&self, id: ImageId) -> Option<T::NativeTexture> {
+    /// Returns the native texture of an image given its ID.
+    pub fn get_native_texture(&self, id: ImageId) -> Result<T::NativeTexture, ErrorKind> {
         self.get_image(id)
-            .and_then(|image| self.renderer.get_native_texture(image).ok())
+            .ok_or(ErrorKind::ImageIdNotFound)
+            .and_then(|image| self.renderer.get_native_texture(image))
     }
 
     pub fn get_image(&self, id: ImageId) -> Option<&T::Image> {
@@ -1512,10 +1514,6 @@ impl Renderer for RecordingRenderer {
         *self.last_commands.borrow_mut() = commands;
     }
 
-    fn get_native_texture(&self, image: &Self::Image) -> Result<Self::NativeTexture, ErrorKind> {
-        Ok(())
-    }
-
     fn alloc_image(&mut self, info: crate::ImageInfo) -> Result<Self::Image, ErrorKind> {
         Ok(Self::Image { info })
     }
@@ -1525,7 +1523,7 @@ impl Renderer for RecordingRenderer {
         _native_texture: Self::NativeTexture,
         _info: crate::ImageInfo,
     ) -> Result<Self::Image, ErrorKind> {
-        Err(ErrorKind::UnsuportedImageFromat)
+        Err(ErrorKind::UnsupportedImageFormat)
     }
 
     fn update_image(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -551,6 +551,11 @@ where
         Ok(id)
     }
 
+    pub fn get_native_texture(&self, id: ImageId) -> Option<T::NativeTexture> {
+        self.get_image(id)
+            .and_then(|image| self.renderer.get_native_texture(image).ok())
+    }
+
     pub fn get_image(&self, id: ImageId) -> Option<&T::Image> {
         self.images.get(id)
     }
@@ -1505,6 +1510,10 @@ impl Renderer for RecordingRenderer {
         commands: Vec<renderer::Command>,
     ) {
         *self.last_commands.borrow_mut() = commands;
+    }
+
+    fn get_native_texture(&self, image: &Self::Image) -> Result<Self::NativeTexture, ErrorKind> {
+        Ok(())
     }
 
     fn alloc_image(&mut self, info: crate::ImageInfo) -> Result<Self::Image, ErrorKind> {

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -104,7 +104,10 @@ pub trait Renderer {
     ) -> Result<Self::Image, ErrorKind>;
     fn update_image(&mut self, image: &mut Self::Image, data: ImageSource, x: usize, y: usize)
         -> Result<(), ErrorKind>;
-    fn get_native_texture(&self, image: &Self::Image) -> Result<Self::NativeTexture, ErrorKind>;
+    #[allow(unused_variables)]
+    fn get_native_texture(&self, image: &Self::Image) -> Result<Self::NativeTexture, ErrorKind> {
+        Err(ErrorKind::UnsupportedImageFormat)
+    }
     fn delete_image(&mut self, image: Self::Image, image_id: ImageId);
 
     fn screenshot(&mut self) -> Result<ImgVec<RGBA8>, ErrorKind>;

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -104,6 +104,7 @@ pub trait Renderer {
     ) -> Result<Self::Image, ErrorKind>;
     fn update_image(&mut self, image: &mut Self::Image, data: ImageSource, x: usize, y: usize)
         -> Result<(), ErrorKind>;
+    fn get_native_texture(&self, image: &Self::Image) -> Result<Self::NativeTexture, ErrorKind>;
     fn delete_image(&mut self, image: Self::Image, image_id: ImageId);
 
     fn screenshot(&mut self) -> Result<ImgVec<RGBA8>, ErrorKind>;

--- a/src/renderer/opengl.rs
+++ b/src/renderer/opengl.rs
@@ -687,6 +687,10 @@ impl Renderer for OpenGl {
         }
     }
 
+    fn get_native_texture(&self, image: &Self::Image) -> Result<Self::NativeTexture, ErrorKind> {
+        Ok(image.id())
+    }
+
     fn render(&mut self, images: &mut ImageStore<Self::Image>, verts: &[Vertex], commands: Vec<Command>) {
         self.current_program = 0;
         self.main_program().bind();

--- a/src/renderer/void.rs
+++ b/src/renderer/void.rs
@@ -18,6 +18,10 @@ impl Renderer for Void {
 
     fn render(&mut self, images: &mut ImageStore<VoidImage>, verts: &[Vertex], commands: Vec<Command>) {}
 
+    fn get_native_texture(&self, image: &Self::Image) -> Result<Self::NativeTexture, ErrorKind> {
+        Ok(())
+    }
+
     fn alloc_image(&mut self, info: ImageInfo) -> Result<Self::Image, ErrorKind> {
         Ok(VoidImage { info })
     }

--- a/src/renderer/void.rs
+++ b/src/renderer/void.rs
@@ -18,10 +18,6 @@ impl Renderer for Void {
 
     fn render(&mut self, images: &mut ImageStore<VoidImage>, verts: &[Vertex], commands: Vec<Command>) {}
 
-    fn get_native_texture(&self, image: &Self::Image) -> Result<Self::NativeTexture, ErrorKind> {
-        Ok(())
-    }
-
     fn alloc_image(&mut self, info: ImageInfo) -> Result<Self::Image, ErrorKind> {
         Ok(VoidImage { info })
     }
@@ -31,7 +27,7 @@ impl Renderer for Void {
         _native_texture: Self::NativeTexture,
         _info: ImageInfo,
     ) -> Result<Self::Image, ErrorKind> {
-        Err(ErrorKind::UnsuportedImageFromat)
+        Err(ErrorKind::UnsupportedImageFormat)
     }
 
     fn update_image(


### PR DESCRIPTION
I'm using this for sharing textures between windows in a multi-window setup. The texture can be created and managed by the main window canvas and then this method (`get_native_texture`)  can be used to get the native texture, which can then be used with `create_image_from_native_texture` for the canvases of the  subwindows. This avoids needing to create the native texture manually, which avoids needing to import glow. 