### PR TITLE
Require WebGL 2 for WASM builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to this project will be documented in this file.
  - **breaking**: Removed pub key field in ImageId. This accidentally
    exposed the implementation detail of the image store (generational-arena),
    which has been replaced with slotmap.
+ - For WASM builds, require WebGL 2. This is supported by all major browsers
+   and needed to make `ImageFlags::REPEAT_X/Y` work.
  - Bumped MSRV to 1.66.
 
 ## [0.8.2] - 2024-01-20

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ glutin = { version = "0.30.3", optional = true, default-features = false }
 web_sys = { version = "0.3", package = "web-sys", features = [
     "WebGlContextAttributes",
     "HtmlImageElement",
+    "WebGl2RenderingContext",
 ] }
 wasm-bindgen = "0.2"
 

--- a/src/renderer/opengl.rs
+++ b/src/renderer/opengl.rs
@@ -89,16 +89,16 @@ impl OpenGl {
         attrs.antialias(false);
 
         use wasm_bindgen::JsCast;
-        let webgl1_context = match canvas.get_context_with_context_options("webgl", &attrs) {
-            Ok(Some(context)) => context.dyn_into::<web_sys::WebGlRenderingContext>().unwrap(),
+        let webgl2_context = match canvas.get_context_with_context_options("webgl2", &attrs) {
+            Ok(Some(context)) => context.dyn_into::<web_sys::WebGl2RenderingContext>().unwrap(),
             _ => {
                 return Err(ErrorKind::GeneralError(
-                    "Canvas::getContext failed to retrieve WebGL 1 context".to_owned(),
+                    "Canvas::getContext failed to retrieve WebGL 2 context".to_owned(),
                 ))
             }
         };
 
-        let context = glow::Context::from_webgl1_context(webgl1_context);
+        let context = glow::Context::from_webgl2_context(webgl2_context);
         Self::new_from_context(context, true)
     }
 


### PR DESCRIPTION
WebGL 2 is supported by all major browsers nowadays (even Safari). ImageFlags::REPEAT_X seems to not work with WebGL1 and causes mis-rendering (see by changing examples/demo.rs to use that instead of ImageFlags::empty()).