### PR TITLE
Fix validation errors when running with WASM and wgpu feature

### DIFF
--- a/src/renderer/wgpu.rs
+++ b/src/renderer/wgpu.rs
@@ -1188,17 +1188,10 @@ impl PipelineState {
         pipeline_layout: &wgpu::PipelineLayout,
         shader_module: &wgpu::ShaderModule,
     ) -> wgpu::RenderPipeline {
-        let constants = HashMap::from([
-            ("shader_type".to_string(), self.shader_type.to_f32() as f64),
-            (
-                "enable_glyph_texture".to_string(),
-                if self.enable_glyph_texture { 1.0 } else { 0.0 },
-            ),
-            (
-                "render_to_texture".to_string(),
-                if self.render_to_texture { 1.0 } else { 0. },
-            ),
-        ]);
+        let constants = HashMap::from([(
+            "render_to_texture".to_string(),
+            if self.render_to_texture { 1.0 } else { 0. },
+        )]);
 
         device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
             label: None,


### PR DESCRIPTION
See issue #229 

This change prevents errors such as:
```
Pipeline overridable constant ""shader_type"" not found in [ShaderModule "wgpu/shader.wgsl"].
 - While validating vertex stage ([ShaderModule "wgpu/shader.wgsl"], entryPoint: "vs_main").
```
when running with WASM and the `wgpu` feature enabled.

----

Running example with:
```sh
cargo install wasm-bindgen-cli
cargo build --target=wasm32-unknown-unknown --example demo
wasm-bindgen ./target/wasm32-unknown-unknown/debug/examples/demo.wasm --out-dir examples/generated --target web

cd examples/
python3 -m http.server
```

Tested on Windows and Chrome 134.0.6998.89

Before: errors
![image](https://github.com/user-attachments/assets/4db298be-9caf-48c6-8f7c-e6f625cb9798)

After: success
![image](https://github.com/user-attachments/assets/c8c328d7-80fd-4794-a7d6-4923459cd19e)

