### PR TITLE
Render uniformly-scaled text crisply via scale-baked atlas glyphs

### DIFF
--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -338,11 +338,18 @@ impl Transform2D {
         (sx + sy) * 0.5
     }
 
-    /// Returns true if this transform is approximately a pure translation,
-    /// i.e. no rotation, scaling, or skew.
-    pub(crate) fn is_pure_translation(&self, epsilon: f32) -> bool {
-        let &Self([a, b, c, d, ..]) = self;
-        (a - 1.0).abs() < epsilon && b.abs() < epsilon && c.abs() < epsilon && (d - 1.0).abs() < epsilon
+    /// If this transform is a uniform scale combined with a translation (no
+    /// rotation, skew, reflection, or non-uniform scaling), returns
+    /// `(scale, tx, ty)`; otherwise returns `None`.
+    ///
+    /// `epsilon` is the tolerance for the off-diagonal terms being zero and for
+    /// the two diagonal terms being equal. A pure translation reports a scale of
+    /// `1.0`.
+    pub(crate) fn as_uniform_scale_translation(&self, epsilon: f32) -> Option<(f32, f32, f32)> {
+        let &Self([a, b, c, d, tx, ty]) = self;
+        let is_uniform =
+            b.abs() < epsilon && c.abs() < epsilon && (a - d).abs() < epsilon * a.abs().max(1.0) && a > 0.0;
+        is_uniform.then_some((a, tx, ty))
     }
 
     /// Converts the current transformation matrix to a 3×4 matrix format.
@@ -527,5 +534,78 @@ impl Default for Bounds {
 impl Bounds {
     pub(crate) fn contains(&self, x: f32, y: f32) -> bool {
         (self.minx..=self.maxx).contains(&x) && (self.miny..=self.maxy).contains(&y)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Transform2D;
+
+    const EPS: f32 = 1e-3;
+
+    #[test]
+    fn uniform_scale_translation() {
+        // (description, transform, expected (scale, tx, ty) or None)
+        #[allow(clippy::type_complexity)]
+        let cases: &[(&str, Transform2D, Option<(f32, f32, f32)>)] = &[
+            ("identity", Transform2D::identity(), Some((1.0, 0.0, 0.0))),
+            (
+                "pure translation",
+                Transform2D::translation(3.0, 4.0),
+                Some((1.0, 3.0, 4.0)),
+            ),
+            (
+                "uniform scale + translation",
+                Transform2D::new(2.0, 0.0, 0.0, 2.0, 5.0, 6.0),
+                Some((2.0, 5.0, 6.0)),
+            ),
+            ("pure scale", Transform2D::scaling(2.0, 2.0), Some((2.0, 0.0, 0.0))),
+            ("rotation", Transform2D::rotation(std::f32::consts::FRAC_PI_4), None),
+            // Non-zero off-diagonal term.
+            ("skew", Transform2D::new(1.0, 0.0, 0.5, 1.0, 0.0, 0.0), None),
+            // Different x and y scale.
+            (
+                "non-uniform scale",
+                Transform2D::new(2.0, 0.0, 0.0, 3.0, 0.0, 0.0),
+                None,
+            ),
+            // Negative uniform scale (180° reflection): a is not > 0.
+            ("negative scale", Transform2D::new(-2.0, 0.0, 0.0, -2.0, 0.0, 0.0), None),
+            // Y-flip: a and d differ in sign.
+            ("y-flip", Transform2D::new(1.0, 0.0, 0.0, -1.0, 0.0, 0.0), None),
+            // Off-diagonal terms just under epsilon are treated as zero...
+            (
+                "off-diagonal drift within epsilon",
+                Transform2D::new(2.0, 5e-4, 5e-4, 2.0, 0.0, 0.0),
+                Some((2.0, 0.0, 0.0)),
+            ),
+            // ... but just over epsilon is rejected.
+            (
+                "off-diagonal drift over epsilon",
+                Transform2D::new(2.0, 2e-3, 0.0, 2.0, 0.0, 0.0),
+                None,
+            ),
+            // Squareness (a vs d) uses a relative tolerance (eps * max(|a|, 1)), so
+            // a 0.05 difference at scale 100 (0.05 < 1e-3 * 100) is still uniform...
+            (
+                "squareness within relative tolerance",
+                Transform2D::new(100.0, 0.0, 0.0, 100.05, 0.0, 0.0),
+                Some((100.0, 0.0, 0.0)),
+            ),
+            // ... while a difference of 1.0 at the same scale is not.
+            (
+                "squareness over relative tolerance",
+                Transform2D::new(100.0, 0.0, 0.0, 101.0, 0.0, 0.0),
+                None,
+            ),
+        ];
+
+        for (description, transform, expected) in cases {
+            assert_eq!(
+                transform.as_uniform_scale_translation(EPS),
+                *expected,
+                "case: {description}"
+            );
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1527,13 +1527,49 @@ where
         let text_context = self.text_context.clone();
         let mut text_context = text_context.borrow_mut();
 
-        // When the canvas transform includes scale, rotation, or skew, fall back to
-        // path-based rendering instead of using atlas bitmaps. Atlas glyphs are rasterized
-        // at a fixed size, so applying a non-translation transform to the textured quad
-        // produces blurry or aliased results.
-        // Use 1e-3 as epsilon: tight enough to catch any intentional transform,
-        // but generous enough to tolerate floating-point drift from matrix operations.
-        let need_direct_rendering = paint.text.font_size > 92.0 || !self.state().transform.is_pure_translation(1e-3);
+        // How this glyph run is rasterized for the current canvas transform.
+        #[derive(Clone, Copy)]
+        enum Rasterization {
+            Path,
+            Atlas,
+            ScaledAtlas { scale: f32, translation: (f32, f32) },
+        }
+
+        // Classify the canvas transform. 1e-3 epsilon: tight enough to catch any
+        // intentional transform, loose enough to tolerate matrix-op drift.
+        let rasterization = match self.state().transform.as_uniform_scale_translation(1e-3) {
+            // Rotation / skew / non-uniform / negative scale: outline rendering.
+            None => Rasterization::Path,
+            Some((scale, tx, ty)) => {
+                // Quantize the baked scale so small animation steps don't churn the
+                // atlas; 1/16 steps (≈6%) are imperceptible at typical zoom levels.
+                let scale = geometry::quantize(scale, 1.0 / 16.0).max(1.0 / 16.0);
+                if paint.text.font_size * scale > 92.0 {
+                    // Cached bitmap would be too large.
+                    Rasterization::Path
+                } else if scale == 1.0 {
+                    // Pure translation (within a quantization step): nothing to bake.
+                    Rasterization::Atlas
+                } else if matches!(paint.flavor, PaintFlavor::Color(_)) {
+                    Rasterization::ScaledAtlas {
+                        scale,
+                        translation: (tx, ty),
+                    }
+                } else {
+                    // Gradients/images map their coordinates through the canvas
+                    // transform that the atlas path swaps out for a translation,
+                    // which would shift them; keep those direct.
+                    Rasterization::Path
+                }
+            }
+        };
+
+        let need_direct_rendering = matches!(rasterization, Rasterization::Path);
+        let effective_scale = match rasterization {
+            Rasterization::ScaledAtlas { scale, .. } => scale,
+            _ => 1.0,
+        };
+        let effective_font_size = paint.text.font_size * effective_scale;
 
         let Some(font) = text_context.font_mut(font_id) else {
             return Err(ErrorKind::NoFontFound);
@@ -1561,6 +1597,15 @@ where
             })
             .collect::<Vec<_>>();
 
+        // When baking scale into the rasterization, pre-multiply glyph positions
+        // by `effective_scale` so that under a translation-only canvas transform
+        // they still land at the original screen position.
+        let scaled = |g: &PositionedGlyph| PositionedGlyph {
+            x: g.x * effective_scale,
+            y: g.y * effective_scale,
+            glyph_id: g.glyph_id,
+        };
+
         let mut draw_commands = if need_direct_rendering {
             text::render_direct(
                 self,
@@ -1580,8 +1625,8 @@ where
                 font_id,
                 font,
                 &font_face,
-                non_color_glyphs.into_iter(),
-                paint.text.font_size,
+                non_color_glyphs.iter().map(scaled),
+                effective_font_size,
                 paint.stroke.line_width,
                 render_mode,
                 normalized_coords,
@@ -1598,24 +1643,57 @@ where
                     self.glyph_atlas.clone()
                 };
 
-                atlas.render_atlas(
-                    self,
-                    font_id,
-                    font,
-                    &font_face,
-                    color_glyphs.into_iter(),
-                    paint.text.font_size,
-                    paint.stroke.line_width,
-                    render_mode,
-                    normalized_coords,
-                )?
+                // Color glyphs on the atlas path follow the same scale baking.
+                // On the direct path we leave them at the original font_size —
+                // that already matches today's behavior.
+                if need_direct_rendering {
+                    atlas.render_atlas(
+                        self,
+                        font_id,
+                        font,
+                        &font_face,
+                        color_glyphs.into_iter(),
+                        paint.text.font_size,
+                        paint.stroke.line_width,
+                        render_mode,
+                        normalized_coords,
+                    )?
+                } else {
+                    atlas.render_atlas(
+                        self,
+                        font_id,
+                        font,
+                        &font_face,
+                        color_glyphs.iter().map(scaled),
+                        effective_font_size,
+                        paint.stroke.line_width,
+                        render_mode,
+                        normalized_coords,
+                    )?
+                }
             };
 
             draw_commands.alpha_glyphs.extend(color_commands.alpha_glyphs);
             draw_commands.color_glyphs.extend(color_commands.color_glyphs);
         }
 
-        self.draw_glyph_commands(draw_commands, paint);
+        // For the scaled-atlas path, present the pre-scaled glyph quads with a
+        // translation-only transform so the bitmap shows at its on-screen pixel
+        // size. render_atlas already emitted quads in the scaled glyph space, so
+        // only draw_glyph_commands (which applies the canvas transform) needs the
+        // swap — and since it is infallible, the transform is always restored even
+        // though the fallible rendering above used `?`.
+        match rasterization {
+            Rasterization::ScaledAtlas {
+                translation: (tx, ty), ..
+            } => {
+                let saved = self.state().transform;
+                self.state_mut().transform = Transform2D::translation(tx, ty);
+                self.draw_glyph_commands(draw_commands, paint);
+                self.state_mut().transform = saved;
+            }
+            _ => self.draw_glyph_commands(draw_commands, paint),
+        }
 
         Ok(())
     }
@@ -1864,4 +1942,134 @@ fn test_image_blit_fast_path() {
             ..
         })
     ));
