### PR TITLE
Add Canvas 2D drop shadows (shadowColor / shadowBlur / shadowOffset)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -522,6 +522,19 @@ where
     /// shadow color is fully transparent no offscreen shadow pass is performed and
     /// drawing adds zero overhead. The shadow color's own alpha multiplies the
     /// shadow's coverage.
+    ///
+    /// # Performance
+    ///
+    /// Shadows are not cheap: every shadowed fill, stroke or text draw renders the
+    /// shape's coverage into a transient offscreen image sized to its padded
+    /// bounds, runs a two-pass Gaussian blur over it (when `shadowBlur` is
+    /// non-zero), and composites the result — per draw, every frame. Prefer
+    /// shadowing a few composed shapes over many small primitives, and if the
+    /// same shadowed shape is drawn every frame, consider rendering it once into
+    /// an [image](Self::create_image_empty) via
+    /// [`set_render_target`](Self::set_render_target) and re-drawing that cached
+    /// image instead. Setting a fully transparent shadow color restores the
+    /// zero-overhead path.
     pub fn set_shadow_color(&mut self, color: Color) {
         self.state_mut().shadow_color = color;
     }
@@ -1455,10 +1468,18 @@ where
         else {
             return;
         };
-        let Ok(blurred_image) = self.create_image_empty(width, height, PixelFormat::Rgba8, ImageFlags::PREMULTIPLIED)
-        else {
-            self.delete_image(coverage_image);
-            return;
+        // The blur kernel divides by sigma, so a zero (or sub-pixel) blur skips
+        // the filter pass entirely — and with it the second offscreen image.
+        let blurred_image = if sigma >= 0.01 {
+            match self.create_image_empty(width, height, PixelFormat::Rgba8, ImageFlags::PREMULTIPLIED) {
+                Ok(image) => Some(image),
+                Err(_) => {
+                    self.delete_image(coverage_image);
+                    return;
+                }
+            }
+        } else {
+            None
         };
 
         let previous_target = self.current_render_target;
@@ -1505,10 +1526,9 @@ where
 
         self.restore();
 
-        // Blur the coverage into the second offscreen image. The blur kernel
-        // divides by sigma, so for a zero (or sub-pixel) blur we skip the filter
-        // entirely and composite the sharp coverage directly.
-        let source_image = if sigma >= 0.01 {
+        // Blur the coverage into the second offscreen image; a sharp shadow (no
+        // blur image allocated) composites the coverage directly.
+        let source_image = if let Some(blurred_image) = blurred_image {
             self.filter_image(blurred_image, ImageFilter::GaussianBlur { sigma }, coverage_image);
             blurred_image
         } else {
@@ -1550,7 +1570,9 @@ where
         // The transient images are referenced by deferred draw commands, so they
         // can only be freed after the next flush. Queue them for later cleanup.
         self.shadow_images.push(coverage_image);
-        self.shadow_images.push(blurred_image);
+        if let Some(blurred_image) = blurred_image {
+            self.shadow_images.push(blurred_image);
+        }
     }
 
     /// Frees offscreen images allocated by drop-shadow passes during the frame.
@@ -1921,13 +1943,22 @@ where
             }
         }
 
+        // The run-level shadow above is the only shadow this text should cast.
+        // Glyph runs that fall back to outline rendering are drawn through
+        // fill/stroke_path_internal, whose own shadow hooks would otherwise add a
+        // second shadow per glyph on top of it — so suppress shadows while the
+        // actual glyphs are drawn, restoring afterwards (also on error).
+        let saved_shadow_color = self.state().shadow_color;
+        self.state_mut().shadow_color = Color::rgbaf(0.0, 0.0, 0.0, 0.0);
+
+        let mut glyph_run_result = Ok(());
         for (font_id, glyph_run) in &layout
             .glyphs
             .iter()
             .filter(|shaped_glyph| !shaped_glyph.c.is_control())
             .chunk_by(|g| g.font_id)
         {
-            self.draw_glyph_run(
+            glyph_run_result = self.draw_glyph_run(
                 glyph_run.map(|shaped_glyph| PositionedGlyph {
                     x: shaped_glyph.x * invscale,
                     y: shaped_glyph.y * invscale,
@@ -1937,8 +1968,14 @@ where
                 font_id,
                 &normalized_coords,
                 render_mode,
-            )?;
+            );
+            if glyph_run_result.is_err() {
+                break;
+            }
         }
+
+        self.state_mut().shadow_color = saved_shadow_color;
+        glyph_run_result?;
 
         layout.scale(invscale);
 
@@ -3000,5 +3037,52 @@ fn large_shadow_blur_records_unclamped_spec_sigma() {
         sigma,
         Some(20.0),
         "the command must carry the unclamped spec sigma (blur/2); the 8.0 clamp is a renderer-side limitation"
+    );
+}
+
+/// A shadowed text run must perform exactly one run-level shadow pass, no matter
+/// how the glyphs are rasterized. Outline-rendered glyphs (large font sizes) are
+/// drawn through `fill_path_internal`, whose own shadow hook would otherwise add
+/// a per-glyph shadow on top of the run shadow — double-darkening the result and
+/// multiplying the offscreen cost by the glyph count. Compare the number of
+/// offscreen target switches for a 1-glyph and a many-glyph string: it must not
+/// scale with glyph count.
+#[cfg(feature = "textlayout")]
+#[test]
+fn outline_text_shadow_pass_count_is_glyph_count_invariant() {
+    use renderer::CommandType;
+
+    let shadow_target_switches = |text: &str| -> usize {
+        let renderer = RecordingRenderer::default();
+        let recorded = renderer.last_commands.clone();
+        let mut canvas = Canvas::new(renderer).unwrap();
+        canvas.set_size(600, 300, 1.0);
+
+        let font = canvas
+            .add_font("examples/assets/RobotoFlex-VariableFont.ttf")
+            .expect("Font not found");
+        // Font size above the atlas cap forces the outline (path) rasterization.
+        let paint = Paint::color(Color::white()).with_font(&[font]).with_font_size(100.0);
+
+        canvas.set_shadow_color(Color::rgba(0, 0, 0, 255));
+        canvas.set_shadow_offset(10.0, 10.0);
+        canvas.fill_text(20.0, 150.0, text, &paint).unwrap();
+        canvas.flush_to_output(());
+
+        let commands = recorded.borrow();
+        commands
+            .iter()
+            .filter(|c| matches!(c.cmd_type, CommandType::SetRenderTarget(RenderTarget::Image(_))))
+            .count()
+    };
+
+    let single = shadow_target_switches("I");
+    let many = shadow_target_switches("Illuminate");
+
+    assert!(single > 0, "shadowed text must run an offscreen shadow pass");
+    assert_eq!(
+        single, many,
+        "shadow passes must not scale with glyph count: outline glyphs would each cast \
+         their own shadow on top of the run-level one"
     );
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -533,10 +533,11 @@ where
     /// deviation is `shadowBlur / 2`, expressed in output (device) pixels. The
     /// default is `0` (no blur). Negative or non-finite values are ignored.
     ///
-    /// Known limitation: both renderer backends clamp the effective blur standard
-    /// deviation to 8.0 in their blur shader (a GLES 2.0 constraint on loop
-    /// bounds), so very large `shadowBlur` values (above ~16) stop spreading
-    /// further than a sigma of 8.0.
+    /// Known limitation: the blur shader caps its kernel reach at +/-24 px (a
+    /// GLES 2.0 constraint on loop bounds). This covers the full +/-3 sigma for
+    /// `shadowBlur` <= 16, which matches reference browsers exactly; larger values
+    /// render marginally tighter than spec (about 94% of the target sigma at
+    /// `shadowBlur` 24).
     pub fn set_shadow_blur(&mut self, blur: f32) {
         if blur.is_finite() && blur >= 0.0 {
             self.state_mut().shadow_blur = blur;
@@ -2960,14 +2961,15 @@ fn opaque_shadow_emits_offscreen_blur_pass() {
     );
 }
 
-/// Known limitation: both backends clamp the Gaussian standard deviation to 8.0
-/// in the blur shader (GLES 2.0 forbids non-constant loop bounds, so the sample
-/// count must have a fixed upper limit — see `render_gaussian_blur` in the
-/// OpenGL backend and `gaussian_blur_filter` in the wgpu backend). femtovg
-/// faithfully records the spec sigma (`shadowBlur / 2`) in the draw command, so
-/// the divergence lives entirely in the renderer: for `shadowBlur > 16` the
-/// effective blur saturates at sigma 8.0 rather than growing further. This test
-/// documents that the command still carries the un-clamped, spec-correct sigma.
+/// Known limitation: the blur shader uses the true (spec) Gaussian weights but
+/// caps the kernel *reach* (tap count) at +/-24 px, because GLES 2.0 forbids
+/// non-constant loop bounds (see `render_gaussian_blur` in the OpenGL backend and
+/// `gaussian_blur_filter` in the wgpu backend). The reach covers the full +/-3
+/// sigma for sigma <= 8 (`shadowBlur` <= 16), so those blurs match the reference
+/// renderers exactly. For larger `shadowBlur` the reach is below 3 sigma, so the
+/// blur renders marginally tighter than spec (about 94% of the target sigma at
+/// `shadowBlur` 24). femtovg still records the un-clamped, spec-correct sigma
+/// (`shadowBlur / 2`) in the draw command; this test documents that.
 #[test]
 fn large_shadow_blur_records_unclamped_spec_sigma() {
     use renderer::CommandType;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -270,6 +270,12 @@ struct State {
     transform: Transform2D,
     scissor: Scissor,
     alpha: f32,
+    // Canvas 2D drop-shadow attributes. Defaults match the HTML spec: a fully
+    // transparent shadow color (which disables shadows entirely), zero blur and
+    // zero offset. See `Canvas::set_shadow_color` and friends.
+    shadow_color: Color,
+    shadow_blur: f32,
+    shadow_offset: [f32; 2],
 }
 
 impl Default for State {
@@ -279,6 +285,11 @@ impl Default for State {
             transform: Transform2D::identity(),
             scissor: Scissor::default(),
             alpha: 1.0,
+            // rgba(0, 0, 0, 0): the spec default. A transparent shadow color
+            // means no shadow is painted, so the default path adds zero work.
+            shadow_color: Color::rgbaf(0.0, 0.0, 0.0, 0.0),
+            shadow_blur: 0.0,
+            shadow_offset: [0.0, 0.0],
         }
     }
 }
@@ -303,6 +314,10 @@ pub struct Canvas<T: Renderer> {
     tess_tol: f32,
     dist_tol: f32,
     gradients: GradientStore,
+    // Transient offscreen images allocated for drop-shadow passes. They are
+    // referenced by deferred draw commands, so they can only be freed once those
+    // commands have been submitted to the renderer (i.e. after flush).
+    shadow_images: Vec<ImageId>,
 }
 
 impl<T> Canvas<T>
@@ -330,6 +345,7 @@ where
             tess_tol: 0.25,
             dist_tol: 0.01,
             gradients: GradientStore::new(),
+            shadow_images: Vec::new(),
         };
 
         canvas.save();
@@ -359,6 +375,7 @@ where
             tess_tol: 0.25,
             dist_tol: 0.01,
             gradients: GradientStore::new(),
+            shadow_images: Vec::new(),
         };
 
         canvas.save();
@@ -439,6 +456,7 @@ where
         self.verts.clear();
         self.gradients
             .release_old_gradients(&mut self.images, &mut self.renderer);
+        self.release_shadow_images();
         if let Some(atlas) = self.ephemeral_glyph_atlas.take() {
             atlas.clear(self);
         }
@@ -495,6 +513,44 @@ where
     /// Already transparent paths will get proportionally more transparent as well.
     pub fn set_global_alpha(&mut self, alpha: f32) {
         self.state_mut().alpha = alpha;
+    }
+
+    /// Sets the color of drop shadows drawn behind subsequent fills, strokes and text.
+    ///
+    /// This mirrors the Canvas 2D `shadowColor` attribute. The default is a fully
+    /// transparent color (`rgba(0, 0, 0, 0)`), which disables shadows: when the
+    /// shadow color is fully transparent no offscreen shadow pass is performed and
+    /// drawing adds zero overhead. The shadow color's own alpha multiplies the
+    /// shadow's coverage.
+    pub fn set_shadow_color(&mut self, color: Color) {
+        self.state_mut().shadow_color = color;
+    }
+
+    /// Sets the blur radius applied to drop shadows.
+    ///
+    /// This mirrors the Canvas 2D `shadowBlur` attribute. Following the HTML
+    /// drawing model, the shadow image is blurred with a Gaussian whose standard
+    /// deviation is `shadowBlur / 2`, expressed in output (device) pixels. The
+    /// default is `0` (no blur). Negative or non-finite values are ignored.
+    ///
+    /// Known limitation: both renderer backends clamp the effective blur standard
+    /// deviation to 8.0 in their blur shader (a GLES 2.0 constraint on loop
+    /// bounds), so very large `shadowBlur` values (above ~16) stop spreading
+    /// further than a sigma of 8.0.
+    pub fn set_shadow_blur(&mut self, blur: f32) {
+        if blur.is_finite() && blur >= 0.0 {
+            self.state_mut().shadow_blur = blur;
+        }
+    }
+
+    /// Sets the drop shadow offset, in the current user coordinate space.
+    ///
+    /// This mirrors the Canvas 2D `shadowOffsetX`/`shadowOffsetY` attributes.
+    /// Positive `x` shifts the shadow right and positive `y` shifts it down. The
+    /// offset is transformed by the current transform, matching the spec. The
+    /// default is `(0, 0)`.
+    pub fn set_shadow_offset(&mut self, x: f32, y: f32) {
+        self.state_mut().shadow_offset = [x, y];
     }
 
     /// Sets the composite operation.
@@ -940,11 +996,27 @@ where
         let mut paint_flavor = paint_flavor.clone();
         let transform = self.state().transform;
 
-        // The path cache saves a flattened and transformed version of the path.
-        let mut path_cache = path.cache(&transform, self.tess_tol, self.dist_tol);
-
         let canvas_width = self.width();
         let canvas_height = self.height();
+
+        // Draw the drop shadow (if any) under the fill. The closure re-enters
+        // fill_path_internal with the shadow tint; render_shadow temporarily
+        // disables shadows in the state so this does not recurse. This runs in its
+        // own scope so the path cache's RefMut borrow is released before the path
+        // is cloned (cloning a Path while its cache is borrowed would panic).
+        if self.shadow_enabled() {
+            let bounds = {
+                let cache = path.cache(&transform, self.tess_tol, self.dist_tol);
+                cache.bounds
+            };
+            let path = path.clone();
+            self.render_shadow(bounds, move |canvas, tint| {
+                canvas.fill_path_internal(&path, &PaintFlavor::Color(tint), anti_alias, fill_rule);
+            });
+        }
+
+        // The path cache saves a flattened and transformed version of the path.
+        let mut path_cache = path.cache(&transform, self.tess_tol, self.dist_tol);
 
         // Early out if path is outside the canvas bounds
         if path_cache.bounds.maxx < 0.0
@@ -1123,6 +1195,37 @@ where
             return;
         }
 
