### PR TITLE
Fix glyph overlap clipping

### DIFF
--- a/src/text.rs
+++ b/src/text.rs
@@ -1113,7 +1113,7 @@ impl GlyphAtlas {
                             },
                         );
                     } else {
-                        canvas.fill_path_internal(path, &PaintFlavor::Color(mask_color), false, FillRule::EvenOdd);
+                        canvas.fill_path_internal(path, &PaintFlavor::Color(mask_color), false, FillRule::NonZero);
                     }
 
                     canvas.restore();
@@ -1297,7 +1297,7 @@ pub fn render_direct<T: Renderer>(
                         },
                     );
                 } else {
-                    canvas.fill_path_internal(path.borrow(), paint_flavor, anti_alias, FillRule::EvenOdd);
+                    canvas.fill_path_internal(path.borrow(), paint_flavor, anti_alias, FillRule::NonZero);
                 }
             }
             #[cfg(feature = "image-loading")]


### PR DESCRIPTION
Fixes #183

Text was being rendered with wrong winding rule which caused overlapping glyph paths to create holes inside itself.

The issue is easily reproduced by using Inter font as described in #183 by swapping it for Roboto in demo example but applies to other fonts which are designed that way. The issue is most noticeable when zooming on text in demo (scaling the whole view).

Before:
![Screenshot from 2024-11-10 20-53-45](https://github.com/user-attachments/assets/38a0c19e-8731-434c-bfb0-2c594f5cca0d)

After:
![Screenshot from 2024-11-10 21-42-02](https://github.com/user-attachments/assets/3e85a29b-c14c-493d-8218-b98848b82cb4)

