### PR TITLE
Add rounded scissor support

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1707,7 +1707,7 @@ where
             &glyph_texture,
             &scissor,
             1.0,
-            1.0,
+            self.fringe_width,
             -1.0,
         );
 
@@ -1954,6 +1954,19 @@ fn first_draw_params(commands: &[renderer::Command]) -> &Params {
         .expect("expected a draw command")
 }
 
+#[cfg(all(test, feature = "textlayout"))]
+fn first_glyph_draw_params(commands: &[renderer::Command]) -> &Params {
+    use renderer::CommandType;
+
+    commands
+        .iter()
+        .find_map(|command| match &command.cmd_type {
+            CommandType::Triangles { params } if params.glyph_texture_type != 0 => Some(params),
+            _ => None,
+        })
+        .expect("expected a glyph draw command")
+}
+
 #[cfg(test)]
 fn assert_approx_eq(actual: f32, expected: f32) {
     assert!(
@@ -1984,6 +1997,37 @@ fn rounded_scissor_radius_is_clamped_into_render_params() {
     let params = first_draw_params(&commands);
     assert_eq!(params.glyph_texture_type, 0);
     assert_approx_eq(params.scissor_radius, 10.0);
+}
+
+#[cfg(feature = "textlayout")]
+#[test]
+fn glyph_scissor_ramp_matches_fill_at_high_dpi() {
+    let renderer = RecordingRenderer::default();
+    let recorded_commands = renderer.last_commands.clone();
+    let mut canvas = Canvas::new(renderer).unwrap();
+    canvas.set_size(100, 100, 2.0);
+
+    let font = canvas
+        .add_font("examples/assets/RobotoFlex-VariableFont.ttf")
+        .expect("Font not found");
+    let paint = Paint::color(Color::white()).with_font(&[font]).with_font_size(16.0);
+
+    canvas.rounded_scissor(10.0, 10.0, 56.0, 28.0, 14.0);
+
+    let mut rect = Path::new();
+    rect.rect(0.0, 0.0, 100.0, 100.0);
+    canvas.fill_path(&rect, &Paint::color(Color::white()));
+    canvas.fill_text(12.0, 30.0, "Click", &paint).unwrap();
+    canvas.flush_to_output(());
+
+    let commands = recorded_commands.borrow();
+    let fill = first_draw_params(&commands);
+    let glyph = first_glyph_draw_params(&commands);
+
+    assert_approx_eq(glyph.scissor_scale[0], 2.0);
+    assert_approx_eq(glyph.scissor_scale[1], 2.0);
+    assert_approx_eq(glyph.scissor_scale[0], fill.scissor_scale[0]);
+    assert_approx_eq(glyph.scissor_scale[1], fill.scissor_scale[1]);
 }
 
 #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1955,6 +1955,14 @@ fn first_draw_params(commands: &[renderer::Command]) -> &Params {
 }
 
 #[cfg(test)]
+fn assert_approx_eq(actual: f32, expected: f32) {
+    assert!(
+        (actual - expected).abs() < 0.001,
+        "expected {actual} to be approximately {expected}"
+    );
+}
+
+#[cfg(test)]
 fn fill_rect_with_current_scissor(canvas: &mut Canvas<RecordingRenderer>) {
     let mut path = Path::new();
     path.rect(0.0, 0.0, 100.0, 100.0);
@@ -1974,7 +1982,8 @@ fn rounded_scissor_radius_is_clamped_into_render_params() {
 
     let commands = recorded_commands.borrow();
     let params = first_draw_params(&commands);
-    assert!((params.scissor_radius - 10.0).abs() < 0.001);
+    assert_eq!(params.glyph_texture_type, 0);
+    assert_approx_eq(params.scissor_radius, 10.0);
 }
 
 #[test]
@@ -1990,7 +1999,68 @@ fn intersect_scissor_preserves_contained_rounded_clip() {
 
     let commands = recorded_commands.borrow();
     let params = first_draw_params(&commands);
-    assert!((params.scissor_radius - 8.0).abs() < 0.001);
+    assert_eq!(params.glyph_texture_type, 0);
+    assert_approx_eq(params.scissor_radius, 8.0);
+}
+
+#[test]
+fn intersect_scissor_inside_rounded_clip_uses_rectangular_inner_clip() {
+    let renderer = RecordingRenderer::default();
+    let recorded_commands = renderer.last_commands.clone();
+    let mut canvas = Canvas::new(renderer).unwrap();
+    canvas.set_size(100, 100, 1.0);
+
+    canvas.rounded_scissor(10.0, 10.0, 80.0, 80.0, 20.0);
+    canvas.intersect_scissor(35.0, 35.0, 20.0, 20.0);
+    fill_rect_with_current_scissor(&mut canvas);
+
+    let commands = recorded_commands.borrow();
+    let params = first_draw_params(&commands);
+    assert_eq!(params.glyph_texture_type, 0);
+    assert_approx_eq(params.scissor_radius, 0.0);
+    assert_approx_eq(params.scissor_ext[0], 10.0);
+    assert_approx_eq(params.scissor_ext[1], 10.0);
+}
+
+#[test]
+fn intersect_rounded_scissor_partial_overlap_falls_back_to_rectangular_intersection() {
+    let renderer = RecordingRenderer::default();
+    let recorded_commands = renderer.last_commands.clone();
+    let mut canvas = Canvas::new(renderer).unwrap();
+    canvas.set_size(100, 100, 1.0);
+
+    canvas.rounded_scissor(10.0, 10.0, 40.0, 40.0, 12.0);
+    canvas.intersect_rounded_scissor(35.0, 35.0, 40.0, 40.0, 12.0);
+    fill_rect_with_current_scissor(&mut canvas);
+
+    let commands = recorded_commands.borrow();
+    let params = first_draw_params(&commands);
+    assert_eq!(params.glyph_texture_type, 0);
+    assert_approx_eq(params.scissor_radius, 0.0);
+    assert_approx_eq(params.scissor_ext[0], 7.5);
+    assert_approx_eq(params.scissor_ext[1], 7.5);
+}
+
+#[test]
+fn rounded_scissor_captures_transform_at_clip_time() {
+    let renderer = RecordingRenderer::default();
+    let recorded_commands = renderer.last_commands.clone();
+    let mut canvas = Canvas::new(renderer).unwrap();
+    canvas.set_size(100, 100, 1.0);
+
+    canvas.scale(2.0, 3.0);
+    canvas.rounded_scissor(10.0, 10.0, 20.0, 10.0, 4.0);
+    canvas.reset_transform();
+    fill_rect_with_current_scissor(&mut canvas);
+
+    let commands = recorded_commands.borrow();
+    let params = first_draw_params(&commands);
+    assert_eq!(params.glyph_texture_type, 0);
+    assert_approx_eq(params.scissor_radius, 4.0);
+    assert_approx_eq(params.scissor_ext[0], 10.0);
+    assert_approx_eq(params.scissor_ext[1], 5.0);
+    assert_approx_eq(params.scissor_scale[0], 2.0);
+    assert_approx_eq(params.scissor_scale[1], 3.0);
 }
 
 #[test]
@@ -2006,5 +2076,6 @@ fn intersect_rounded_scissor_uses_inner_radius_when_contained() {
 
     let commands = recorded_commands.borrow();
     let params = first_draw_params(&commands);
-    assert!((params.scissor_radius - 10.0).abs() < 0.001);
+    assert_eq!(params.glyph_texture_type, 0);
+    assert_approx_eq(params.scissor_radius, 10.0);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -815,6 +815,7 @@ where
     /// scissor or when the previous clip is a containing rectangle with the same
     /// transform. Other intersections fall back to rectangular scissoring.
     pub fn intersect_rounded_scissor(&mut self, x: f32, y: f32, w: f32, h: f32, r: f32) {
+        let tolerance = self.dist_tol;
         let state = self.state_mut();
 
         // If no previous scissor has been set, set the scissor as current scissor.
@@ -840,7 +841,6 @@ where
         let res = rect.intersect(Rect::new(x, y, w, h));
 
         let requested = Rect::new(x, y, w, h);
-        let tolerance = 1e-3;
         let requested_contains_existing = requested.x <= rect.x + tolerance
             && requested.y <= rect.y + tolerance
             && rect.x + rect.w <= requested.x + requested.w + tolerance
@@ -870,7 +870,7 @@ where
                 } else {
                     0.0
                 };
-                dx * dx + dy * dy <= radius * radius + tolerance
+                dx * dx + dy * dy <= (radius + tolerance) * (radius + tolerance)
             };
             let rounded_contains_requested = contains_point(requested.x, requested.y)
                 && contains_point(requested.x + requested.w, requested.y)
@@ -1598,13 +1598,13 @@ where
         let text_context = self.text_context.clone();
         let mut text_context = text_context.borrow_mut();
 
-        // Very large glyphs need path rendering, and large transformed glyphs avoid
-        // magnifying atlas bitmaps. Smaller transformed text stays on the atlas so
-        // it keeps the browser-like hinted weight expected by canvas UI text.
+        // When the canvas transform includes scale, rotation, or skew, fall back to
+        // path-based rendering instead of using atlas bitmaps. Atlas glyphs are rasterized
+        // at a fixed size, so applying a non-translation transform to the textured quad
+        // produces blurry or aliased results.
         // Use 1e-3 as epsilon: tight enough to catch any intentional transform,
         // but generous enough to tolerate floating-point drift from matrix operations.
-        let need_direct_rendering = paint.text.font_size > 92.0
-            || (paint.text.font_size > 64.0 && !self.state().transform.is_pure_translation(1e-3));
+        let need_direct_rendering = paint.text.font_size > 92.0 || !self.state().transform.is_pure_translation(1e-3);
 
         let Some(font) = text_context.font_mut(font_id) else {
             return Err(ErrorKind::NoFontFound);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -194,6 +194,7 @@ impl Default for CompositeOperationState {
 struct Scissor {
     transform: Transform2D,
     extent: Option<[f32; 2]>,
+    radius: f32,
 }
 
 impl Scissor {
@@ -777,6 +778,13 @@ where
     ///
     /// The scissor rectangle is transformed by the current transform.
     pub fn scissor(&mut self, x: f32, y: f32, w: f32, h: f32) {
+        self.rounded_scissor(x, y, w, h, 0.0);
+    }
+
+    /// Sets the current rounded scissor rectangle.
+    ///
+    /// The scissor rectangle is transformed by the current transform.
+    pub fn rounded_scissor(&mut self, x: f32, y: f32, w: f32, h: f32, r: f32) {
         let state = self.state_mut();
 
         let w = w.max(0.0);
@@ -787,6 +795,7 @@ where
         state.scissor.transform = transform;
 
         state.scissor.extent = Some([w * 0.5, h * 0.5]);
+        state.scissor.radius = r.max(0.0).min(w * 0.5).min(h * 0.5);
     }
 
     /// Intersects current scissor rectangle with the specified rectangle.
@@ -797,11 +806,20 @@ where
     /// rectangle and the previous scissor rectangle transformed in the current
     /// transform space. The resulting shape is always rectangle.
     pub fn intersect_scissor(&mut self, x: f32, y: f32, w: f32, h: f32) {
+        self.intersect_rounded_scissor(x, y, w, h, 0.0);
+    }
+
+    /// Intersects current scissor rectangle with the specified rounded rectangle.
+    ///
+    /// The resulting rounded corners are exact when this is the first active
+    /// scissor or when the previous clip is a containing rectangle with the same
+    /// transform. Other intersections fall back to rectangular scissoring.
+    pub fn intersect_rounded_scissor(&mut self, x: f32, y: f32, w: f32, h: f32, r: f32) {
         let state = self.state_mut();
 
         // If no previous scissor has been set, set the scissor as current scissor.
         if state.scissor.extent.is_none() {
-            self.scissor(x, y, w, h);
+            self.rounded_scissor(x, y, w, h, r);
             return;
         }
 
@@ -821,7 +839,60 @@ where
         let rect = Rect::new(tx - tex, ty - tey, tex * 2.0, tey * 2.0);
         let res = rect.intersect(Rect::new(x, y, w, h));
 
-        self.scissor(res.x, res.y, res.w, res.h);
+        let requested = Rect::new(x, y, w, h);
+        let tolerance = 1e-3;
+        let requested_contains_existing = requested.x <= rect.x + tolerance
+            && requested.y <= rect.y + tolerance
+            && rect.x + rect.w <= requested.x + requested.w + tolerance
+            && rect.y + rect.h <= requested.y + requested.h + tolerance;
+        if r <= 0.0 && state.scissor.radius > 0.0 && requested_contains_existing {
+            return;
+        }
+
+        if r <= 0.0 && state.scissor.radius > 0.0 {
+            let radius = state.scissor.radius;
+            let contains_point = |x: f32, y: f32| {
+                let left = rect.x + radius;
+                let right = rect.x + rect.w - radius;
+                let top = rect.y + radius;
+                let bottom = rect.y + rect.h - radius;
+                let dx = if x < left {
+                    left - x
+                } else if x > right {
+                    x - right
+                } else {
+                    0.0
+                };
+                let dy = if y < top {
+                    top - y
+                } else if y > bottom {
+                    y - bottom
+                } else {
+                    0.0
+                };
+                dx * dx + dy * dy <= radius * radius + tolerance
+            };
+            let rounded_contains_requested = contains_point(requested.x, requested.y)
+                && contains_point(requested.x + requested.w, requested.y)
+                && contains_point(requested.x, requested.y + requested.h)
+                && contains_point(requested.x + requested.w, requested.y + requested.h);
+            if rounded_contains_requested {
+                self.scissor(res.x, res.y, res.w, res.h);
+            } else {
+                self.rounded_scissor(res.x, res.y, res.w, res.h, radius);
+            }
+            return;
+        }
+
+        let contains_requested = rect.x <= requested.x + tolerance
+            && rect.y <= requested.y + tolerance
+            && requested.x + requested.w <= rect.x + rect.w + tolerance
+            && requested.y + requested.h <= rect.y + rect.h + tolerance;
+        if contains_requested {
+            self.rounded_scissor(requested.x, requested.y, requested.w, requested.h, r);
+        } else {
+            self.scissor(res.x, res.y, res.w, res.h);
+        }
     }
 
     /// Reset and disables scissoring.
@@ -1527,13 +1598,13 @@ where
         let text_context = self.text_context.clone();
         let mut text_context = text_context.borrow_mut();
 
-        // When the canvas transform includes scale, rotation, or skew, fall back to
-        // path-based rendering instead of using atlas bitmaps. Atlas glyphs are rasterized
-        // at a fixed size, so applying a non-translation transform to the textured quad
-        // produces blurry or aliased results.
+        // Very large glyphs need path rendering, and large transformed glyphs avoid
+        // magnifying atlas bitmaps. Smaller transformed text stays on the atlas so
+        // it keeps the browser-like hinted weight expected by canvas UI text.
         // Use 1e-3 as epsilon: tight enough to catch any intentional transform,
         // but generous enough to tolerate floating-point drift from matrix operations.
-        let need_direct_rendering = paint.text.font_size > 92.0 || !self.state().transform.is_pure_translation(1e-3);
+        let need_direct_rendering = paint.text.font_size > 92.0
+            || (paint.text.font_size > 64.0 && !self.state().transform.is_pure_translation(1e-3));
 
         let Some(font) = text_context.font_mut(font_id) else {
             return Err(ErrorKind::NoFontFound);
@@ -1864,4 +1935,76 @@ fn test_image_blit_fast_path() {
             ..
         })
     ));
+}
+
+#[cfg(test)]
+fn first_draw_params(commands: &[renderer::Command]) -> &Params {
+    use renderer::CommandType;
+
+    commands
+        .iter()
+        .find_map(|command| match &command.cmd_type {
+            CommandType::ConvexFill { params } | CommandType::Stroke { params } | CommandType::Triangles { params } => {
+                Some(params)
+            }
+            CommandType::ConcaveFill { fill_params, .. } => Some(fill_params),
+            CommandType::StencilStroke { params1, .. } => Some(params1),
+            _ => None,
+        })
+        .expect("expected a draw command")
+}
+
+#[cfg(test)]
+fn fill_rect_with_current_scissor(canvas: &mut Canvas<RecordingRenderer>) {
+    let mut path = Path::new();
+    path.rect(0.0, 0.0, 100.0, 100.0);
+    canvas.fill_path(&path, &Paint::color(Color::white()));
+    canvas.flush_to_output(());
+}
+
+#[test]
+fn rounded_scissor_radius_is_clamped_into_render_params() {
+    let renderer = RecordingRenderer::default();
+    let recorded_commands = renderer.last_commands.clone();
+    let mut canvas = Canvas::new(renderer).unwrap();
+    canvas.set_size(100, 100, 1.0);
+
+    canvas.rounded_scissor(10.0, 10.0, 40.0, 20.0, 100.0);
+    fill_rect_with_current_scissor(&mut canvas);
+
+    let commands = recorded_commands.borrow();
+    let params = first_draw_params(&commands);
+    assert!((params.scissor_radius - 10.0).abs() < 0.001);
+}
+
+#[test]
+fn intersect_scissor_preserves_contained_rounded_clip() {
+    let renderer = RecordingRenderer::default();
+    let recorded_commands = renderer.last_commands.clone();
+    let mut canvas = Canvas::new(renderer).unwrap();
+    canvas.set_size(100, 100, 1.0);
+
+    canvas.rounded_scissor(10.0, 10.0, 40.0, 20.0, 8.0);
+    canvas.intersect_scissor(0.0, 0.0, 100.0, 100.0);
+    fill_rect_with_current_scissor(&mut canvas);
+
+    let commands = recorded_commands.borrow();
+    let params = first_draw_params(&commands);
+    assert!((params.scissor_radius - 8.0).abs() < 0.001);
+}
+
+#[test]
+fn intersect_rounded_scissor_uses_inner_radius_when_contained() {
+    let renderer = RecordingRenderer::default();
+    let recorded_commands = renderer.last_commands.clone();
+    let mut canvas = Canvas::new(renderer).unwrap();
+    canvas.set_size(100, 100, 1.0);
+
+    canvas.scissor(0.0, 0.0, 100.0, 100.0);
+    canvas.intersect_rounded_scissor(10.0, 10.0, 40.0, 20.0, 100.0);
+    fill_rect_with_current_scissor(&mut canvas);
+
+    let commands = recorded_commands.borrow();
+    let params = first_draw_params(&commands);
+    assert!((params.scissor_radius - 10.0).abs() < 0.001);
 }

--- a/src/renderer/opengl/main-fs.glsl
+++ b/src/renderer/opengl/main-fs.glsl
@@ -24,6 +24,7 @@ uniform vec4 frag[UNIFORMARRAY_SIZE];
 #define imageBlurFilterDirection frag[11].yz
 #define imageBlurFilterSigma frag[11].w
 #define imageBlurFilterCoeff frag[12].xyz
+#define scissorRadius frag[12].w
 
 uniform sampler2D tex;
 uniform sampler2D glyphtex;
@@ -50,6 +51,13 @@ float sdroundrect(vec2 pt, vec2 ext, float rad) {
 
 // Scissoring
 float scissorMask(vec2 p) {
+    if (scissorRadius > 0.0) {
+        vec2 pt = (scissorMat * vec3(p,1.0)).xy;
+        float distance = sdroundrect(pt, scissorExt, scissorRadius);
+        float edge = glyphTextureType != 0.0 ? 0.375 : 0.5;
+        return clamp(edge - distance * min(scissorScale.x, scissorScale.y), 0.0, 1.0);
+    }
+
     vec2 sc = (abs((scissorMat * vec3(p,1.0)).xy) - scissorExt);
     sc = vec2(0.5,0.5) - sc * scissorScale;
     return clamp(sc.x,0.0,1.0) * clamp(sc.y,0.0,1.0);

--- a/src/renderer/opengl/main-fs.glsl
+++ b/src/renderer/opengl/main-fs.glsl
@@ -54,8 +54,7 @@ float scissorMask(vec2 p) {
     if (scissorRadius > 0.0) {
         vec2 pt = (scissorMat * vec3(p,1.0)).xy;
         float distance = sdroundrect(pt, scissorExt, scissorRadius);
-        float edge = glyphTextureType != 0.0 ? 0.375 : 0.5;
-        return clamp(edge - distance * min(scissorScale.x, scissorScale.y), 0.0, 1.0);
+        return clamp(0.5 - distance * min(scissorScale.x, scissorScale.y), 0.0, 1.0);
     }
 
     vec2 sc = (abs((scissorMat * vec3(p,1.0)).xy) - scissorExt);

--- a/src/renderer/opengl/uniform_array.rs
+++ b/src/renderer/opengl/uniform_array.rs
@@ -43,6 +43,10 @@ impl UniformArray {
         self.0[34..36].copy_from_slice(&scale);
     }
 
+    pub fn set_scissor_radius(&mut self, radius: f32) {
+        self.0[51] = radius;
+    }
+
     pub fn set_extent(&mut self, ext: [f32; 2]) {
         self.0[36..38].copy_from_slice(&ext);
     }
@@ -98,6 +102,7 @@ impl From<&Params> for UniformArray {
         arr.set_outer_col(params.outer_col);
         arr.set_scissor_ext(params.scissor_ext);
         arr.set_scissor_scale(params.scissor_scale);
+        arr.set_scissor_radius(params.scissor_radius);
         arr.set_extent(params.extent);
         arr.set_radius(params.radius);
         arr.set_feather(params.feather);

--- a/src/renderer/params.rs
+++ b/src/renderer/params.rs
@@ -14,6 +14,7 @@ pub struct Params {
     pub(crate) outer_col: [f32; 4],
     pub(crate) scissor_ext: [f32; 2],
     pub(crate) scissor_scale: [f32; 2],
+    pub(crate) scissor_radius: f32,
     pub(crate) extent: [f32; 2],
     pub(crate) radius: f32,
     pub(crate) feather: f32,
@@ -58,6 +59,7 @@ impl Params {
 
         params.scissor_ext = scissor_ext;
         params.scissor_scale = scissor_scale;
+        params.scissor_radius = scissor.radius;
 
         params.stroke_mult = (stroke_width * 0.5 + fringe_width * 0.5) / fringe_width;
         params.stroke_thr = stroke_thr;

--- a/src/renderer/wgpu.rs
+++ b/src/renderer/wgpu.rs
@@ -105,6 +105,10 @@ impl UniformArray {
         self.0[34..36].copy_from_slice(&scale);
     }
 
+    pub fn set_scissor_radius(&mut self, radius: f32) {
+        self.0[51] = radius;
+    }
+
     pub fn set_extent(&mut self, ext: [f32; 2]) {
         self.0[36..38].copy_from_slice(&ext);
     }
@@ -160,6 +164,7 @@ impl From<&Params> for UniformArray {
         arr.set_outer_col(params.outer_col);
         arr.set_scissor_ext(params.scissor_ext);
         arr.set_scissor_scale(params.scissor_scale);
+        arr.set_scissor_radius(params.scissor_radius);
         arr.set_extent(params.extent);
         arr.set_radius(params.radius);
         arr.set_feather(params.feather);

--- a/src/renderer/wgpu/shader.wgsl
+++ b/src/renderer/wgpu/shader.wgsl
@@ -16,6 +16,7 @@ struct Params {
     image_blur_filter_sigma: f32,
     image_blur_filter_direction: vec2<f32>,
     image_blur_filter_coeff: vec3<f32>,
+    scissor_radius: f32,
 }
 
 const SHADER_TYPE_FillGradient: i32 = 0;
@@ -191,6 +192,13 @@ fn sdroundrect(pt: vec2<f32>, ext: vec2<f32>, rad: f32) -> f32 {
 
 // Scissoring
 fn scissorMask(p: vec2<f32>, params: Params) -> f32 {
+    if (params.scissor_radius > 0.0) {
+        let pt = (params.scissor_mat * vec3<f32>(p, 1.0)).xy;
+        let distance = sdroundrect(pt, params.scissor_ext, params.scissor_radius);
+        let edge = select(0.5, 0.375, params.glyph_texture_type != 0.0);
+        return clamp(edge - distance * min(params.scissor_scale.x, params.scissor_scale.y), 0.0, 1.0);
+    }
+
     var sc: vec2<f32> = (abs((params.scissor_mat * vec3<f32>(p,1.0)).xy) - params.scissor_ext);
     sc = vec2(0.5,0.5) - sc * params.scissor_scale;
     return clamp(sc.x,0.0,1.0) * clamp(sc.y,0.0,1.0);

--- a/src/renderer/wgpu/shader.wgsl
+++ b/src/renderer/wgpu/shader.wgsl
@@ -195,8 +195,7 @@ fn scissorMask(p: vec2<f32>, params: Params) -> f32 {
     if (params.scissor_radius > 0.0) {
         let pt = (params.scissor_mat * vec3<f32>(p, 1.0)).xy;
         let distance = sdroundrect(pt, params.scissor_ext, params.scissor_radius);
-        let edge = select(0.5, 0.375, params.glyph_texture_type != 0.0);
-        return clamp(edge - distance * min(params.scissor_scale.x, params.scissor_scale.y), 0.0, 1.0);
+        return clamp(0.5 - distance * min(params.scissor_scale.x, params.scissor_scale.y), 0.0, 1.0);
     }
 
     var sc: vec2<f32> = (abs((params.scissor_mat * vec3<f32>(p,1.0)).xy) - params.scissor_ext);


### PR DESCRIPTION
## Summary

- add `Canvas::rounded_scissor` and `Canvas::intersect_rounded_scissor`
- thread scissor radius through renderer params and uniforms
- apply the rounded scissor mask in OpenGL and wgpu shaders

References: follows the existing NanoVG/femtovg scissor-mask shader model for clipping, with Canvas-style rounded-rect clip use cases. Tests cover radius clamping and rectangular/rounded intersection behavior.

Split out of #279.

## Validation

- `cargo fmt --check`
- `cargo test`
- `cargo test --features wgpu`