+        // Draw the drop shadow (if any) under the stroke. The path-cache bounds
+        // only cover the centerline, so expand them by the device-space stroke
+        // half-width before handing them to render_shadow. This runs in its own
+        // scope so the cache's RefMut borrow is released before the path is cloned
+        // (cloning a Path while its cache is borrowed would panic). render_shadow
+        // disables shadows in the state, so re-entering stroke does not recurse.
+        if self.shadow_enabled() {
+            let centerline = {
+                let cache = path.cache(&transform, self.tess_tol, self.dist_tol);
+                cache.bounds
+            };
+            // Skip fully off-screen shapes (matches the cull below).
+            let on_screen = centerline.maxx >= 0.0
+                && centerline.minx <= self.width() as f32
+                && centerline.maxy >= 0.0
+                && centerline.miny <= self.height() as f32;
+            if on_screen {
+                let half = (stroke.line_width * transform.average_scale()).max(self.fringe_width) * 0.5;
+                let mut bounds = centerline;
+                bounds.minx -= half;
+                bounds.miny -= half;
+                bounds.maxx += half;
+                bounds.maxy += half;
+                let path = path.clone();
+                let stroke = stroke.clone();
+                self.render_shadow(bounds, move |canvas, tint| {
+                    canvas.stroke_path_internal(&path, &PaintFlavor::Color(tint), anti_alias, &stroke);
+                });
+            }
+        }
+
         // The path cache saves a flattened and transformed version of the path.
         let mut path_cache = path.cache(&transform, self.tess_tol, self.dist_tol);
 
@@ -1232,6 +1335,157 @@ where
         }
 
         self.append_cmd(cmd);
+    }
+
+    /// Returns `true` when the current state would paint a visible drop shadow.
+    ///
+    /// Matching the Canvas spec, shadows are only drawn when the shadow color is
+    /// not fully transparent. When this returns `false` the drawing entry points
+    /// skip the whole offscreen shadow pass, so the common (no-shadow) case has
+    /// zero added cost.
+    fn shadow_enabled(&self) -> bool {
+        self.state().shadow_color.a > 0.0
+    }
+
+    /// Renders a drop shadow for a shape whose device-space bounding box is
+    /// `shape_bounds`, using the supplied closure to draw the shape's coverage.
+    ///
+    /// The shape is first rendered (tinted with the shadow color) into a transient
+    /// offscreen image sized to the padded bounding box, then Gaussian-blurred via
+    /// the existing `filter_image` path (standard deviation `shadowBlur / 2`), and
+    /// finally composited back into the current render target, translated by the
+    /// device-space shadow offset and drawn *under* the actual shape. The current
+    /// scissor, global alpha and composite operation are honored when compositing.
+    ///
+    /// `draw_coverage` is invoked with the shadow color (premultiplied by global
+    /// alpha) and is expected to issue the shape's normal draw command(s); the
+    /// canvas transform in effect during the call already maps the shape's
+    /// device-space coordinates into the offscreen image.
+    fn render_shadow(&mut self, shape_bounds: Bounds, draw_coverage: impl FnOnce(&mut Self, Color)) {
+        // Degenerate / off-screen bounds: nothing to cast a shadow from.
+        if shape_bounds.maxx <= shape_bounds.minx || shape_bounds.maxy <= shape_bounds.miny {
+            return;
+        }
+
+        let state = *self.state();
+        let shadow_color = state.shadow_color;
+
+        // Standard deviation in device pixels (HTML drawing model: sigma = blur/2).
+        let sigma = state.shadow_blur / 2.0;
+
+        // Device-space shadow offset (the user-space offset transformed by the CTM,
+        // ignoring translation since an offset is a vector).
+        let [ox, oy] = state.shadow_offset;
+        let (txx, txy) = {
+            let Transform2D([a, b, c, d, _, _]) = state.transform;
+            (a * ox + c * oy, b * ox + d * oy)
+        };
+
+        // Pad the offscreen image for the blur kernel reach (~3 sigma covers
+        // >99.7% of the Gaussian) plus a fringe pixel for antialiased edges.
+        let pad = (sigma * 3.0).ceil() + 2.0;
+
+        // Coverage is rendered at the shape's own location; the offset is applied
+        // later when compositing, so the offscreen only needs to bound the shape.
+        let minx = (shape_bounds.minx - pad).floor();
+        let miny = (shape_bounds.miny - pad).floor();
+        let maxx = (shape_bounds.maxx + pad).ceil();
+        let maxy = (shape_bounds.maxy + pad).ceil();
+
+        let width = (maxx - minx) as usize;
+        let height = (maxy - miny) as usize;
+
+        // Guard against absurd allocations (e.g. enormous blur on a huge shape).
+        if width == 0 || height == 0 || width > 8192 || height > 8192 {
+            return;
+        }
+
+        let Ok(coverage_image) = self.create_image_empty(width, height, PixelFormat::Rgba8, ImageFlags::empty()) else {
+            return;
+        };
+        let Ok(blurred_image) = self.create_image_empty(width, height, PixelFormat::Rgba8, ImageFlags::empty()) else {
+            self.delete_image(coverage_image);
+            return;
+        };
+
+        let previous_target = self.current_render_target;
+
+        // Draw the shape's coverage, tinted with the shadow color, into the
+        // offscreen image. The image space is the device space translated so the
+        // padded bbox origin maps to (0, 0): pre-translate the CTM by (-minx, -miny).
+        self.save();
+        self.set_render_target(RenderTarget::Image(coverage_image));
+        self.clear_rect(0, 0, width as u32, height as u32, Color::rgbaf(0.0, 0.0, 0.0, 0.0));
+
+        // Build the offset transform for coverage rendering: original CTM with an
+        // extra device-space translation that shifts the shape into the offscreen.
+        let mut coverage_transform = Transform2D::translation(-minx, -miny);
+        coverage_transform.premultiply(&state.transform);
+        self.state_mut().transform = coverage_transform;
+        // Shadows are rasterized at full coverage and tinted opaque; the shadow
+        // color's alpha and the global alpha are applied when compositing.
+        self.state_mut().alpha = 1.0;
+        self.state_mut().scissor = Scissor::default();
+        self.state_mut().composite_operation = CompositeOperationState::default();
+        self.state_mut().shadow_color = Color::rgbaf(0.0, 0.0, 0.0, 0.0);
+
+        let opaque_shadow_tint = Color::rgbaf(shadow_color.r, shadow_color.g, shadow_color.b, 1.0);
+        draw_coverage(self, opaque_shadow_tint);
+
+        self.restore();
+
+        // Blur the coverage into the second offscreen image. The blur kernel
+        // divides by sigma, so for a zero (or sub-pixel) blur we skip the filter
+        // entirely and composite the sharp coverage directly.
+        let source_image = if sigma >= 0.01 {
+            self.filter_image(blurred_image, ImageFilter::GaussianBlur { sigma }, coverage_image);
+            blurred_image
+        } else {
+            coverage_image
+        };
+
+        // Composite the shadow back into the original target, offset by the
+        // device-space shadow offset and drawn under the shape. The shadow color's
+        // alpha and the global alpha are folded into the image tint here.
+        self.set_render_target(previous_target);
+
+        let dst_x = minx + txx;
+        let dst_y = miny + txy;
+
+        // The shadow image already carries shadow_color.rgb; modulate its alpha by
+        // the shadow color alpha and the current global alpha.
+        let tint = Color::rgbaf(1.0, 1.0, 1.0, shadow_color.a * state.alpha);
+        let mut shadow_paint = Paint::image_tint(source_image, dst_x, dst_y, width as f32, height as f32, 0.0, tint);
+        shadow_paint.set_anti_alias(false);
+
+        // Composite in plain device space (identity transform) at the offset
+        // position, honoring the caller's scissor and composite operation.
+        let saved_transform = self.state().transform;
+        let saved_alpha = self.state().alpha;
+        self.state_mut().transform = Transform2D::identity();
+        self.state_mut().alpha = 1.0;
+        self.state_mut().shadow_color = Color::rgbaf(0.0, 0.0, 0.0, 0.0);
+
+        let mut shadow_rect = Path::new();
+        shadow_rect.rect(dst_x, dst_y, width as f32, height as f32);
+        self.fill_path_internal(&shadow_rect, &shadow_paint.flavor, false, FillRule::NonZero);
+
+        self.state_mut().transform = saved_transform;
+        self.state_mut().alpha = saved_alpha;
+        self.state_mut().shadow_color = shadow_color;
+
+        // The transient images are referenced by deferred draw commands, so they
+        // can only be freed after the next flush. Queue them for later cleanup.
+        self.shadow_images.push(coverage_image);
+        self.shadow_images.push(blurred_image);
+    }
+
+    /// Frees offscreen images allocated by drop-shadow passes during the frame.
+    /// Called after the renderer has consumed the frame's commands.
+    fn release_shadow_images(&mut self) {
+        for id in std::mem::take(&mut self.shadow_images) {
+            self.images.remove(&mut self.renderer, id);
+        }
     }
 
     fn render_unclipped_image_blit(&mut self, target_rect: &Rect, transform: &Transform2D, paint_flavor: &PaintFlavor) {
@@ -1556,6 +1810,38 @@ where
             text::normalize_variations(&text_context, &paint.text.font_ids, &paint.text.font_variations)
         };
 
