### PR TITLE
Update wgpu backend to wgpu 29.0.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ image = { version = "0.25.0", optional = true, default-features = false }
 serde = { version = "1.0", optional = true, features = ["derive", "rc"] }
 glow = { version = "0.17.0", default-features = false }
 log = "0.4"
-wgpu = { version = "28", optional = true, default-features = false, features = ["wgsl"] }
+wgpu = { version = "29.0.3", optional = true, default-features = false, features = ["wgsl"] }
 itertools = "0.14"
 ttf-parser = { version = "0.25.1", optional = true }
 swash = { version = "0.2.6", optional = true }
@@ -48,7 +48,7 @@ web_sys = { version = "0.3", package = "web-sys", features = [
     "WebGl2RenderingContext",
 ] }
 wasm-bindgen = "0.2"
-wgpu = { version = "28", optional = true, default-features = false, features = ["web"] }
+wgpu = { version = "29.0.3", optional = true, default-features = false, features = ["web"] }
 
 [features]
 default = ["image-loading", "textlayout"]
@@ -73,7 +73,7 @@ cosmic-text = "0.19.0"
 swash = "0.2.6"
 lazy_static = "1.4.0"
 pollster = "0.4"
-wgpu = { version = "28" }
+wgpu = { version = "29.0.3" }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 glutin = "0.32.3"
@@ -90,7 +90,7 @@ console_error_panic_hook = "0.1.5"
 instant = { version = "0.1", features = ["wasm-bindgen", "now"] }
 resource = { version = "0.6.1", features = ["force-static"] }
 getrandom = { version = "0.4.1", features = ["wasm_js"] }
-wgpu = { version = "28", features = ["webgl"] }
+wgpu = { version = "29.0.3", features = ["webgl"] }
 wasm-bindgen-futures = { version = "0.4.45" }
 
 [[example]]

--- a/examples/helpers/wgpu.rs
+++ b/examples/helpers/wgpu.rs
@@ -25,10 +25,11 @@ impl WindowSurface for DemoSurface {
     }
 
     fn present(&self, canvas: &mut femtovg::Canvas<Self::Renderer>) {
-        let frame = self
-            .surface
-            .get_current_texture()
-            .expect("unable to get next texture from swapchain");
+        let frame = match self.surface.get_current_texture() {
+            wgpu::CurrentSurfaceTexture::Success(frame) | wgpu::CurrentSurfaceTexture::Suboptimal(frame) => frame,
+            wgpu::CurrentSurfaceTexture::Timeout | wgpu::CurrentSurfaceTexture::Occluded => return,
+            status => panic!("unable to get next texture from swapchain: {status:?}"),
+        };
 
         let commands = canvas.flush_to_output(&frame.texture);
 
@@ -72,7 +73,7 @@ impl ApplicationHandler for WgpuApp {
         let gles_minor_version = wgpu::Gles3MinorVersion::from_env().unwrap_or_default();
 
         let instance = pollster::block_on(wgpu::util::new_instance_with_webgpu_detection(
-            &wgpu::InstanceDescriptor {
+            wgpu::InstanceDescriptor {
                 backends,
                 flags: wgpu::InstanceFlags::from_build_config().with_env(),
                 backend_options: wgpu::BackendOptions {
@@ -80,14 +81,17 @@ impl ApplicationHandler for WgpuApp {
                         shader_compiler: dx12_shader_compiler,
                         presentation_system: dx12_presentation_system,
                         latency_waitable_object: dx12_latency_waitable_object,
+                        ..Default::default()
                     },
                     gl: wgpu::GlBackendOptions {
                         gles_minor_version,
                         fence_behavior: wgpu::GlFenceBehavior::default(),
+                        ..Default::default()
                     },
                     noop: wgpu::NoopBackendOptions::default(),
                 },
                 memory_budget_thresholds: wgpu::MemoryBudgetThresholds::default(),
+                display: None,
             },
         ));
 
@@ -265,11 +269,12 @@ pub async fn start_wgpu_wasm() {
     #[cfg(debug_assertions)]
     console_error_panic_hook::set_once();
 
-    let instance = wgpu::util::new_instance_with_webgpu_detection(&wgpu::InstanceDescriptor {
+    let instance = wgpu::util::new_instance_with_webgpu_detection(wgpu::InstanceDescriptor {
         backends: wgpu::Backends::from_env().unwrap_or_default(),
         flags: wgpu::InstanceFlags::from_build_config().with_env(),
         backend_options: wgpu::BackendOptions::default(),
         memory_budget_thresholds: wgpu::MemoryBudgetThresholds::default(),
+        display: None,
     })
     .await;
 

--- a/src/renderer/wgpu.rs
+++ b/src/renderer/wgpu.rs
@@ -331,7 +331,7 @@ impl WGPURenderer {
 
         let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
             label: None,
-            bind_group_layouts: &[&viewport_bind_group_layout, &bind_group_layout],
+            bind_group_layouts: &[Some(&viewport_bind_group_layout), Some(&bind_group_layout)],
             immediate_size: 0,
         });
 
@@ -1329,8 +1329,8 @@ impl PipelineState {
                 .as_ref()
                 .map(|stencil_state| wgpu::DepthStencilState {
                     format: wgpu::TextureFormat::Stencil8,
-                    depth_write_enabled: false,
-                    depth_compare: wgpu::CompareFunction::Always,
+                    depth_write_enabled: Some(false),
+                    depth_compare: Some(wgpu::CompareFunction::Always),
                     stencil: stencil_state.clone(),
                     bias: Default::default(),
                 }),
@@ -1377,7 +1377,7 @@ impl BindGroupState {
             empty_texture,
         );
 
-        if (main_texture_view.is_external() || glyph_texture_view.is_external()) {
+        if main_texture_view.is_external() || glyph_texture_view.is_external() {
             unimplemented!("External texture shaders and bind groups are not implemented yet");
         }
 


### PR DESCRIPTION
I need this so I avoid linking two different versions of wgpu into my fork of BabylonNative that I've converted to use purely WebGPU / wgpu-native and eliminate GLES legacy code. I integration tested (screenshot attached) where I use JS to create a new texture via canvas, write text and boxes with gradients into the texture, and then BabylonJS renders that onto a spinning cube using the WebGPU JS API. I also tested with various sanitizers in this integration test as a precaution, even though Rust intrinsically prevents most of those issues.

all femtovg CI and unit tests pass in my femtovg fork, and it doesn't looks like it's a breaking change for existing users of femtovg. It would be awesome if you could merge and publish! :D

<img width="3024" height="1964" alt="image" src="https://github.com/user-attachments/assets/b39577ce-f2e8-4e8a-a89a-c6756bc0ae43" />
