### PR TITLE
Add API to draw runs of glyphs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [0.18.0] - TBD
+
+- Added API to drawing runs of glyphs from the same font.
+
 ## [0.17.0] - 2025-09-05
 
 - Bump MSRV to 1.85.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -271,3 +271,4 @@ All notable changes to this project will be documented in this file.
 [0.15.0]: https://github.com/femtovg/femtovg/releases/tag/v0.15.0
 [0.16.0]: https://github.com/femtovg/femtovg/releases/tag/v0.16.0
 [0.17.0]: https://github.com/femtovg/femtovg/releases/tag/v0.17.0
+[0.18.0]: https://github.com/femtovg/femtovg/releases/tag/v0.18.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ serde = { version = "1.0", optional = true, features = ["derive", "rc"] }
 glow = { version = "0.16.0", default-features = false }
 log = "0.4"
 wgpu = { version = "26", optional = true, default-features = false, features = ["wgsl"] }
+itertools = "0.14"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 glutin = { version = "0.31", optional = true, default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "femtovg"
 description = "Antialiased 2D vector drawing library"
-version = "0.17.0"
+version = "0.18.0"
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 authors = [

--- a/examples/external_text.rs
+++ b/examples/external_text.rs
@@ -220,7 +220,7 @@ fn run<W: WindowSurface>(mut canvas: Canvas<W::Renderer>, el: EventLoop<()>, mut
                     buffer.set_metrics(&mut font_system, Metrics::new(20.0 * dpi_factor, 25.0 * dpi_factor));
                     buffer.set_size(&mut font_system, Some(size.width as f32), Some(size.height as f32));
                     let cmds = cache.fill_to_cmds(&mut font_system, &mut canvas, &buffer, (0.0, 0.0));
-                    canvas.draw_glyph_commands(cmds, &Paint::color(Color::black()), 1.0);
+                    canvas.draw_glyph_commands(cmds, &Paint::color(Color::black()));
 
                     surface.present(&mut canvas);
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1385,10 +1385,20 @@ where
         let bitmap_glyphs = layout.has_bitmap_glyphs();
         let need_direct_rendering = text_settings.font_size > 92.0;
 
+        let glyphs = layout
+            .glyphs
+            .iter()
+            .filter(|shaped_glyph| !shaped_glyph.c.is_control())
+            .map(|shaped_glyph| {
+                let glyph_x = shaped_glyph.x - shaped_glyph.bearing_x;
+                let glyph_y = shaped_glyph.y + shaped_glyph.bearing_y;
+                (glyph_x, glyph_y, shaped_glyph.font_id, shaped_glyph.glyph_id)
+            });
+
         if need_direct_rendering && !bitmap_glyphs {
             text::render_direct(
                 self,
-                &layout,
+                glyphs,
                 &paint.flavor,
                 paint.shape_anti_alias,
                 &stroke,
@@ -1404,7 +1414,7 @@ where
             };
 
             let draw_commands =
-                atlas.render_atlas(self, &layout, text_settings.font_size, stroke.line_width, render_mode)?;
+                atlas.render_atlas(self, glyphs, text_settings.font_size, stroke.line_width, render_mode)?;
             self.draw_glyph_commands(draw_commands, paint, scale);
         }
 

--- a/src/text.rs
+++ b/src/text.rs
@@ -1012,7 +1012,9 @@ impl GlyphAtlas {
 
         let (mut glyph_representation, glyph_metrics, scale) = {
             let scale = font.scale(font_size);
-            let maybe_glyph_metrics = font.glyph(&font_face, glyph_id).map(|g| g.metrics.clone());
+            let maybe_glyph_metrics = font
+                .glyph(&font_face, glyph_id)
+                .map(|g| std::cell::Ref::map(g, |g| &g.metrics));
 
             if let (Some(glyph_representation), Some(glyph_metrics)) = (
                 font.glyph_rendering_representation(&font_face, glyph_id, font_size as u16),

--- a/src/text.rs
+++ b/src/text.rs
@@ -147,7 +147,6 @@ pub struct ShapedGlyph {
     pub offset_y: f32,
     pub bearing_x: f32,
     pub bearing_y: f32,
-    pub bitmap_glyph: bool,
 }
 
 #[derive(Clone, Debug, Default)]
@@ -528,10 +527,6 @@ impl TextMetrics {
     pub fn height(&self) -> f32 {
         self.height
     }
-
-    pub(crate) fn has_bitmap_glyphs(&self) -> bool {
-        self.glyphs.iter().any(|g| g.bitmap_glyph)
-    }
 }
 
 // Shaper
@@ -777,7 +772,6 @@ fn shape_word(
                 offset_y: position.y_offset as f32 * scale,
                 bearing_x: 0.0,
                 bearing_y: 0.0,
-                bitmap_glyph: false,
             };
 
             if let Some(glyph) = font.glyph(&face, g.glyph_id) {
@@ -785,7 +779,6 @@ fn shape_word(
                 g.height = glyph.metrics.height * scale;
                 g.bearing_x = glyph.metrics.bearing_x * scale;
                 g.bearing_y = glyph.metrics.bearing_y * scale;
-                g.bitmap_glyph = glyph.path.is_none();
             }
 
             shaped_word.width += g.advance_x + letter_spacing;

--- a/src/text.rs
+++ b/src/text.rs
@@ -20,7 +20,8 @@ use unicode_segmentation::UnicodeSegmentation;
 
 use crate::{
     paint::{PaintFlavor, StrokeSettings, TextSettings},
-    Canvas, Color, ErrorKind, FillRule, ImageFlags, ImageId, ImageInfo, Paint, PixelFormat, RenderTarget, Renderer,
+    Canvas, Color, ErrorKind, FillRule, ImageFlags, ImageId, ImageInfo, Paint, PixelFormat, PositionedGlyph,
+    RenderTarget, Renderer,
 };
 
 mod atlas;
@@ -890,6 +891,7 @@ pub struct Quad {
 }
 
 /// Represents the drawing commands for glyphs, separated into alpha and color glyphs.
+#[derive(Default)]
 pub struct GlyphDrawCommands {
     /// Drawing commands for alpha (opacity) glyphs.
     pub alpha_glyphs: Vec<DrawCommand>,
@@ -907,7 +909,7 @@ impl GlyphAtlas {
     pub(crate) fn render_atlas<T: Renderer>(
         &self,
         canvas: &mut Canvas<T>,
-        glyphs: impl IntoIterator<Item = (f32, f32, FontId, u16)>,
+        glyphs: impl Iterator<Item = PositionedGlyph>,
         font_size: f32,
         line_width: f32,
         mode: RenderMode,
@@ -923,13 +925,22 @@ impl GlyphAtlas {
 
         let initial_render_target = canvas.current_render_target;
 
-        for (glyph_x, glyph_y, font_id, glyph_id) in glyphs.into_iter() {
-            let subpixel_location = crate::geometry::quantize(glyph_x.fract(), 0.1) * 10.0;
+        for glyph in glyphs {
+            let subpixel_location = crate::geometry::quantize(glyph.x.fract(), 0.1) * 10.0;
 
-            let id = RenderedGlyphId::new(glyph_id, font_id, font_size, line_width, mode, subpixel_location as u8);
+            let id = RenderedGlyphId::new(
+                glyph.glyph_id,
+                glyph.font_id,
+                font_size,
+                line_width,
+                mode,
+                subpixel_location as u8,
+            );
 
             if !self.rendered_glyphs.borrow().contains_key(&id) {
-                if let Some(glyph) = self.render_glyph(canvas, font_size, line_width, mode, font_id, glyph_id)? {
+                if let Some(glyph) =
+                    self.render_glyph(canvas, font_size, line_width, mode, glyph.font_id, glyph.glyph_id)?
+                {
                     self.rendered_glyphs.borrow_mut().insert(id, glyph);
                 } else {
                     continue;
@@ -960,8 +971,8 @@ impl GlyphAtlas {
 
                 let line_width_offset = if rendered.color_glyph { 0. } else { line_width_offset };
 
-                q.x0 = glyph_x.trunc() - line_width_offset - GLYPH_PADDING as f32;
-                q.y0 = glyph_y.round() - rendered.bearing_y as f32 - line_width_offset - GLYPH_PADDING as f32;
+                q.x0 = glyph.x.trunc() - line_width_offset - GLYPH_PADDING as f32;
+                q.y0 = glyph.y.round() - rendered.bearing_y as f32 - line_width_offset - GLYPH_PADDING as f32;
                 q.x1 = q.x0 + rendered.width as f32;
                 q.y1 = q.y0 + rendered.height as f32;
 
@@ -1240,25 +1251,25 @@ impl GlyphAtlas {
 
 pub fn render_direct<T: Renderer>(
     canvas: &mut Canvas<T>,
-    glyphs: impl IntoIterator<Item = (f32, f32, FontId, u16)>,
+    glyphs: impl Iterator<Item = PositionedGlyph>,
     paint_flavor: &PaintFlavor,
     anti_alias: bool,
     stroke: &StrokeSettings,
     font_size: f32,
     mode: RenderMode,
-    invscale: f32,
 ) -> Result<(), ErrorKind> {
     let text_context = canvas.text_context.clone();
-    let mut text_context = text_context.borrow_mut();
 
-    for (glyph_x, glyph_y, font_id, glyph_id) in glyphs.into_iter() {
+    for glyph in glyphs {
+        let mut text_context = text_context.borrow_mut();
         let (glyph_rendering, scale) = {
-            let font = text_context.font_mut(font_id).ok_or(ErrorKind::NoFontFound)?;
+            let font = text_context.font_mut(glyph.font_id).ok_or(ErrorKind::NoFontFound)?;
             let face = font.face_ref();
 
             let scale = font.scale(font_size);
 
-            let Some(glyph_rendering) = font.glyph_rendering_representation(&face, glyph_id, font_size as u16) else {
+            let Some(glyph_rendering) = font.glyph_rendering_representation(&face, glyph.glyph_id, font_size as u16)
+            else {
                 continue;
             };
 
@@ -1272,8 +1283,8 @@ pub fn render_direct<T: Renderer>(
             RenderMode::Stroke => stroke.line_width / scale,
         };
 
-        canvas.translate(glyph_x * invscale, glyph_y * invscale);
-        canvas.scale(scale * invscale, -scale * invscale);
+        canvas.translate(glyph.x, glyph.y);
+        canvas.scale(scale, -scale);
 
         match glyph_rendering {
             GlyphRendering::RenderAsPath(path) => {

--- a/src/text/font.rs
+++ b/src/text/font.rs
@@ -6,6 +6,7 @@ use std::collections::hash_map::Entry;
 
 use crate::{ErrorKind, Path};
 
+#[derive(Clone)]
 pub struct GlyphMetrics {
     pub width: f32,
     pub height: f32,

--- a/src/text/font.rs
+++ b/src/text/font.rs
@@ -6,7 +6,6 @@ use std::collections::hash_map::Entry;
 
 use crate::{ErrorKind, Path};
 
-#[derive(Clone)]
 pub struct GlyphMetrics {
     pub width: f32,
     pub height: f32,


### PR DESCRIPTION
If the users do their own text layout and shaping, then these APIs provide a convenient way of delegating just the glyph rendering and especially glyph atlas handling to FemtoVG.