+        // Draw the drop shadow (if any) under the text. The shaped layout gives a
+        // user-space box; transform its corners by the CTM to obtain device-space
+        // bounds and let render_shadow re-enter draw_text with the shadow tint.
+        // (render_shadow disables shadows in the state so this does not recurse.)
+        if self.shadow_enabled() {
+            // Layout metrics are in the scaled shaping space; bring them back to
+            // user space. Expand vertically by the line height on both sides so
+            // ascenders, descenders and diacritics are fully covered.
+            let lx = layout.x * invscale;
+            let ly = layout.y * invscale;
+            let lw = layout.width() * invscale;
+            let lh = layout.height() * invscale;
+            let (ux0, uy0, ux1, uy1) = (lx, ly - lh, lx + lw, ly + lh + lh);
+
+            let transform = self.state().transform;
+            let mut device = Bounds::default();
+            for (cx, cy) in [(ux0, uy0), (ux1, uy0), (ux1, uy1), (ux0, uy1)] {
+                let (dx, dy) = transform.transform_point(cx, cy);
+                device.minx = device.minx.min(dx);
+                device.miny = device.miny.min(dy);
+                device.maxx = device.maxx.max(dx);
+                device.maxy = device.maxy.max(dy);
+            }
+
+            let text = text.to_owned();
+            let mut shadow_paint = paint.clone();
+            self.render_shadow(device, move |canvas, tint| {
+                shadow_paint.set_color(tint);
+                let _ = canvas.draw_text(x, y, &text, &shadow_paint, render_mode);
+            });
+        }
+
         for (font_id, glyph_run) in &layout
             .glyphs
             .iter()
@@ -1861,6 +2147,7 @@ where
         self.verts.clear();
         self.gradients
             .release_old_gradients(&mut self.images, &mut self.renderer);
+        self.release_shadow_images();
         if let Some(atlas) = self.ephemeral_glyph_atlas.take() {
             atlas.clear(self);
         }
@@ -2330,4 +2617,183 @@ fn fill_text_selects_atlas_or_path_rendering() {
             ),
         }
     }
+}
+
+/// The Canvas 2D shadow attributes must start at their spec-mandated defaults:
+/// a fully transparent shadow color, zero blur and zero offset.
+#[test]
+fn shadow_attribute_defaults_match_spec() {
+    let canvas = Canvas::new(RecordingRenderer::default()).unwrap();
+    let state = canvas.state();
+
+    assert_eq!(state.shadow_color, Color::rgbaf(0.0, 0.0, 0.0, 0.0));
+    assert_eq!(state.shadow_blur, 0.0);
+    assert_eq!(state.shadow_offset, [0.0, 0.0]);
+    // Transparent shadow color disables shadows entirely.
+    assert!(!canvas.shadow_enabled());
+}
+
+/// `set_shadow_blur` ignores negative and non-finite values, matching the Canvas
+/// spec ("on setting, if the value is negative, infinite, or NaN, it must be
+/// ignored").
+#[test]
+fn shadow_blur_rejects_invalid_values() {
+    let mut canvas = Canvas::new(RecordingRenderer::default()).unwrap();
+
+    canvas.set_shadow_blur(4.0);
+    assert_eq!(canvas.state().shadow_blur, 4.0);
+
+    canvas.set_shadow_blur(-1.0);
+    assert_eq!(canvas.state().shadow_blur, 4.0, "negative blur must be ignored");
+
+    canvas.set_shadow_blur(f32::NAN);
+    assert_eq!(canvas.state().shadow_blur, 4.0, "NaN blur must be ignored");
+
+    canvas.set_shadow_blur(f32::INFINITY);
+    assert_eq!(canvas.state().shadow_blur, 4.0, "infinite blur must be ignored");
+}
+
+/// Shadow attributes are part of the drawing state and must be stacked by
+/// save()/restore() like every other state member.
+#[test]
+fn shadow_state_is_saved_and_restored() {
+    let mut canvas = Canvas::new(RecordingRenderer::default()).unwrap();
+
+    canvas.set_shadow_color(Color::rgba(10, 20, 30, 40));
+    canvas.set_shadow_blur(5.0);
+    canvas.set_shadow_offset(3.0, 7.0);
+
+    canvas.save();
+    canvas.set_shadow_color(Color::rgba(99, 99, 99, 99));
+    canvas.set_shadow_blur(11.0);
+    canvas.set_shadow_offset(-1.0, -2.0);
+    assert_eq!(canvas.state().shadow_blur, 11.0);
+    canvas.restore();
+
+    assert_eq!(canvas.state().shadow_color, Color::rgba(10, 20, 30, 40));
+    assert_eq!(canvas.state().shadow_blur, 5.0);
+    assert_eq!(canvas.state().shadow_offset, [3.0, 7.0]);
+}
+
+/// With a transparent shadow color (the default), filling a path must NOT emit
+/// any offscreen shadow work: no SetRenderTarget and no RenderFilteredImage
+/// commands, just the plain fill. This guards the "zero added overhead" rule.
+#[test]
+fn transparent_shadow_emits_no_offscreen_work() {
+    use renderer::CommandType;
+
+    let renderer = RecordingRenderer::default();
+    let recorded = renderer.last_commands.clone();
+    let mut canvas = Canvas::new(renderer).unwrap();
+    canvas.set_size(100, 100, 1.0);
+
+    // Shadow color left at its transparent default.
+    canvas.set_shadow_blur(10.0);
+    canvas.set_shadow_offset(5.0, 5.0);
+
+    let mut path = Path::new();
+    path.rect(10.0, 10.0, 30.0, 30.0);
+    canvas.fill_path(&path, &Paint::color(Color::rgb(255, 0, 0)));
+    canvas.flush_to_output(());
+
+    let commands = recorded.borrow();
+    assert!(
+        !commands
+            .iter()
+            .any(|c| matches!(c.cmd_type, CommandType::RenderFilteredImage { .. })),
+        "transparent shadow must not run the blur filter"
+    );
+    assert!(
+        !commands
+            .iter()
+            .any(|c| matches!(c.cmd_type, CommandType::SetRenderTarget(RenderTarget::Image(_)))),
+        "transparent shadow must not allocate an offscreen render target"
+    );
+}
+
+/// With an opaque shadow color and a non-zero blur, filling a path must emit the
+/// offscreen shadow pass: render the coverage into an image target and run the
+/// Gaussian blur filter before the final fill.
+#[test]
+fn opaque_shadow_emits_offscreen_blur_pass() {
+    use renderer::CommandType;
+
+    let renderer = RecordingRenderer::default();
+    let recorded = renderer.last_commands.clone();
+    let mut canvas = Canvas::new(renderer).unwrap();
+    canvas.set_size(100, 100, 1.0);
+
+    canvas.set_shadow_color(Color::rgba(0, 0, 0, 255));
+    canvas.set_shadow_blur(6.0);
+    canvas.set_shadow_offset(4.0, 4.0);
+
+    let mut path = Path::new();
+    path.rect(10.0, 10.0, 30.0, 30.0);
+    canvas.fill_path(&path, &Paint::color(Color::rgb(255, 0, 0)));
+    canvas.flush_to_output(());
+
+    let commands = recorded.borrow();
+    let filtered = commands.iter().find_map(|c| match c.cmd_type {
+        CommandType::RenderFilteredImage { filter, .. } => Some(filter),
+        _ => None,
+    });
+
+    match filtered {
+        Some(ImageFilter::GaussianBlur { sigma }) => {
+            // HTML drawing model: sigma == shadowBlur / 2.
+            assert!(
+                (sigma - 3.0).abs() < 1e-4,
+                "expected sigma 3.0 for blur 6.0, got {sigma}"
+            );
+        }
+        None => panic!("opaque shadow must run the Gaussian blur filter"),
+    }
+
+    assert!(
+        commands
+            .iter()
+            .any(|c| matches!(c.cmd_type, CommandType::SetRenderTarget(RenderTarget::Image(_)))),
+        "opaque shadow must render coverage into an offscreen image target"
+    );
+}
+
+/// Known limitation: both backends clamp the Gaussian standard deviation to 8.0
+/// in the blur shader (GLES 2.0 forbids non-constant loop bounds, so the sample
+/// count must have a fixed upper limit — see `render_gaussian_blur` in the
+/// OpenGL backend and `gaussian_blur_filter` in the wgpu backend). femtovg
+/// faithfully records the spec sigma (`shadowBlur / 2`) in the draw command, so
+/// the divergence lives entirely in the renderer: for `shadowBlur > 16` the
+/// effective blur saturates at sigma 8.0 rather than growing further. This test
+/// documents that the command still carries the un-clamped, spec-correct sigma.
+#[test]
+fn large_shadow_blur_records_unclamped_spec_sigma() {
+    use renderer::CommandType;
+
+    let renderer = RecordingRenderer::default();
+    let recorded = renderer.last_commands.clone();
+    let mut canvas = Canvas::new(renderer).unwrap();
+    canvas.set_size(100, 100, 1.0);
+
+    // shadowBlur 40 => spec sigma 20, well past the renderers' 8.0 clamp.
+    canvas.set_shadow_color(Color::rgba(0, 0, 0, 255));
+    canvas.set_shadow_blur(40.0);
+
+    let mut path = Path::new();
+    path.rect(40.0, 40.0, 20.0, 20.0);
+    canvas.fill_path(&path, &Paint::color(Color::rgb(255, 0, 0)));
+    canvas.flush_to_output(());
+
+    let commands = recorded.borrow();
+    let sigma = commands.iter().find_map(|c| match c.cmd_type {
+        CommandType::RenderFilteredImage {
+            filter: ImageFilter::GaussianBlur { sigma },
+            ..
+        } => Some(sigma),
+        _ => None,
+    });
+    assert_eq!(
+        sigma,
+        Some(20.0),
+        "the command must carry the unclamped spec sigma (blur/2); the 8.0 clamp is a renderer-side limitation"
+    );
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -543,14 +543,19 @@ where
         }
     }
 
-    /// Sets the drop shadow offset, in the current user coordinate space.
+    /// Sets the drop shadow offset, in output (device) pixels.
     ///
     /// This mirrors the Canvas 2D `shadowOffsetX`/`shadowOffsetY` attributes.
-    /// Positive `x` shifts the shadow right and positive `y` shifts it down. The
-    /// offset is transformed by the current transform, matching the spec. The
-    /// default is `(0, 0)`.
+    /// Positive `x` shifts the shadow right and positive `y` shifts it down. Per
+    /// the spec the offset is *not* affected by the current transformation
+    /// matrix: it keeps the same magnitude and direction relative to the shape
+    /// regardless of scale or rotation. Non-finite values are ignored (the
+    /// previous offset is preserved), matching the Canvas setter semantics used
+    /// by `set_shadow_blur`. The default is `(0, 0)`.
     pub fn set_shadow_offset(&mut self, x: f32, y: f32) {
-        self.state_mut().shadow_offset = [x, y];
+        if x.is_finite() && y.is_finite() {
+            self.state_mut().shadow_offset = [x, y];
+        }
     }
 
     /// Sets the composite operation.
