### PR TITLE
Fix docs.rs build

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 #![deny(missing_docs)]
-#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_cfg))]
 
 /*!
  * The femtovg API is (like [NanoVG](https://github.com/memononen/nanovg))


### PR DESCRIPTION
A recent change to Rust nightly means that doc_auto_cfg no longer builds. This affects the femtovg 0.19 release https://docs.rs/crate/femtovg/0.19.0.

The fix is to use `doc_cfg` instead of `doc_auto_cfg`