### PR TITLE
Fall back to path rendering for glyphs under non-translation transforms

### DIFF
--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -338,6 +338,13 @@ impl Transform2D {
         (sx + sy) * 0.5
     }
 
+    /// Returns true if this transform is approximately a pure translation,
+    /// i.e. no rotation, scaling, or skew.
+    pub(crate) fn is_pure_translation(&self, epsilon: f32) -> bool {
+        let &Self([a, b, c, d, ..]) = self;
+        (a - 1.0).abs() < epsilon && b.abs() < epsilon && c.abs() < epsilon && (d - 1.0).abs() < epsilon
+    }
+
     /// Converts the current transformation matrix to a 3×4 matrix format.
     pub fn to_mat3x4(self) -> [f32; 12] {
         let Self([a, b, c, d, x, y]) = self;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1499,7 +1499,13 @@ where
         let text_context = self.text_context.clone();
         let mut text_context = text_context.borrow_mut();
 
-        let need_direct_rendering = paint.text.font_size > 92.0;
+        // When the canvas transform includes scale, rotation, or skew, fall back to
+        // path-based rendering instead of using atlas bitmaps. Atlas glyphs are rasterized
+        // at a fixed size, so applying a non-translation transform to the textured quad
+        // produces blurry or aliased results.
+        // Use 1e-3 as epsilon: tight enough to catch any intentional transform,
+        // but generous enough to tolerate floating-point drift from matrix operations.
+        let need_direct_rendering = paint.text.font_size > 92.0 || !self.state().transform.is_pure_translation(1e-3);
 
         let Some(font) = text_context.font_mut(font_id) else {
             return Err(ErrorKind::NoFontFound);


### PR DESCRIPTION
Atlas-cached glyphs are rasterized at a fixed size, so scaling or rotating the textured quad produces blurry or aliased results. Detect when the canvas transform includes scale, rotation, or skew and use the existing direct (path-based) rendering path instead.