+}
+
+/// Text rendering picks one of two strategies depending on the canvas transform
+/// and paint: cached atlas bitmaps (emitting a `Triangles` command that samples a
+/// glyph texture) or direct outline rendering (emitting plain path fills with no
+/// glyph texture). Verify each canvas use is routed to the expected strategy.
+#[cfg(feature = "textlayout")]
+#[test]
+fn fill_text_selects_atlas_or_path_rendering() {
+    use crate::paint::GlyphTexture;
+    use renderer::CommandType;
+
+    #[derive(Clone, Copy)]
+    enum PaintKind {
+        Solid,
+        BigSolid,
+        Gradient,
+    }
+
+    #[derive(Debug, PartialEq)]
+    enum Expect {
+        Atlas,
+        Path,
+    }
+
+    // A fresh canvas per case so the persistent glyph atlas (or any other state)
+    // built by one case can't influence another. A large viewport plus a
+    // near-origin draw position keeps even the heavily scaled cases on-screen —
+    // off-screen geometry is culled, which would hide the commands we inspect.
+    let make_canvas = || {
+        let renderer = RecordingRenderer::default();
+        let recorded = renderer.last_commands.clone();
+        let mut canvas = Canvas::new(renderer).unwrap();
+        canvas.set_size(4000, 4000, 1.0);
+        let font = canvas
+            .add_font_mem(include_bytes!("../examples/assets/amiri-regular.ttf"))
+            .expect("failed to load test font");
+        (canvas, recorded, font)
+    };
+
+    // (description, canvas transform, paint, expected strategy)
+    let cases = [
+        // Pure translation: cached atlas bitmaps, nothing baked.
+        (
+            "pure translation",
+            Transform2D::translation(10.0, 20.0),
+            PaintKind::Solid,
+            Expect::Atlas,
+        ),
+        // Uniform scale + solid color: the scale is baked into the atlas bitmap.
+        (
+            "uniform scale, solid",
+            Transform2D::scaling(2.0, 2.0),
+            PaintKind::Solid,
+            Expect::Atlas,
+        ),
+        // A scale that quantizes back to 1.0 still uses the atlas.
+        (
+            "near-unit scale, solid",
+            Transform2D::scaling(1.02, 1.02),
+            PaintKind::Solid,
+            Expect::Atlas,
+        ),
+        // Gradients can't bake scale (their coords map through the swapped-out
+        // transform), so a scaled gradient falls back to outlines.
+        (
+            "uniform scale, gradient",
+            Transform2D::scaling(2.0, 2.0),
+            PaintKind::Gradient,
+            Expect::Path,
+        ),
+        // Rotation isn't a uniform scale + translation: outlines.
+        (
+            "rotation",
+            Transform2D::rotation(std::f32::consts::FRAC_PI_4),
+            PaintKind::Solid,
+            Expect::Path,
+        ),
+        // Effective size over the 92px atlas cap: outlines.
+        (
+            "oversized scale",
+            Transform2D::scaling(20.0, 20.0),
+            PaintKind::Solid,
+            Expect::Path,
+        ),
+        (
+            "oversized font",
+            Transform2D::identity(),
+            PaintKind::BigSolid,
+            Expect::Path,
+        ),
+    ];
+
+    for (description, transform, paint_kind, expect) in cases {
+        let (mut canvas, recorded, font) = make_canvas();
+        let paint = match paint_kind {
+            PaintKind::Solid => Paint::color(Color::black()).with_font(&[font]),
+            PaintKind::BigSolid => Paint::color(Color::black()).with_font(&[font]).with_font_size(100.0),
+            PaintKind::Gradient => {
+                Paint::linear_gradient(0.0, 0.0, 100.0, 0.0, Color::black(), Color::white()).with_font(&[font])
+            }
+        };
+
+        // A fresh canvas starts at the identity transform.
+        canvas.set_transform(&transform);
+        canvas.fill_text(10.0, 40.0, "Hello", &paint).unwrap();
+        canvas.flush_to_output(());
+
+        let commands = recorded.borrow();
+        // Atlas rendering blits glyphs from a glyph texture; outline rendering only
+        // ever emits plain path fills (note: atlas cache misses also emit path fills
+        // while rasterizing into the atlas, so the glyph texture is the reliable
+        // discriminator, not the absence of fills).
+        let used_atlas = commands.iter().any(|c| !matches!(c.glyph_texture, GlyphTexture::None));
+        let filled_outlines = commands.iter().any(|c| {
+            matches!(c.glyph_texture, GlyphTexture::None)
+                && matches!(
+                    c.cmd_type,
+                    CommandType::ConvexFill { .. } | CommandType::ConcaveFill { .. }
+                )
+        });
+
+        match expect {
+            Expect::Atlas => assert!(used_atlas, "expected atlas rendering for case: {description}"),
+            Expect::Path => assert!(
+                filled_outlines && !used_atlas,
+                "expected outline rendering for case: {description} (used_atlas={used_atlas}, filled_outlines={filled_outlines})"
+            ),
+        }
+    }
 }


### PR DESCRIPTION
Previously any canvas transform that was not a pure translation forced text onto the path-rendering ("direct") fallback. As a result a uniformly zoomed or scaled UI paid for outline rasterization on every glyph and lost the benefit of the glyph atlas.

Instead, recognize a uniform-scale + translation transform and, for solid-color fills, bake the scale into the atlas rasterization instead of falling back:

  - rasterize the glyphs at font_size * scale,
  - pre-multiply the glyph positions by the same scale, and
  - draw the resulting quads with a translation-only transform.

This yields crisp text at the correct on-screen size while still hitting the shared glyph atlas. The baked scale is quantized to 1/16 steps so small animation changes don't thrash the atlas cache.