@@ -1000,7 +1005,8 @@ where
         let canvas_height = self.height();
 
         // Draw the drop shadow (if any) under the fill. The closure re-enters
-        // fill_path_internal with the shadow tint; render_shadow temporarily
+        // fill_path_internal with the *real* paint so render_shadow can build the
+        // shadow from the source's true per-pixel alpha; render_shadow temporarily
         // disables shadows in the state so this does not recurse. This runs in its
         // own scope so the path cache's RefMut borrow is released before the path
         // is cloned (cloning a Path while its cache is borrowed would panic).
@@ -1009,10 +1015,15 @@ where
                 let cache = path.cache(&transform, self.tess_tol, self.dist_tol);
                 cache.bounds
             };
-            let path = path.clone();
-            self.render_shadow(bounds, move |canvas, tint| {
-                canvas.fill_path_internal(&path, &PaintFlavor::Color(tint), anti_alias, fill_rule);
-            });
+            // Only skip when even the offset+blurred shadow cannot reach the
+            // target; an off-screen shape may still cast an on-screen shadow.
+            if self.shadow_could_be_visible(bounds) {
+                let path = path.clone();
+                let shadow_flavor = paint_flavor.clone();
+                self.render_shadow(bounds, move |canvas| {
+                    canvas.fill_path_internal(&path, &shadow_flavor, anti_alias, fill_rule);
+                });
+            }
         }
 
         // The path cache saves a flattened and transformed version of the path.
@@ -1206,22 +1217,22 @@ where
                 let cache = path.cache(&transform, self.tess_tol, self.dist_tol);
                 cache.bounds
             };
