### PR TITLE
Fix to use log crates for logging

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ lru = { version = "0.12.0", default-features = false }
 image = { version = "0.24.0", optional = true, default-features = false }
 serde = { version = "1.0", optional = true, features = ["derive", "rc"] }
 glow = { version = "0.13.0", default-features = false }
+log = "0.4"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 glutin = { version = "0.30.3", optional = true, default-features = false }

--- a/examples/paint_image.rs
+++ b/examples/paint_image.rs
@@ -89,7 +89,7 @@ fn run(
     let mut shape = Shape::Rect;
     let mut time_warp = 0;
 
-    eprintln!("Scroll vertically to change zoom, horizontally (or vertically with Shift) to change time warp, click to cycle shape.");
+    log::error!("Scroll vertically to change zoom, horizontally (or vertically with Shift) to change time warp, click to cycle shape.");
 
     let mut swap_directions = false;
 

--- a/examples/svg.rs
+++ b/examples/svg.rs
@@ -62,7 +62,7 @@ fn run(
         total_sisze_bytes += path.0.size();
     }
 
-    println!("Path mem usage: {}kb", total_sisze_bytes / 1024);
+    log::info!("Path mem usage: {}kb", total_sisze_bytes / 1024);
 
     el.run(move |event, _, control_flow| {
         *control_flow = ControlFlow::Poll;

--- a/src/path/cache.rs
+++ b/src/path/cache.rs
@@ -1158,7 +1158,7 @@ fn main() {
     let mut iter = MutStridedChunks::new(&mut my_array);
 
     while let Some(subslice) = iter.next() {
-        println!("{:?}", subslice);
+        log::info!("{:?}", subslice);
     }
 }
 */

--- a/src/renderer/opengl.rs
+++ b/src/renderer/opengl.rs
@@ -215,7 +215,7 @@ impl OpenGl {
             _ => "Unknown error",
         };
 
-        eprintln!("({err}) Error on {label} - {message}");
+        log::error!("({err}) Error on {label} - {message}");
     }
 
     fn gl_factor(factor: BlendFactor) -> u32 {


### PR DESCRIPTION
Thanks for the great crate.

I am using this crate on macOS and GTK4 and femtovg outputs a lot of errors to stderr when I resize windows and such.
For me this behavior is causing me to miss other important logs.

Therefore, this PR will be changed to use the `log` crate, which allows you to adjust the log output.


https://github.com/femtovg/femtovg/assets/1794232/0d26091b-b1b0-4a45-bc96-1eeaa3ec00c7