-            // Skip fully off-screen shapes (matches the cull below).
-            let on_screen = centerline.maxx >= 0.0
-                && centerline.minx <= self.width() as f32
-                && centerline.maxy >= 0.0
-                && centerline.miny <= self.height() as f32;
-            if on_screen {
-                let half = (stroke.line_width * transform.average_scale()).max(self.fringe_width) * 0.5;
-                let mut bounds = centerline;
-                bounds.minx -= half;
-                bounds.miny -= half;
-                bounds.maxx += half;
-                bounds.maxy += half;
+            let half = (stroke.line_width * transform.average_scale()).max(self.fringe_width) * 0.5;
+            let mut bounds = centerline;
+            bounds.minx -= half;
+            bounds.miny -= half;
+            bounds.maxx += half;
+            bounds.maxy += half;
+            // Skip only when even the offset+blurred shadow cannot reach the
+            // render target. The offset and blur spread can pull a shadow back
+            // on-screen for a shape whose own bounds are off-screen, so we must
+            // not cull on the shape's bounds alone.
+            if self.shadow_could_be_visible(bounds) {
                 let path = path.clone();
                 let stroke = stroke.clone();
-                self.render_shadow(bounds, move |canvas, tint| {
-                    canvas.stroke_path_internal(&path, &PaintFlavor::Color(tint), anti_alias, &stroke);
+                let shadow_flavor = paint_flavor.clone();
+                self.render_shadow(bounds, move |canvas| {
+                    canvas.stroke_path_internal(&path, &shadow_flavor, anti_alias, &stroke);
                 });
             }
         }
@@ -1339,29 +1350,61 @@ where
 
     /// Returns `true` when the current state would paint a visible drop shadow.
     ///
-    /// Matching the Canvas spec, shadows are only drawn when the shadow color is
-    /// not fully transparent. When this returns `false` the drawing entry points
-    /// skip the whole offscreen shadow pass, so the common (no-shadow) case has
-    /// zero added cost.
+    /// Matching the Canvas spec, a shadow is only drawn when the shadow color is
+    /// not fully transparent *and* at least one of the blur or offset components
+    /// is non-zero. (An opaque shadow color with zero blur and zero offset would
+    /// land exactly under the shape and contribute nothing, so the spec treats it
+    /// as no shadow.) When this returns `false` the drawing entry points skip the
+    /// whole offscreen shadow pass, so the common (no-shadow) case has zero added
+    /// cost.
     fn shadow_enabled(&self) -> bool {
-        self.state().shadow_color.a > 0.0
+        let state = self.state();
+        state.shadow_color.a > 0.0
+            && (state.shadow_blur != 0.0 || state.shadow_offset[0] != 0.0 || state.shadow_offset[1] != 0.0)
+    }
+
+    /// Returns `true` when the drop shadow for a shape with the given device-space
+    /// `shape_bounds` could land on the render target once the (device-space)
+    /// shadow offset and blur spread are taken into account.
+    ///
+    /// Drawing entry points must not cull a shadow on the shape's own bounds
+    /// alone: a shape entirely off-screen can still cast a visible shadow when the
+    /// offset and/or blur pull the shadow back onto the target. The blur spread is
+    /// `ceil(3 * sigma)` (sigma = `shadowBlur / 2`), which covers >99.7% of the
+    /// Gaussian — the same reach `render_shadow` uses to pad its offscreen image.
+    fn shadow_could_be_visible(&self, shape_bounds: Bounds) -> bool {
+        let state = self.state();
+        let [ox, oy] = state.shadow_offset;
+        let spread = (state.shadow_blur / 2.0 * 3.0).ceil();
+        let minx = shape_bounds.minx + ox - spread;
+        let miny = shape_bounds.miny + oy - spread;
+        let maxx = shape_bounds.maxx + ox + spread;
+        let maxy = shape_bounds.maxy + oy + spread;
+        maxx >= 0.0 && minx <= self.width() as f32 && maxy >= 0.0 && miny <= self.height() as f32
     }
 
     /// Renders a drop shadow for a shape whose device-space bounding box is
     /// `shape_bounds`, using the supplied closure to draw the shape's coverage.
     ///
-    /// The shape is first rendered (tinted with the shadow color) into a transient
-    /// offscreen image sized to the padded bounding box, then Gaussian-blurred via
-    /// the existing `filter_image` path (standard deviation `shadowBlur / 2`), and
-    /// finally composited back into the current render target, translated by the
-    /// device-space shadow offset and drawn *under* the actual shape. The current
-    /// scissor, global alpha and composite operation are honored when compositing.
+    /// Per the Canvas drawing model the shadow is built from the *alpha of the
+    /// actually-rendered source*, not from a forced-opaque tint: a semi-transparent
+    /// fill, or a gradient/image with transparent texels, must cast a
+    /// correspondingly weaker shadow. To achieve this the closure draws the real
+    /// source (its actual paint and per-pixel alpha) into a transient offscreen
+    /// image, then a solid `shadowColor` is composited over it with
+    /// `CompositeOperation::SourceIn`, which masks the shadow color by the source's
+    /// alpha. The result carries `shadowColor.rgb` with alpha
+    /// `source.alpha * shadowColor.a` per pixel. That image is then
+    /// Gaussian-blurred via the existing `filter_image` path (standard deviation
+    /// `shadowBlur / 2`) and finally composited back into the current render
+    /// target, translated by the device-space shadow offset and drawn *under* the
+    /// actual shape. The current scissor, global alpha and composite operation are
+    /// honored when compositing.
     ///
-    /// `draw_coverage` is invoked with the shadow color (premultiplied by global
-    /// alpha) and is expected to issue the shape's normal draw command(s); the
-    /// canvas transform in effect during the call already maps the shape's
-    /// device-space coordinates into the offscreen image.
-    fn render_shadow(&mut self, shape_bounds: Bounds, draw_coverage: impl FnOnce(&mut Self, Color)) {
+    /// `draw_coverage` is expected to issue the shape's normal draw command(s) with
+    /// its real paint; the canvas transform in effect during the call already maps
+    /// the shape's device-space coordinates into the offscreen image.
+    fn render_shadow(&mut self, shape_bounds: Bounds, draw_coverage: impl FnOnce(&mut Self)) {
         // Degenerate / off-screen bounds: nothing to cast a shadow from.
         if shape_bounds.maxx <= shape_bounds.minx || shape_bounds.maxy <= shape_bounds.miny {
             return;
@@ -1373,13 +1416,14 @@ where
         // Standard deviation in device pixels (HTML drawing model: sigma = blur/2).
         let sigma = state.shadow_blur / 2.0;
 
-        // Device-space shadow offset (the user-space offset transformed by the CTM,
-        // ignoring translation since an offset is a vector).
-        let [ox, oy] = state.shadow_offset;
-        let (txx, txy) = {
-            let Transform2D([a, b, c, d, _, _]) = state.transform;
-            (a * ox + c * oy, b * ox + d * oy)
-        };
+        // The shadow offset is expressed in output (device) pixels and, per the
+        // Canvas spec, is NOT affected by the current transformation matrix: it
+        // keeps the same magnitude and direction relative to the shape under any
+        // scale or rotation. Apply the raw components directly when positioning
+        // the blurred shadow (matching WebKit: "canvas shadows must not be
+        // affected by any transformation and keep the same offset relative to the
+        // shape").
+        let [txx, txy] = state.shadow_offset;
 
         // Pad the offscreen image for the blur kernel reach (~3 sigma covers
         // >99.7% of the Gaussian) plus a fringe pixel for antialiased edges.
@@ -1400,18 +1444,27 @@ where
             return;
         }
 
-        let Ok(coverage_image) = self.create_image_empty(width, height, PixelFormat::Rgba8, ImageFlags::empty()) else {
+        // Offscreen render targets store premultiplied-alpha results, so flag the
+        // images as PREMULTIPLIED. Otherwise the image-sampling shader would
+        // re-premultiply on composite (multiplying rgb by alpha a second time),
+        // darkening partially-transparent shadow texels — which the source-alpha
+        // shadow now produces wherever the source is semi-transparent or
+        // antialiased.
+        let Ok(coverage_image) = self.create_image_empty(width, height, PixelFormat::Rgba8, ImageFlags::PREMULTIPLIED)
+        else {
             return;
         };
-        let Ok(blurred_image) = self.create_image_empty(width, height, PixelFormat::Rgba8, ImageFlags::empty()) else {
+        let Ok(blurred_image) = self.create_image_empty(width, height, PixelFormat::Rgba8, ImageFlags::PREMULTIPLIED)
+        else {
             self.delete_image(coverage_image);
             return;
         };
 
         let previous_target = self.current_render_target;
 
-        // Draw the shape's coverage, tinted with the shadow color, into the
-        // offscreen image. The image space is the device space translated so the
+        // Draw the *real* source (its actual paint and per-pixel alpha) into the
+        // offscreen image, then recolor it by the shadow color while preserving the
+        // source alpha. The image space is the device space translated so the
         // padded bbox origin maps to (0, 0): pre-translate the CTM by (-minx, -miny).
         self.save();
         self.set_render_target(RenderTarget::Image(coverage_image));
@@ -1422,15 +1475,32 @@ where
         let mut coverage_transform = Transform2D::translation(-minx, -miny);
         coverage_transform.premultiply(&state.transform);
         self.state_mut().transform = coverage_transform;
-        // Shadows are rasterized at full coverage and tinted opaque; the shadow
-        // color's alpha and the global alpha are applied when compositing.
+        // Render the source at full strength: the shadow color's alpha and the
+        // global alpha are applied later (the former via the SourceIn mask below,
+        // the latter when compositing the finished shadow under the shape).
         self.state_mut().alpha = 1.0;
         self.state_mut().scissor = Scissor::default();
         self.state_mut().composite_operation = CompositeOperationState::default();
         self.state_mut().shadow_color = Color::rgbaf(0.0, 0.0, 0.0, 0.0);
 
-        let opaque_shadow_tint = Color::rgbaf(shadow_color.r, shadow_color.g, shadow_color.b, 1.0);
-        draw_coverage(self, opaque_shadow_tint);
+        // 1. Rasterize the source with its real paint so the offscreen holds the
+        //    source's true per-pixel alpha (semi-transparent fills, gradient/image
+        //    transparency, antialiased edges, ...).
+        draw_coverage(self);
+
+        // 2. Recolor by the shadow color, masked by the source alpha. SourceIn
+        //    keeps `shadowColor * dst.alpha`, so the offscreen ends up carrying
+        //    shadowColor.rgb with per-pixel alpha = source.alpha * shadowColor.a.
+        //    Where the source was transparent the shadow stays transparent, so a
+        //    fully transparent source casts no shadow and a 50%-alpha source casts
+        //    a half-strength shadow. The mask must cover the whole offscreen in its
+        //    own pixel space, so draw it with the identity transform (not the
+        //    shape's coverage transform, which is scaled/translated).
+        self.state_mut().transform = Transform2D::identity();
+        self.state_mut().composite_operation = CompositeOperationState::new(CompositeOperation::SourceIn);
+        let mut mask_rect = Path::new();
+        mask_rect.rect(0.0, 0.0, width as f32, height as f32);
+        self.fill_path_internal(&mask_rect, &PaintFlavor::Color(shadow_color), false, FillRule::NonZero);
 
         self.restore();
 
@@ -1446,15 +1516,17 @@ where
 
         // Composite the shadow back into the original target, offset by the
         // device-space shadow offset and drawn under the shape. The shadow color's
-        // alpha and the global alpha are folded into the image tint here.
+        // alpha is already baked into the image (via the SourceIn mask); only the
+        // global alpha is folded into the image tint here.
         self.set_render_target(previous_target);
 
         let dst_x = minx + txx;
         let dst_y = miny + txy;
 
-        // The shadow image already carries shadow_color.rgb; modulate its alpha by
-        // the shadow color alpha and the current global alpha.
-        let tint = Color::rgbaf(1.0, 1.0, 1.0, shadow_color.a * state.alpha);
+        // The shadow image already carries shadowColor.rgb and per-pixel alpha
+        // `source.alpha * shadowColor.a` (baked in by the SourceIn mask above), so
+        // here we only fold in the current global alpha.
+        let tint = Color::rgbaf(1.0, 1.0, 1.0, state.alpha);
         let mut shadow_paint = Paint::image_tint(source_image, dst_x, dst_y, width as f32, height as f32, 0.0, tint);
         shadow_paint.set_anti_alias(false);
 
@@ -1834,12 +1906,18 @@ where
                 device.maxy = device.maxy.max(dy);
             }
 
-            let text = text.to_owned();
-            let mut shadow_paint = paint.clone();
-            self.render_shadow(device, move |canvas, tint| {
-                shadow_paint.set_color(tint);
-                let _ = canvas.draw_text(x, y, &text, &shadow_paint, render_mode);
-            });
+            // Skip only when the offset+blurred shadow cannot reach the target;
+            // text just off-screen may still cast an on-screen shadow.
+            if self.shadow_could_be_visible(device) {
+                let text = text.to_owned();
+                // Draw the text with its *real* paint so the shadow is built from
+                // the glyphs' true coverage/alpha; render_shadow recolors it by the
+                // shadow color while preserving that alpha.
+                let shadow_paint = paint.clone();
+                self.render_shadow(device, move |canvas| {
+                    let _ = canvas.draw_text(x, y, &text, &shadow_paint, render_mode);
+                });
+            }
         }
 
         for (font_id, glyph_run) in &layout
@@ -2631,6 +2709,20 @@ fn shadow_attribute_defaults_match_spec() {
     assert_eq!(state.shadow_offset, [0.0, 0.0]);
     // Transparent shadow color disables shadows entirely.
     assert!(!canvas.shadow_enabled());
+
+    // Per the enable rule, even an opaque shadow color stays disabled while blur
+    // and offset are both zero (the shadow would land exactly under the shape).
+    let mut canvas = canvas;
+    canvas.set_shadow_color(Color::rgba(0, 0, 0, 255));
+    assert!(
+        !canvas.shadow_enabled(),
+        "opaque color alone (zero blur, zero offset) must not enable a shadow"
+    );
+    canvas.set_shadow_offset(1.0, 0.0);
+    assert!(
+        canvas.shadow_enabled(),
+        "a non-zero offset with an opaque color must enable the shadow"
+    );
 }
 
 /// `set_shadow_blur` ignores negative and non-finite values, matching the Canvas
@@ -2651,6 +2743,117 @@ fn shadow_blur_rejects_invalid_values() {
 
     canvas.set_shadow_blur(f32::INFINITY);
     assert_eq!(canvas.state().shadow_blur, 4.0, "infinite blur must be ignored");
+}
+
+/// `set_shadow_offset` ignores non-finite values, preserving the previous offset.
+/// This matches the Canvas setter semantics already used by `set_shadow_blur` and
+/// keeps NaN/inf out of the offscreen geometry.
+#[test]
+fn shadow_offset_rejects_non_finite_values() {
+    let mut canvas = Canvas::new(RecordingRenderer::default()).unwrap();
+
+    canvas.set_shadow_offset(10.0, -5.0);
+    assert_eq!(canvas.state().shadow_offset, [10.0, -5.0]);
+
+    canvas.set_shadow_offset(f32::NAN, 7.0);
+    assert_eq!(
+        canvas.state().shadow_offset,
+        [10.0, -5.0],
+        "NaN x must be ignored, previous offset preserved"
+    );
+
+    canvas.set_shadow_offset(3.0, f32::INFINITY);
+    assert_eq!(
+        canvas.state().shadow_offset,
+        [10.0, -5.0],
+        "infinite y must be ignored, previous offset preserved"
+    );
+
+    canvas.set_shadow_offset(f32::NEG_INFINITY, f32::NAN);
+    assert_eq!(
+        canvas.state().shadow_offset,
+        [10.0, -5.0],
+        "non-finite components must be ignored, previous offset preserved"
+    );
+
+    // A subsequent finite update still applies.
+    canvas.set_shadow_offset(2.0, 4.0);
+    assert_eq!(canvas.state().shadow_offset, [2.0, 4.0]);
+}
+
+/// Per the Canvas spec a shadow is painted only when the shadow color is
+/// non-transparent AND at least one of blur, offsetX or offsetY is non-zero. An
+/// opaque shadow color with zero blur and zero offset must therefore emit no
+/// offscreen shadow pass; flipping on a non-zero offset *or* a non-zero blur must
+/// re-enable it.
+#[test]
+fn shadow_enable_rule_requires_blur_or_offset() {
+    use renderer::CommandType;
+
+    let run = |configure: &dyn Fn(&mut Canvas<RecordingRenderer>)| -> bool {
+        let renderer = RecordingRenderer::default();
+        let recorded = renderer.last_commands.clone();
+        let mut canvas = Canvas::new(renderer).unwrap();
+        canvas.set_size(100, 100, 1.0);
+        configure(&mut canvas);
+
+        let mut path = Path::new();
+        path.rect(10.0, 10.0, 30.0, 30.0);
+        canvas.fill_path(&path, &Paint::color(Color::rgb(255, 0, 0)));
+        canvas.flush_to_output(());
+
+        let commands = recorded.borrow();
+        commands
+            .iter()
+            .any(|c| matches!(c.cmd_type, CommandType::SetRenderTarget(RenderTarget::Image(_))))
+    };
+
+    // Opaque color, zero blur, zero offset: no shadow.
+    assert!(
+        !run(&|canvas| {
+            canvas.set_shadow_color(Color::rgba(0, 0, 0, 255));
+            canvas.set_shadow_blur(0.0);
+            canvas.set_shadow_offset(0.0, 0.0);
+        }),
+        "opaque color with zero blur and zero offset must not emit a shadow pass"
+    );
+
+    // A non-zero offsetX re-enables the shadow.
+    assert!(
+        run(&|canvas| {
+            canvas.set_shadow_color(Color::rgba(0, 0, 0, 255));
+            canvas.set_shadow_offset(5.0, 0.0);
+        }),
+        "a non-zero offset must re-enable the shadow"
+    );
+
+    // A non-zero offsetY re-enables the shadow.
+    assert!(
+        run(&|canvas| {
+            canvas.set_shadow_color(Color::rgba(0, 0, 0, 255));
+            canvas.set_shadow_offset(0.0, 5.0);
+        }),
+        "a non-zero offsetY must re-enable the shadow"
+    );
+
+    // A non-zero blur re-enables the shadow.
+    assert!(
+        run(&|canvas| {
+            canvas.set_shadow_color(Color::rgba(0, 0, 0, 255));
+            canvas.set_shadow_blur(4.0);
+        }),
+        "a non-zero blur must re-enable the shadow"
+    );
+
+    // Non-zero blur/offset but transparent color stays disabled.
+    assert!(
+        !run(&|canvas| {
+            canvas.set_shadow_color(Color::rgba(0, 0, 0, 0));
+            canvas.set_shadow_blur(4.0);
+            canvas.set_shadow_offset(5.0, 5.0);
+        }),
+        "transparent shadow color must keep the shadow disabled"
+    );
 }
 
 /// Shadow attributes are part of the drawing state and must be stacked by

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1464,14 +1464,24 @@ where
         // darkening partially-transparent shadow texels — which the source-alpha
         // shadow now produces wherever the source is semi-transparent or
         // antialiased.
-        let Ok(coverage_image) = self.create_image_empty(width, height, PixelFormat::Rgba8, ImageFlags::PREMULTIPLIED)
-        else {
+        //
+        // Image render targets store their content vertically flipped in texture
+        // space: both backends keep the GL FBO convention where canvas y = 0 lands
+        // on the *last* texture row (the wgpu backend's texture-target vertex
+        // stage reproduces it deliberately, and the glyph atlas pre-flips its
+        // rasterization coordinates to compensate). FLIP_Y declares that
+        // orientation so the composite below samples the coverage upright;
+        // without it the shadow is mirrored about its rect's horizontal midline.
+        // The Gaussian blur is unaffected: each of its two passes flips once, so
+        // the blurred image keeps the coverage image's orientation.
+        let image_flags = ImageFlags::PREMULTIPLIED | ImageFlags::FLIP_Y;
+        let Ok(coverage_image) = self.create_image_empty(width, height, PixelFormat::Rgba8, image_flags) else {
             return;
         };
         // The blur kernel divides by sigma, so a zero (or sub-pixel) blur skips
         // the filter pass entirely — and with it the second offscreen image.
         let blurred_image = if sigma >= 0.01 {
-            match self.create_image_empty(width, height, PixelFormat::Rgba8, ImageFlags::PREMULTIPLIED) {
+            match self.create_image_empty(width, height, PixelFormat::Rgba8, image_flags) {
                 Ok(image) => Some(image),
                 Err(_) => {
                     self.delete_image(coverage_image);
@@ -1911,13 +1921,25 @@ where
         // (render_shadow disables shadows in the state so this does not recurse.)
         if self.shadow_enabled() {
             // Layout metrics are in the scaled shaping space; bring them back to
-            // user space. Expand vertically by the line height on both sides so
+            // user space. The horizontal extent is derived from the union of the
+            // glyph boxes rather than the advance-summed layout width: negative
+            // letter spacing can collapse the summed width to zero while ink is
+            // still painted, and the shadow must cover everything that is drawn.
+            // Expand by the line height on all sides so bearings, overhang,
             // ascenders, descenders and diacritics are fully covered.
-            let lx = layout.x * invscale;
+            let (mut gx0, mut gx1) = (f32::INFINITY, f32::NEG_INFINITY);
+            for glyph in &layout.glyphs {
+                gx0 = gx0.min(glyph.x);
+                gx1 = gx1.max(glyph.x + glyph.width);
+            }
             let ly = layout.y * invscale;
-            let lw = layout.width() * invscale;
             let lh = layout.height() * invscale;
-            let (ux0, uy0, ux1, uy1) = (lx, ly - lh, lx + lw, ly + lh + lh);
+            let (ux0, uy0, ux1, uy1) = if gx0 <= gx1 {
+                (gx0 * invscale - lh, ly - lh, gx1 * invscale + lh, ly + lh + lh)
+            } else {
+                // No drawable glyphs: nothing painted, nothing to shadow.
+                (0.0, 0.0, 0.0, 0.0)
+            };
 
             let transform = self.state().transform;
             let mut device = Bounds::default();

--- a/src/renderer/opengl/main-fs.glsl
+++ b/src/renderer/opengl/main-fs.glsl
@@ -131,7 +131,7 @@ vec4 renderPlainTextureCopy() {
 }
 
 vec4 renderFilteredImage() {
-    float sampleCount = ceil(1.5 * imageBlurFilterSigma);
+    float sampleCount = ceil(3.0 * imageBlurFilterSigma);
 
     vec3 gaussian_coeff = imageBlurFilterCoeff;
 
@@ -139,9 +139,10 @@ vec4 renderFilteredImage() {
     float coefficient_sum = gaussian_coeff.x;
     gaussian_coeff.xy *= gaussian_coeff.yz;
 
-    for (float i = 1.0; i <= 12.0; i += 1.) {
-        // Work around GLES 2.0 limitation of only allowing constant loop indices
-        // by breaking here. Sigma has an upper bound of 8, imposed on the Rust side.
+    for (float i = 1.0; i <= 24.0; i += 1.) {
+        // Work around GLES 2.0 limitation of only allowing constant loop indices by
+        // breaking here. Sigma is clamped to 8 on the Rust side and the kernel reaches
+        // +/-3*sigma, so the tap count never exceeds this 24-iteration bound.
         if (i >= sampleCount) {
             break;
         }

--- a/src/renderer/wgpu/shader.wgsl
+++ b/src/renderer/wgpu/shader.wgsl
@@ -253,7 +253,7 @@ fn renderPlainTextureCopy(vertex: VertexOutput, params: Params) -> vec4<f32> {
 }
 
 fn renderFilteredImage(vertex: VertexOutput, params: Params) -> vec4<f32> {
-    let sampleCount: f32 = ceil(1.5 * params.image_blur_filter_sigma);
+    let sampleCount: f32 = ceil(3.0 * params.image_blur_filter_sigma);
 
     var gaussian_coeff: vec3<f32> = params.image_blur_filter_coeff;
 
@@ -262,9 +262,10 @@ fn renderFilteredImage(vertex: VertexOutput, params: Params) -> vec4<f32> {
     gaussian_coeff.x *= gaussian_coeff.y;
     gaussian_coeff.y *= gaussian_coeff.z;
 
-    for (var i: f32 = 1.0; i <= 12.0; i += 1.) {
-        // Work around GLES 2.0 limitation of only allowing constant loop indices
-        // by breaking here. Sigma has an upper bound of 8, imposed on the Rust side.
+    for (var i: f32 = 1.0; i <= 24.0; i += 1.) {
+        // Work around GLES 2.0 limitation of only allowing constant loop indices by
+        // breaking here. Sigma is clamped to 8 on the Rust side and the kernel reaches
+        // +/-3*sigma, so the tap count never exceeds this 24-iteration bound.
         if (i >= sampleCount) {
             break;
         }

--- a/tests/shadow_wgpu.rs
+++ b/tests/shadow_wgpu.rs
@@ -1,0 +1,347 @@
+//! Headless GPU render tests for Canvas 2D drop shadows.
+//!
+//! These exercise the actual pixel behavior of the shadow pipeline on the wgpu
+//! backend: an opaque shadow color must paint shadow-colored pixels offset from
+//! the shape, a transparent shadow color must paint nothing, the shadow color's
+//! alpha must be respected, and blur must spread coverage past the shape edge.
+//!
+//! All tests gracefully skip (return early) when no GPU adapter is available so
+//! they don't fail on backend-less CI.
+#![cfg(feature = "wgpu")]
+
+use femtovg::{renderer::WGPURenderer, Canvas, Color, Paint, Path, RenderTarget};
+
+const W: u32 = 120;
+const H: u32 = 120;
+
+/// Lazily create a headless wgpu device/queue. Returns `None` when no adapter is
+/// available (e.g. backend-less CI), so the caller can skip the test.
+fn headless_device() -> Option<(wgpu::Device, wgpu::Queue)> {
+    let instance = wgpu::Instance::default();
+
+    let adapter = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
+        power_preference: wgpu::PowerPreference::default(),
+        force_fallback_adapter: false,
+        compatible_surface: None,
+    }))
+    .ok()?;
+
+    let (device, queue) = pollster::block_on(adapter.request_device(&wgpu::DeviceDescriptor {
+        label: Some("femtovg shadow test device"),
+        required_features: wgpu::Features::empty(),
+        required_limits: wgpu::Limits::downlevel_defaults().using_resolution(adapter.limits()),
+        experimental_features: wgpu::ExperimentalFeatures::disabled(),
+        memory_hints: wgpu::MemoryHints::MemoryUsage,
+        trace: wgpu::Trace::default(),
+    }))
+    .ok()?;
+
+    Some((device, queue))
+}
+
+/// Render `draw` into an offscreen RGBA8 texture and read the pixels back.
+/// Returns a row-major buffer of `[r, g, b, a]` per pixel.
+fn render_to_pixels(
+    device: &wgpu::Device,
+    queue: &wgpu::Queue,
+    draw: impl FnOnce(&mut Canvas<WGPURenderer>),
+) -> Vec<u8> {
+    let target = device.create_texture(&wgpu::TextureDescriptor {
+        label: Some("shadow test target"),
+        size: wgpu::Extent3d {
+            width: W,
+            height: H,
+            depth_or_array_layers: 1,
+        },
+        mip_level_count: 1,
+        sample_count: 1,
+        dimension: wgpu::TextureDimension::D2,
+        format: wgpu::TextureFormat::Rgba8Unorm,
+        usage: wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::COPY_SRC,
+        view_formats: &[],
+    });
+
+    let renderer = WGPURenderer::new(device.clone(), queue.clone());
+    let mut canvas = Canvas::new(renderer).expect("failed to create canvas");
+    canvas.set_size(W, H, 1.0);
+    canvas.clear_rect(0, 0, W, H, Color::rgba(0, 0, 0, 0));
+
+    draw(&mut canvas);
+
+    let commands = canvas.flush_to_output(&target);
+    queue.submit(commands);
+
+    // Copy the target texture into a readback buffer. bytes_per_row must be a
+    // multiple of 256.
+    let unpadded_bytes_per_row = W * 4;
+    let align = wgpu::COPY_BYTES_PER_ROW_ALIGNMENT;
+    let padded_bytes_per_row = unpadded_bytes_per_row.div_ceil(align) * align;
+
+    let readback = device.create_buffer(&wgpu::BufferDescriptor {
+        label: Some("shadow test readback"),
+        size: (padded_bytes_per_row * H) as u64,
+        usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
+        mapped_at_creation: false,
+    });
+
+    let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
+    encoder.copy_texture_to_buffer(
+        wgpu::TexelCopyTextureInfo {
+            texture: &target,
+            mip_level: 0,
+            origin: wgpu::Origin3d::ZERO,
+            aspect: wgpu::TextureAspect::All,
+        },
+        wgpu::TexelCopyBufferInfo {
+            buffer: &readback,
+            layout: wgpu::TexelCopyBufferLayout {
+                offset: 0,
+                bytes_per_row: Some(padded_bytes_per_row),
+                rows_per_image: Some(H),
+            },
+        },
+        wgpu::Extent3d {
+            width: W,
+            height: H,
+            depth_or_array_layers: 1,
+        },
+    );
+    queue.submit(Some(encoder.finish()));
+
+    let slice = readback.slice(..);
+    slice.map_async(wgpu::MapMode::Read, |_| {});
+    device.poll(wgpu::PollType::wait_indefinitely()).unwrap();
+
+    let mapped = slice.get_mapped_range();
+    let mut pixels = vec![0u8; (unpadded_bytes_per_row * H) as usize];
+    for row in 0..H as usize {
+        let src = row * padded_bytes_per_row as usize;
+        let dst = row * unpadded_bytes_per_row as usize;
+        pixels[dst..dst + unpadded_bytes_per_row as usize]
+            .copy_from_slice(&mapped[src..src + unpadded_bytes_per_row as usize]);
+    }
+    drop(mapped);
+    readback.unmap();
+
+    pixels
+}
+
+fn pixel(pixels: &[u8], x: u32, y: u32) -> [u8; 4] {
+    let i = ((y * W + x) * 4) as usize;
+    [pixels[i], pixels[i + 1], pixels[i + 2], pixels[i + 3]]
+}
+
+/// A filled red rect with an opaque green shadow offset down-right must produce
+/// green pixels at the offset location, and the shadow must vanish when the
+/// shadow color is transparent.
+#[test]
+fn opaque_shadow_paints_offset_pixels() {
+    let Some((device, queue)) = headless_device() else {
+        eprintln!("skipping: no wgpu adapter available");
+        return;
+    };
+
+    // Rect at (20,20) size 30x30. Shadow offset by (+30, +30), no blur.
+    let mut rect = Path::new();
+    rect.rect(20.0, 20.0, 30.0, 30.0);
+
+    let with_shadow = render_to_pixels(&device, &queue, |canvas| {
+        canvas.set_shadow_color(Color::rgb(0, 255, 0));
+        canvas.set_shadow_offset(30.0, 30.0);
+        canvas.fill_path(&rect, &Paint::color(Color::rgb(255, 0, 0)));
+    });
+
+    // Sample inside the shadow region but outside the shape: the rect occupies
+    // x,y in [20,50); the shadow is shifted to [50,80). Point (65,65) is shadow
+    // only.
+    let shadow_px = pixel(&with_shadow, 65, 65);
+    assert!(
+        shadow_px[1] > 180 && shadow_px[0] < 80 && shadow_px[3] > 180,
+        "expected opaque green shadow at (65,65), got {shadow_px:?}"
+    );
+
+    // The shape itself is still red.
+    let shape_px = pixel(&with_shadow, 35, 35);
+    assert!(
+        shape_px[0] > 180 && shape_px[1] < 80,
+        "expected red shape at (35,35), got {shape_px:?}"
+    );
+
+    // With a transparent shadow color, the same offset paints nothing there.
+    let no_shadow = render_to_pixels(&device, &queue, |canvas| {
+        canvas.set_shadow_color(Color::rgba(0, 255, 0, 0));
+        canvas.set_shadow_offset(30.0, 30.0);
+        canvas.fill_path(&rect, &Paint::color(Color::rgb(255, 0, 0)));
+    });
+    let empty_px = pixel(&no_shadow, 65, 65);
+    assert!(
+        empty_px[3] < 16,
+        "transparent shadow color must leave (65,65) empty, got {empty_px:?}"
+    );
+}
+
+/// The shadow color's alpha must modulate the painted shadow: a half-alpha shadow
+/// produces a partially transparent shadow region.
+#[test]
+fn shadow_color_alpha_is_respected() {
+    let Some((device, queue)) = headless_device() else {
+        eprintln!("skipping: no wgpu adapter available");
+        return;
+    };
+
+    let mut rect = Path::new();
+    rect.rect(20.0, 20.0, 30.0, 30.0);
+
+    let pixels = render_to_pixels(&device, &queue, |canvas| {
+        canvas.set_shadow_color(Color::rgba(0, 0, 255, 128));
+        canvas.set_shadow_offset(30.0, 30.0);
+        canvas.fill_path(&rect, &Paint::color(Color::rgb(255, 0, 0)));
+    });
+
+    // Onto a transparent background, a half-alpha shadow yields ~50% alpha.
+    let px = pixel(&pixels, 65, 65);
+    assert!(
+        px[3] > 90 && px[3] < 170,
+        "expected ~half alpha shadow at (65,65), got {px:?}"
+    );
+    assert!(px[2] > 100, "shadow should carry blue channel, got {px:?}");
+}
+
+/// Blur must spread the shadow's coverage beyond the shape's hard edge: with a
+/// zero offset and a blur, pixels just outside the shape rectangle pick up
+/// shadow coverage that a sharp (unblurred) shadow would not reach.
+#[test]
+fn blur_spreads_coverage_beyond_edge() {
+    let Some((device, queue)) = headless_device() else {
+        eprintln!("skipping: no wgpu adapter available");
+        return;
+    };
+
+    let mut rect = Path::new();
+    rect.rect(40.0, 40.0, 40.0, 40.0); // occupies [40,80)
+
+    // Sample a point a few pixels outside the right edge of the rect.
+    let probe = (86u32, 60u32);
+
+    let sharp = render_to_pixels(&device, &queue, |canvas| {
+        canvas.set_shadow_color(Color::rgb(0, 0, 0));
+        canvas.set_shadow_blur(0.0);
+        canvas.fill_path(&rect, &Paint::color(Color::rgb(255, 0, 0)));
+    });
+    let sharp_px = pixel(&sharp, probe.0, probe.1);
+
+    let blurred = render_to_pixels(&device, &queue, |canvas| {
+        canvas.set_shadow_color(Color::rgb(0, 0, 0));
+        canvas.set_shadow_blur(12.0);
+        canvas.fill_path(&rect, &Paint::color(Color::rgb(255, 0, 0)));
+    });
+    let blurred_px = pixel(&blurred, probe.0, probe.1);
+
+    // The sharp shadow lands exactly under the shape, so 6px outside the edge it
+    // contributes nothing; the blurred shadow spreads coverage out there.
+    assert!(
+        sharp_px[3] < 16,
+        "unblurred zero-offset shadow must not reach outside the shape, got {sharp_px:?}"
+    );
+    assert!(
+        blurred_px[3] > sharp_px[3] + 16,
+        "blur must spread coverage past the edge (sharp a={}, blurred a={})",
+        sharp_px[3],
+        blurred_px[3]
+    );
+}
+
+/// Drop shadows must also render under offscreen image render targets, not just
+/// the screen. This also confirms shadows compose correctly when the current
+/// render target is an image.
+#[test]
+fn shadow_renders_into_image_target() {
+    use femtovg::{ImageFlags, PixelFormat};
+
+    let Some((device, queue)) = headless_device() else {
+        eprintln!("skipping: no wgpu adapter available");
+        return;
+    };
+
+    // We render into an image target inside the draw closure, then blit it to the
+    // screen so render_to_pixels can read it back.
+    let mut rect = Path::new();
+    rect.rect(20.0, 20.0, 30.0, 30.0);
+
+    let pixels = render_to_pixels(&device, &queue, |canvas| {
+        let img = canvas
+            .create_image_empty(W as usize, H as usize, PixelFormat::Rgba8, ImageFlags::empty())
+            .unwrap();
+        canvas.set_render_target(RenderTarget::Image(img));
+        canvas.clear_rect(0, 0, W, H, Color::rgba(0, 0, 0, 0));
+        canvas.set_shadow_color(Color::rgb(0, 255, 0));
+        canvas.set_shadow_offset(30.0, 30.0);
+        canvas.fill_path(&rect, &Paint::color(Color::rgb(255, 0, 0)));
+
+        canvas.set_render_target(RenderTarget::Screen);
+        let mut full = Path::new();
+        full.rect(0.0, 0.0, W as f32, H as f32);
+        canvas.fill_path(&full, &Paint::image(img, 0.0, 0.0, W as f32, H as f32, 0.0, 1.0));
+        // `img` is referenced by deferred commands until flush; the canvas frees it
+        // on drop.
+    });
+
+    let shadow_px = pixel(&pixels, 65, 65);
+    assert!(
+        shadow_px[1] > 150 && shadow_px[3] > 150,
+        "expected green shadow drawn via image target at (65,65), got {shadow_px:?}"
+    );
+}
+
+/// Filled text must also cast a drop shadow. Render a glyph-heavy string with a
+/// large offset and assert that shadow-colored pixels appear in the offset band
+/// (where the glyphs themselves are not), and that nothing appears there once the
+/// shadow color is made transparent.
+#[test]
+#[cfg(feature = "textlayout")]
+fn text_casts_drop_shadow() {
+    let Some((device, queue)) = headless_device() else {
+        eprintln!("skipping: no wgpu adapter available");
+        return;
+    };
+
+    let font = include_bytes!("../examples/assets/amiri-regular.ttf");
+
+    // Count opaque, blue-tinted shadow pixels in a band offset from the text.
+    let count_blue = |with_shadow: bool| -> usize {
+        let pixels = render_to_pixels(&device, &queue, |canvas| {
+            let id = canvas.add_font_mem(font).expect("load font");
+            let mut paint = Paint::color(Color::rgb(255, 0, 0));
+            paint.set_font(&[id]);
+            paint.set_font_size(40.0);
+            canvas.set_shadow_color(if with_shadow {
+                Color::rgb(0, 0, 255)
+            } else {
+                Color::rgba(0, 0, 255, 0)
+            });
+            canvas.set_shadow_offset(20.0, 20.0);
+            let _ = canvas.fill_text(10.0, 50.0, "Ag", &paint);
+        });
+
+        let mut blue = 0;
+        for y in 0..H {
+            for x in 0..W {
+                let p = pixel(&pixels, x, y);
+                // Blue-dominant, reasonably opaque => a shadow pixel.
+                if p[2] > 120 && p[0] < 80 && p[3] > 120 {
+                    blue += 1;
+                }
+            }
+        }
+        blue
+    };
+
+    let with = count_blue(true);
+    let without = count_blue(false);
+
+    assert!(with > 30, "text shadow should paint blue pixels, got {with}");
+    assert_eq!(
+        without, 0,
+        "transparent shadow color must paint no blue pixels, got {without}"
+    );
+}

--- a/tests/shadow_wgpu.rs
+++ b/tests/shadow_wgpu.rs
@@ -23,6 +23,7 @@ fn headless_device() -> Option<(wgpu::Device, wgpu::Queue)> {
         power_preference: wgpu::PowerPreference::default(),
         force_fallback_adapter: false,
         compatible_surface: None,
+        ..Default::default()
     }))
     .ok()?;
 
@@ -112,7 +113,7 @@ fn render_to_pixels(
     slice.map_async(wgpu::MapMode::Read, |_| {});
     device.poll(wgpu::PollType::wait_indefinitely()).unwrap();
 
-    let mapped = slice.get_mapped_range();
+    let mapped = slice.get_mapped_range().expect("mapped readback range");
     let mut pixels = vec![0u8; (unpadded_bytes_per_row * H) as usize];
     for row in 0..H as usize {
         let src = row * padded_bytes_per_row as usize;

--- a/tests/shadow_wgpu.rs
+++ b/tests/shadow_wgpu.rs
@@ -345,3 +345,130 @@ fn text_casts_drop_shadow() {
         "transparent shadow color must paint no blue pixels, got {without}"
     );
 }
+
+/// The shadow offset must NOT be scaled by the current transform: per the Canvas
+/// spec (and WebKit's rule that "canvas shadows must not be affected by any
+/// transformation") `shadowOffsetX/Y` are in output pixels. Under `scale(2, 2)`
+/// with offset `(10, 0)` the shadow must land ~10 device px from the shape, not
+/// 20.
+#[test]
+fn shadow_offset_is_not_scaled_by_transform() {
+    let Some((device, queue)) = headless_device() else {
+        eprintln!("skipping: no wgpu adapter available");
+        return;
+    };
+
+    // User rect (5,5) size 10x10. Under scale(2,2) it occupies device x,y in
+    // [10,30). Opaque green shadow, offset (10,0) in *user* units passed to the
+    // setter, no blur.
+    let pixels = render_to_pixels(&device, &queue, |canvas| {
+        canvas.scale(2.0, 2.0);
+        canvas.set_shadow_color(Color::rgb(0, 255, 0));
+        canvas.set_shadow_offset(10.0, 0.0);
+        let mut rect = Path::new();
+        rect.rect(5.0, 5.0, 10.0, 10.0);
+        canvas.fill_path(&rect, &Paint::color(Color::rgb(255, 0, 0)));
+    });
+
+    // Raw (correct) offset of 10 device px puts the shadow at device x in [20,40).
+    // x=37,y=20 is inside that band but outside the shape ([10,30)).
+    let inside = pixel(&pixels, 37, 20);
+    assert!(
+        inside[1] > 150 && inside[0] < 90 && inside[3] > 150,
+        "expected green shadow ~10px from the shape at (37,20), got {inside:?}"
+    );
+
+    // x=45 lies past the raw-offset shadow (40) but *inside* a wrongly CTM-scaled
+    // shadow (offset 20 => band [30,50)). It must be empty.
+    let beyond = pixel(&pixels, 45, 20);
+    assert!(
+        beyond[3] < 32,
+        "shadow must not extend to 20px (a CTM-scaled offset); (45,20) should be empty, got {beyond:?}"
+    );
+}
+
+/// A shape whose own bounds are off-screen must still cast a shadow when the
+/// offset (and/or blur) pulls the shadow back onto the render target. The
+/// off-screen cull must therefore not be based on the shape's own bounds alone.
+#[test]
+fn offscreen_shape_with_offset_still_casts_shadow() {
+    let Some((device, queue)) = headless_device() else {
+        eprintln!("skipping: no wgpu adapter available");
+        return;
+    };
+
+    // Rect placed fully to the LEFT of the canvas (x in [-40,-10)), so its own
+    // bounds never touch the target. A +50 px shadow offset moves the shadow to
+    // x in [10,40), squarely on-screen.
+    let mut rect = Path::new();
+    rect.rect(-40.0, 40.0, 30.0, 30.0);
+
+    let pixels = render_to_pixels(&device, &queue, |canvas| {
+        canvas.set_shadow_color(Color::rgb(0, 255, 0));
+        canvas.set_shadow_offset(50.0, 0.0);
+        canvas.fill_path(&rect, &Paint::color(Color::rgb(255, 0, 0)));
+    });
+
+    // Sample inside the shifted shadow band.
+    let shadow_px = pixel(&pixels, 25, 55);
+    assert!(
+        shadow_px[1] > 150 && shadow_px[0] < 90 && shadow_px[3] > 150,
+        "off-screen shape's offset shadow must paint on-screen at (25,55), got {shadow_px:?}"
+    );
+
+    // The shape itself stays off-screen: nothing red is painted.
+    let shape_band = pixel(&pixels, 5, 55);
+    assert!(
+        shape_band[0] < 90,
+        "the shape must remain off-screen (no red on the target), got {shape_band:?}"
+    );
+}
+
+/// The shadow must be built from the *alpha of the actually-rendered source*. A
+/// 50%-alpha fill must cast a visibly weaker shadow than a 100%-alpha fill, and a
+/// fully transparent source must cast no shadow at all.
+#[test]
+fn shadow_strength_follows_source_alpha() {
+    let Some((device, queue)) = headless_device() else {
+        eprintln!("skipping: no wgpu adapter available");
+        return;
+    };
+
+    let mut rect = Path::new();
+    rect.rect(20.0, 20.0, 30.0, 30.0);
+
+    // Opaque black shadow, offset clear of the shape, no blur. Vary only the
+    // *source* fill alpha.
+    let shadow_alpha_for_source = |src_alpha: u8| -> u8 {
+        let pixels = render_to_pixels(&device, &queue, |canvas| {
+            canvas.set_shadow_color(Color::rgb(0, 0, 0));
+            canvas.set_shadow_offset(30.0, 30.0);
+            canvas.fill_path(&rect, &Paint::color(Color::rgba(255, 0, 0, src_alpha)));
+        });
+        // (65,65) is in the shadow band ([50,80)) but outside the shape ([20,50)).
+        pixel(&pixels, 65, 65)[3]
+    };
+
+    let opaque_shadow = shadow_alpha_for_source(255);
+    let half_shadow = shadow_alpha_for_source(128);
+    let transparent_shadow = shadow_alpha_for_source(0);
+
+    assert!(
+        opaque_shadow > 180,
+        "a fully opaque source must cast a strong shadow, got alpha {opaque_shadow}"
+    );
+    // The half-alpha source's shadow must be clearly weaker (~half) and not just
+    // marginally so.
+    assert!(
+        half_shadow + 40 < opaque_shadow,
+        "a 50%-alpha source must cast a visibly weaker shadow (half={half_shadow}, opaque={opaque_shadow})"
+    );
+    assert!(
+        half_shadow > 40,
+        "a 50%-alpha source must still cast some shadow, got alpha {half_shadow}"
+    );
+    assert!(
+        transparent_shadow < 16,
+        "a fully transparent source must cast no shadow, got alpha {transparent_shadow}"
+    );
+}

--- a/tests/shadow_wgpu.rs
+++ b/tests/shadow_wgpu.rs
@@ -474,6 +474,71 @@ fn shadow_strength_follows_source_alpha() {
     );
 }
 
+/// Spec-derived text-shadow property (WHATWG canvas drawing model): the shadow
+/// is built once from the alpha channel of the *entire* painting operation's
+/// output, so its alpha can never exceed the shadow color's alpha — even where
+/// glyphs overlap. An implementation that shadows glyphs individually compounds
+/// alpha in overlap regions (`1 - (1-a)^2`, ~0.75 for a=0.5), which this test
+/// rejects. Checked for both rasterization strategies (atlas and outline), since
+/// the drawing model is defined on the painting operation, not the rasterizer.
+#[cfg(feature = "textlayout")]
+#[test]
+fn text_shadow_alpha_never_exceeds_shadow_color_alpha() {
+    let Some((device, queue)) = headless_device() else {
+        eprintln!("skipping: no wgpu adapter available");
+        return;
+    };
+
+    // Overlapping glyphs via strongly negative letter spacing; the shadow is
+    // offset to the side so shadow-only pixels can be isolated by comparing
+    // against a shadowless render of the same text.
+    let mut check = |font_size: f32, label: &str| {
+        let draw_text = |canvas: &mut Canvas<femtovg::renderer::WGPURenderer>, with_shadow: bool| {
+            let font = canvas
+                .add_font("examples/assets/RobotoFlex-VariableFont.ttf")
+                .expect("Font not found");
+            let paint = Paint::color(Color::white())
+                .with_font(&[font])
+                .with_font_size(font_size)
+                .with_letter_spacing(-0.25 * font_size);
+            if with_shadow {
+                canvas.set_shadow_color(Color::rgba(0, 0, 0, 128));
+                canvas.set_shadow_offset(20.0, 20.0);
+            }
+            canvas.fill_text(10.0, 50.0, "lll", &paint).unwrap();
+        };
+
+        let plain = render_to_pixels(&device, &queue, |canvas| draw_text(canvas, false));
+        let shadowed = render_to_pixels(&device, &queue, |canvas| draw_text(canvas, true));
+
+        // Max shadow alpha over pixels the text itself does not touch.
+        let mut max_shadow = 0u8;
+        for y in 0..H {
+            for x in 0..W {
+                if pixel(&plain, x, y)[3] == 0 {
+                    max_shadow = max_shadow.max(pixel(&shadowed, x, y)[3]);
+                }
+            }
+        }
+
+        assert!(
+            max_shadow >= 100,
+            "{label}: expected a visible shadow (~128 alpha), got max {max_shadow}"
+        );
+        // Union-alpha bound: 128 (= shadowColor.a) plus a little AA headroom.
+        // Per-glyph shadow compounding in the overlap region would reach ~191.
+        assert!(
+            max_shadow <= 140,
+            "{label}: shadow alpha {max_shadow} exceeds the shadow color's alpha; \
+             overlapping glyphs must not compound (shadow must derive from the \
+             painting operation's union alpha)"
+        );
+    };
+
+    check(40.0, "atlas rasterization");
+    check(100.0, "outline rasterization");
+}
+
 /// Regression test for the Gaussian blur falloff *width* (kernel reach).
 ///
 /// The Canvas/SVG drawing model maps `shadowBlur` to a Gaussian with standard

--- a/tests/shadow_wgpu.rs
+++ b/tests/shadow_wgpu.rs
@@ -472,3 +472,71 @@ fn shadow_strength_follows_source_alpha() {
         "a fully transparent source must cast no shadow, got alpha {transparent_shadow}"
     );
 }
+
+/// Regression test for the Gaussian blur falloff *width* (kernel reach).
+///
+/// The Canvas/SVG drawing model maps `shadowBlur` to a Gaussian with standard
+/// deviation `sigma = shadowBlur / 2`, whose edge response falls off over a
+/// 10%-90% width of about `2.563 * sigma`. The blur shader previously sampled
+/// only `+/-1.5*sigma` taps and renormalized by that partial sum, which shrank
+/// the effective sigma to ~0.79x and produced only a ~12px 10-90 width at
+/// `shadowBlur` 12 (sigma 6) -- i.e. shadows were ~21% too tight versus the spec
+/// and versus Chrome/Firefox. With the corrected `+/-3*sigma` reach the width is
+/// ~17px (effective sigma ~6.6, matching Chrome Canary). This test measures that
+/// width directly so a regression back to the truncated kernel fails here rather
+/// than only showing up in a screenshot diff.
+#[test]
+fn shadow_blur_falloff_width_matches_spec_sigma() {
+    let Some((device, queue)) = headless_device() else {
+        eprintln!("skipping: no wgpu adapter available");
+        return;
+    };
+
+    // Black shadow, offset far right so its right edge falls on the empty
+    // background (clear of the shape). Shape at x[10,40] -> shadow core x[70,100].
+    let pixels = render_to_pixels(&device, &queue, |canvas| {
+        canvas.set_shadow_color(Color::rgba(0, 0, 0, 255));
+        canvas.set_shadow_blur(12.0); // spec sigma = 6
+        canvas.set_shadow_offset(60.0, 0.0);
+        let mut p = Path::new();
+        p.rect(10.0, 30.0, 30.0, 60.0);
+        canvas.fill_path(&p, &Paint::color(Color::rgb(255, 0, 0)));
+    });
+
+    // Shadow alpha along the vertical-center row, across the shadow's right edge.
+    let row = 60;
+    let alpha = |x: u32| pixel(&pixels, x, row)[3] as f32;
+    let mut peak = 0.0f32;
+    let mut peak_x = 70u32;
+    for x in 70..=105 {
+        let a = alpha(x);
+        if a > peak {
+            peak = a;
+            peak_x = x;
+        }
+    }
+    assert!(peak > 200.0, "shadow core alpha too low ({peak}); test geometry is off");
+
+    // Sub-pixel x where the falloff (scanning right from the core peak) crosses a
+    // threshold, via linear interpolation between adjacent samples.
+    let cross = |thresh: f32| -> f32 {
+        for x in peak_x..(W - 1) {
+            let (a0, a1) = (alpha(x), alpha(x + 1));
+            if a0 >= thresh && a1 < thresh {
+                return x as f32 + (a0 - thresh) / (a0 - a1);
+            }
+        }
+        (W - 1) as f32
+    };
+    let width = cross(0.1 * peak) - cross(0.9 * peak);
+    let sigma_eff = width / 2.563;
+
+    // Corrected +/-3sigma kernel: ~17px (sigma_eff ~6.6). Truncated +/-1.5sigma
+    // kernel: ~12px (sigma_eff ~4.7). The lower bound rejects the truncated
+    // kernel; the upper bound guards against an over-wide regression.
+    assert!(
+        (14.0..=21.0).contains(&width),
+        "blur 10-90 falloff width {width:.1}px (effective sigma {sigma_eff:.2}) is out of the \
+         expected ~17px band: a value near 12px means the kernel reach regressed to ~1.5*sigma"
+    );
+}


### PR DESCRIPTION
Adds Canvas 2D drop shadows — `shadowColor`, `shadowBlur`, `shadowOffsetX`, `shadowOffsetY` (via `set_shadow_color` / `set_shadow_blur` / `set_shadow_offset`, stacked by `save()`/`restore()`) — for fills, strokes, and text. Reuses the existing Gaussian image-filter and render-to-texture machinery; no new dependencies and no new shader entry points.

When the shadow color is non-transparent, each draw renders the shape's coverage into a transient offscreen image, recolors it by the shadow color preserving the source's alpha, Gaussian-blurs it (σ = `shadowBlur`/2 per the HTML drawing model), and composites it under the shape at the offset. The default (transparent shadow color) adds no new work.

### Conformance (WHATWG Canvas drawing model + WPT `2d.shadow.*`)
- Defaults `rgba(0,0,0,0)` / `0` / `(0,0)`; a shadow is drawn only when the color is non-transparent **and** one of blur/offsetX/offsetY is non-zero.
- Shadow offset is in device space (not transformed by the CTM).
- The shadow is built from the **source's alpha**, so a semi-transparent fill / gradient / image-with-holes casts a proportionally weaker shadow and a fully transparent source casts none.
- `shadowColor` alpha and `globalAlpha` both modulate the shadow.
- Non-finite blur/offset values are ignored (setter semantics).
- cross-checked against Firefox and WebKit's non-WPT test suite to make sure I wasn't repeating mistakes, encoded those lessons as inline unit tests

### Blur-falloff adjustment (also corrects the shared Gaussian blur)
While validating against Chrome Canary I found the Gaussian blur was systematically **~21% too tight**: the shader sampled only `±1.5σ` taps and renormalized by that partial sum, shrinking the effective σ to ~0.79× the spec `σ = blur/2`. The offscreen source was already padded to 3σ and the docs already claimed 3σ reach — only the shader tap count disagreed. This PR widens the sampled reach to `±3σ` and raises the GLES 2.0 constant loop bound from 12 to 24 so 3σ is covered at the σ≤8 cap; the per-tap weights were already the true-σ Gaussian, so this only restores the missing tail, and the early `break` keeps small blurs cheap.

Because `renderFilteredImage` is shared, **this also fixes the existing `ImageFilter::GaussianBlur` image-blur filter** (which was equally too tight). I'm happy to split the blur-kernel change into its own PR and rebase this on top if you'd prefer to keep this one shadow-only.

Verified against Chrome Canary 151 (headless, dpr=1): effective σ now matches at `shadowBlur` 12 and 16 (1.00×, was 0.79×), and the full shadow scene drops to a max per-channel difference of **2/255**. Very large `shadowBlur` (>16) is reach-capped by the 24-tap bound (~94% of target σ at blur 24); `shadowBlur` ≤ 16 is exact.

![femtovg vs Chrome Canary — drop shadow](https://raw.githubusercontent.com/rebeckerspecialties/femtovg/pixel-comparisons/comparisons/shadow.png)

*Left → right: Chrome Canary, femtovg, ×4-amplified difference.*

### Tests
- State / command-inspection (no GPU needed): attribute defaults, the blur-or-offset enable rule, non-finite rejection, save/restore stacking, and transparent-color → no shadow pass.
- wgpu-gated headless render tests (skip gracefully without an adapter): offset placement, offset-not-scaled-by-CTM, source-alpha attenuation, off-screen-shape-with-offset still casts, and a blur-falloff width regression test that fails on the old `±1.5σ` kernel that failed screenshot comparison and passes with the fix.

### Validation
`cargo fmt --check`, `cargo build`, `cargo build --features wgpu`, `cargo test --features "wgpu textlayout"`
