### PR TITLE
Add SVG elliptical arc path builder (Path::svg_arc_to)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3132,6 +3132,8 @@ fn outline_text_shadow_pass_count_is_glyph_count_invariant() {
         "shadow passes must not scale with glyph count: outline glyphs would each cast \
          their own shadow on top of the run-level one"
     );
+}
+
 /// Fills `path` once on `canvas`, flushes, and returns the raw bytes of the
 /// vertex buffer handed to the renderer for that single fill.
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2346,6 +2346,8 @@ pub use rgb;
 pub struct RecordingRenderer {
     /// Vector of the last commands submitted to the renderer.
     pub last_commands: Rc<RefCell<Vec<renderer::Command>>>,
+    /// Vertex buffer submitted with the last render call.
+    pub last_verts: Rc<RefCell<Vec<renderer::Vertex>>>,
 }
 
 #[cfg(test)]
@@ -2362,10 +2364,11 @@ impl Renderer for RecordingRenderer {
         &mut self,
         _output: impl Into<Self::RenderOutput>,
         _images: &mut ImageStore<Self::Image>,
-        _verts: &[renderer::Vertex],
+        verts: &[renderer::Vertex],
         commands: Vec<renderer::Command>,
     ) {
         *self.last_commands.borrow_mut() = commands;
+        *self.last_verts.borrow_mut() = verts.to_vec();
     }
 
     fn alloc_image(&mut self, info: crate::ImageInfo) -> Result<Self::Image, ErrorKind> {
@@ -3129,4 +3132,131 @@ fn outline_text_shadow_pass_count_is_glyph_count_invariant() {
         "shadow passes must not scale with glyph count: outline glyphs would each cast \
          their own shadow on top of the run-level one"
     );
+/// Fills `path` once on `canvas`, flushes, and returns the raw bytes of the
+/// vertex buffer handed to the renderer for that single fill.
+#[cfg(test)]
+fn record_fill_bytes(
+    canvas: &mut Canvas<RecordingRenderer>,
+    verts: &Rc<RefCell<Vec<renderer::Vertex>>>,
+    path: &Path,
+) -> Vec<u8> {
+    canvas.fill_path(path, &Paint::color(Color::white()));
+    canvas.flush_to_output(());
+    bytemuck::cast_slice(verts.borrow().as_slice()).to_vec()
+}
+
+/// `Path` keeps a single-slot interior-mutable tessellation cache keyed by the
+/// canvas transform, so a `Path` shared by two canvases with different
+/// transforms rebuilds that cache on every hand-off. Thrashing is a
+/// performance matter, but leakage would be a correctness bug: one canvas
+/// must never observe geometry flattened under the other canvas's transform.
+#[test]
+fn shared_arc_path_across_canvases_keeps_tessellation_isolated() {
+    let mut path = Path::new();
+    path.move_to(10.0, 10.0);
+    path.svg_arc_to(40.0, 25.0, 0.4, false, true, 120.0, 80.0);
+
+    let make_canvas = || {
+        let renderer = RecordingRenderer::default();
+        let verts = renderer.last_verts.clone();
+        let mut canvas = Canvas::new(renderer).unwrap();
+        canvas.set_size(800, 800, 1.0);
+        (canvas, verts)
+    };
+
+    // Canvas A stays at the identity; canvas B translates and scales.
+    let (mut canvas_a, verts_a) = make_canvas();
+    let (mut canvas_b, verts_b) = make_canvas();
+    canvas_b.translate(100.0, 0.0);
+    canvas_b.scale(2.0, 1.0);
+
+    let a1 = record_fill_bytes(&mut canvas_a, &verts_a, &path);
+    let b1 = record_fill_bytes(&mut canvas_b, &verts_b, &path);
+    let a2 = record_fill_bytes(&mut canvas_a, &verts_a, &path);
+    let b2 = record_fill_bytes(&mut canvas_b, &verts_b, &path);
+
+    assert!(!a1.is_empty() && !b1.is_empty());
+    assert_eq!(a1, a2, "canvas A geometry changed after canvas B used the shared path");
+    assert_eq!(b1, b2, "canvas B geometry changed after canvas A used the shared path");
+    assert_ne!(a1, b1, "the two transforms must produce different geometry");
+}
+
+/// Switching the render target between an image and the screen must not
+/// perturb the tessellation of a path filled on both: the emitted fill
+/// vertices are a function of the path and canvas transform only.
+#[test]
+fn arc_tessellation_is_stable_across_render_target_switches() {
+    let renderer = RecordingRenderer::default();
+    let verts = renderer.last_verts.clone();
+    let mut canvas = Canvas::new(renderer).unwrap();
+    canvas.set_size(400, 400, 1.0);
+    let image = canvas
+        .create_image_empty(400, 400, PixelFormat::Rgba8, ImageFlags::empty())
+        .unwrap();
+
+    let mut path = Path::new();
+    path.move_to(20.0, 200.0);
+    path.svg_arc_to(90.0, 60.0, 0.3, true, false, 260.0, 210.0);
+
+    let targets = [
+        RenderTarget::Image(image),
+        RenderTarget::Screen,
+        RenderTarget::Image(image),
+        RenderTarget::Screen,
+    ];
+    let outputs: Vec<Vec<u8>> = targets
+        .into_iter()
+        .map(|target| {
+            canvas.set_render_target(target);
+            record_fill_bytes(&mut canvas, &verts, &path)
+        })
+        .collect();
+
+    assert!(!outputs[0].is_empty());
+    for (index, output) in outputs.iter().enumerate().skip(1) {
+        assert_eq!(
+            &outputs[0], output,
+            "render {index} diverged from the first despite identical path and transform"
+        );
+    }
+}
+
+/// `Path` and `Canvas` deliberately contain non-`Sync` interior state (the
+/// `RefCell` tessellation cache; `Rc` handles in the canvas), so sharing one
+/// `Path` or `Canvas` across threads is rejected at compile time — see the
+/// `compile_fail` doctest on [`Path`]. What must hold is that fully
+/// independent per-thread instances tessellate deterministically while other
+/// threads do the same concurrently.
+#[test]
+fn arc_tessellation_is_deterministic_across_threads() {
+    let workers: Vec<_> = (0..4)
+        .map(|index| {
+            std::thread::spawn(move || {
+                let renderer = RecordingRenderer::default();
+                let verts = renderer.last_verts.clone();
+                let mut canvas = Canvas::new(renderer).unwrap();
+                canvas.set_size(600, 600, 1.0);
+
+                // Give each thread its own arc so a cross-thread mix-up could
+                // not hide behind identical inputs.
+                let mut path = Path::new();
+                path.move_to(10.0 + index as f32, 20.0);
+                path.svg_arc_to(80.0 + index as f32, 50.0, 0.2, index % 2 == 0, true, 300.0, 240.0);
+
+                let baseline = record_fill_bytes(&mut canvas, &verts, &path);
+                assert!(!baseline.is_empty());
+                for iteration in 1..100 {
+                    let bytes = record_fill_bytes(&mut canvas, &verts, &path);
+                    assert_eq!(
+                        baseline, bytes,
+                        "thread {index} produced unstable geometry at iteration {iteration}"
+                    );
+                }
+            })
+        })
+        .collect();
+
+    for worker in workers {
+        worker.join().unwrap();
+    }
 }

--- a/src/path.rs
+++ b/src/path.rs
@@ -1510,6 +1510,236 @@ mod tests {
         }
     }
 
+    // ---- deterministic property fuzz ----
+
+    /// Minimal deterministic PRNG (Knuth's MMIX LCG constants, high 32 bits
+    /// used) so the fuzz below needs no external crates and replays
+    /// identically on every run.
+    struct Lcg(u64);
+
+    impl Lcg {
+        fn next_u32(&mut self) -> u32 {
+            self.0 = self
+                .0
+                .wrapping_mul(6364136223846793005)
+                .wrapping_add(1442695040888963407);
+            (self.0 >> 32) as u32
+        }
+
+        /// Uniform in [0, 1).
+        fn unit(&mut self) -> f32 {
+            (self.next_u32() >> 8) as f32 / (1u32 << 24) as f32
+        }
+
+        fn range(&mut self, lo: f32, hi: f32) -> f32 {
+            lo + (hi - lo) * self.unit()
+        }
+
+        fn flag(&mut self) -> bool {
+            self.next_u32() & 1 == 1
+        }
+
+        fn one_in(&mut self, n: u32) -> bool {
+            self.next_u32() % n == 0
+        }
+    }
+
+    fn fuzz_coord(rng: &mut Lcg, extreme: bool) -> f32 {
+        if extreme && rng.one_in(3) {
+            let magnitude = if rng.flag() { 1e30 } else { 1e-30 };
+            if rng.flag() {
+                magnitude
+            } else {
+                -magnitude
+            }
+        } else {
+            rng.range(-1e4, 1e4)
+        }
+    }
+
+    fn fuzz_radius(rng: &mut Lcg, extreme: bool) -> f32 {
+        if extreme && rng.one_in(3) {
+            if rng.flag() {
+                1e30
+            } else {
+                1e-30
+            }
+        } else if rng.one_in(40) {
+            0.0
+        } else {
+            rng.range(0.0, 2e3)
+        }
+    }
+
+    /// Independent f64 evaluation of the F.6.5/F.6.6 center parametrization,
+    /// used as ground truth by the fuzz test: returns the arc's center and the
+    /// (possibly F.6.6-scaled) radii.
+    #[allow(clippy::too_many_arguments)]
+    fn svg_arc_center_f64(
+        start: (f32, f32),
+        end: (f32, f32),
+        rx: f32,
+        ry: f32,
+        phi: f32,
+        large_arc: bool,
+        sweep: bool,
+    ) -> (f64, f64, f64, f64) {
+        let (x1, y1) = (f64::from(start.0), f64::from(start.1));
+        let (x2, y2) = (f64::from(end.0), f64::from(end.1));
+        let mut rx = f64::from(rx).abs();
+        let mut ry = f64::from(ry).abs();
+        let (sin_phi, cos_phi) = f64::from(phi).sin_cos();
+
+        let dx2 = (x1 - x2) * 0.5;
+        let dy2 = (y1 - y2) * 0.5;
+        let x1p = cos_phi * dx2 + sin_phi * dy2;
+        let y1p = -sin_phi * dx2 + cos_phi * dy2;
+
+        let lambda = (x1p * x1p) / (rx * rx) + (y1p * y1p) / (ry * ry);
+        if lambda > 1.0 {
+            let s = lambda.sqrt();
+            rx *= s;
+            ry *= s;
+        }
+
+        let rx2 = rx * rx;
+        let ry2 = ry * ry;
+        let numerator = (rx2 * ry2 - rx2 * y1p * y1p - ry2 * x1p * x1p).max(0.0);
+        let denominator = rx2 * y1p * y1p + ry2 * x1p * x1p;
+        let mut coef = (numerator / denominator).sqrt();
+        if large_arc == sweep {
+            coef = -coef;
+        }
+        let cxp = coef * (rx * y1p / ry);
+        let cyp = coef * -(ry * x1p / rx);
+
+        let cx = cos_phi * cxp - sin_phi * cyp + (x1 + x2) * 0.5;
+        let cy = sin_phi * cxp + cos_phi * cyp + (y1 + y2) * 0.5;
+        (cx, cy, rx, ry)
+    }
+
+    /// f64 twin of `ellipse_residual` for the fuzz ground-truth comparison.
+    fn ellipse_residual_f64(px: f64, py: f64, cx: f64, cy: f64, rx: f64, ry: f64, phi: f64) -> f64 {
+        let (sin_phi, cos_phi) = phi.sin_cos();
+        let dx = px - cx;
+        let dy = py - cy;
+        let u = cos_phi * dx + sin_phi * dy;
+        let v = -sin_phi * dx + cos_phi * dy;
+        (u * u) / (rx * rx) + (v * v) / (ry * ry) - 1.0
+    }
+
+    fn bezier_point_f64(p0: (f64, f64), c1: (f64, f64), c2: (f64, f64), p3: (f64, f64), s: f64) -> (f64, f64) {
+        let u = 1.0 - s;
+        let w0 = u * u * u;
+        let w1 = 3.0 * u * u * s;
+        let w2 = 3.0 * u * s * s;
+        let w3 = s * s * s;
+        (
+            w0 * p0.0 + w1 * c1.0 + w2 * c2.0 + w3 * p3.0,
+            w0 * p0.1 + w1 * c1.1 + w2 * c2.1 + w3 * p3.1,
+        )
+    }
+
+    #[test]
+    fn svg_arc_deterministic_property_fuzz() {
+        const ITERATIONS: u32 = 20_000;
+
+        let mut rng = Lcg(0x5eed_1e57_ab1e_f00d);
+
+        for iteration in 0..ITERATIONS {
+            // ~1 in 50 iterations swap some inputs for extreme magnitudes.
+            let extreme = rng.one_in(50);
+
+            let start = (fuzz_coord(&mut rng, extreme), fuzz_coord(&mut rng, extreme));
+            let end = (fuzz_coord(&mut rng, extreme), fuzz_coord(&mut rng, extreme));
+            let rx = fuzz_radius(&mut rng, extreme);
+            let ry = fuzz_radius(&mut rng, extreme);
+            let phi = rng.range(-10.0, 10.0);
+            let large_arc = rng.flag();
+            let sweep = rng.flag();
+
+            let case = format!(
+                "iteration {iteration}: move_to({}, {}); \
+                 svg_arc_to({rx:e}, {ry:e}, {phi}, {large_arc}, {sweep}, {}, {})",
+                start.0, start.1, end.0, end.1
+            );
+
+            // (a) must not panic.
+            let mut path = Path::new();
+            path.move_to(start.0, start.1);
+            path.svg_arc_to(rx, ry, phi, large_arc, sweep, end.0, end.1);
+
+            // (b) every emitted coordinate is finite.
+            let mut last = start;
+            let mut segments = Vec::new();
+            for verb in path.verbs() {
+                let coords: Vec<f32> = match verb {
+                    Verb::MoveTo(x, y) | Verb::LineTo(x, y) => vec![x, y],
+                    Verb::BezierTo(c1x, c1y, c2x, c2y, x, y) => vec![c1x, c1y, c2x, c2y, x, y],
+                    Verb::Close | Verb::Solid | Verb::Hole => vec![],
+                };
+                assert!(
+                    coords.iter().all(|value| value.is_finite()),
+                    "non-finite coordinate in {verb:?} for {case}"
+                );
+                match verb {
+                    Verb::MoveTo(x, y) | Verb::LineTo(x, y) => last = (x, y),
+                    Verb::BezierTo(c1x, c1y, c2x, c2y, x, y) => {
+                        segments.push((last, (c1x, c1y), (c2x, c2y), (x, y)));
+                        last = (x, y);
+                    }
+                    _ => {}
+                }
+            }
+
+            // (c) for non-degenerate finite inputs the path must land on the
+            // requested endpoint within 1e-2 relative tolerance.
+            let degenerate = start == end || rx.abs() <= 1e-6 || ry.abs() <= 1e-6;
+            if !degenerate {
+                let tolerance = 1e-2 * (end.0.abs() + end.1.abs()).max(1.0);
+                assert!(
+                    (last.0 - end.0).abs() <= tolerance && (last.1 - end.1).abs() <= tolerance,
+                    "endpoint {last:?} != requested {end:?} for {case}"
+                );
+            }
+
+            // (d) well-conditioned cases: every sampled point of the emitted
+            // bezier chain lies on the ground-truth rotated ellipse.
+            let radii_in_range = |r: f64| (1.0..=2e3).contains(&r);
+            if !extreme && radii_in_range(f64::from(rx)) && radii_in_range(f64::from(ry)) && start != end {
+                let (cx, cy, srx, sry) = svg_arc_center_f64(start, end, rx, ry, phi, large_arc, sweep);
+                // F.6.6 scaling can push the effective radii outside the
+                // well-conditioned band; only check while they stay inside it.
+                if radii_in_range(srx) && radii_in_range(sry) {
+                    assert!(
+                        !segments.is_empty(),
+                        "well-conditioned arc must emit bezier segments for {case}"
+                    );
+                    // Base tolerance matches ELLIPSE_RESIDUAL_TOL (Maisonobe
+                    // segment error); the second term covers f32 quantization
+                    // of coordinates of magnitude ~point_scale amplified by
+                    // the implicit-form gradient (~1/min_radius).
+                    let point_scale = cx.abs() + cy.abs() + srx + sry;
+                    let min_radius = srx.min(sry);
+                    let tolerance = 5e-3 + 8.0 * f64::from(f32::EPSILON) * point_scale / min_radius;
+                    for (p0, c1, c2, p3) in &segments {
+                        for step in 0..=4 {
+                            let s = f64::from(step) / 4.0;
+                            let to_f64 = |p: (f32, f32)| (f64::from(p.0), f64::from(p.1));
+                            let (px, py) = bezier_point_f64(to_f64(*p0), to_f64(*c1), to_f64(*c2), to_f64(*p3), s);
+                            let residual = ellipse_residual_f64(px, py, cx, cy, srx, sry, f64::from(phi));
+                            assert!(
+                                residual.abs() < tolerance,
+                                "sampled point ({px}, {py}) at s={s} off ground-truth ellipse \
+                                 (residual {residual}, tolerance {tolerance}) for {case}"
+                            );
+                        }
+                    }
+                }
+            }
+        }
+    }
+
     #[test]
     fn svg_arc_tiny_radii_scale_up_without_overflow() {
         // Minimized from the deterministic fuzz (iteration 78 of seed

--- a/src/path.rs
+++ b/src/path.rs
@@ -429,6 +429,14 @@ impl Path {
     /// arc, a zero radius degrades to a straight line, negative radii use their
     /// absolute value, and radii too small to span the endpoints are scaled up.
     pub fn svg_arc_to(&mut self, rx: f32, ry: f32, x_axis_rotation: f32, large_arc: bool, sweep: bool, x: f32, y: f32) {
+        // The HTML Canvas path primitives (`ellipse()`, `arc()`, `arcTo()`)
+        // return early without changing the path "if any of the arguments are
+        // infinite or NaN"; apply the same rule here so a single bad value
+        // cannot poison every later coordinate derived from the current point.
+        if !rx.is_finite() || !ry.is_finite() || !x_axis_rotation.is_finite() || !x.is_finite() || !y.is_finite() {
+            return;
+        }
+
         let start = if self.verbs.is_empty() {
             let origin = Position { x: 0.0, y: 0.0 };
             self.move_to(origin.x, origin.y);
@@ -1468,6 +1476,47 @@ mod tests {
                 resid.abs() < ELLIPSE_RESIDUAL_TOL,
                 "semicircle point ({px}, {py}) off radius-50 circle, residual {resid}"
             );
+        }
+    }
+
+    #[test]
+    fn svg_arc_non_finite_arguments_leave_path_unchanged() {
+        // Canvas-spec rule: path methods return early, adding nothing, when any
+        // argument is infinite or NaN. Exercise every float argument position
+        // with every non-finite value.
+        let bad_values = [f32::NAN, f32::INFINITY, f32::NEG_INFINITY];
+
+        for arg_index in 0..5 {
+            for &bad in &bad_values {
+                let mut args = [50.0, 40.0, 0.3, 90.0, 60.0];
+                args[arg_index] = bad;
+
+                let mut path = Path::new();
+                path.move_to(10.0, 20.0);
+                let before = path.verbs().count();
+                path.svg_arc_to(args[0], args[1], args[2], true, false, args[3], args[4]);
+                assert_eq!(
+                    before,
+                    path.verbs().count(),
+                    "non-finite arg {arg_index} ({bad}) must add no verbs"
+                );
+
+                // The path must remain fully usable afterwards: a follow-up
+                // line_to continues from the pre-arc current point.
+                path.line_to(70.0, 80.0);
+                let verbs: Vec<_> = path.verbs().collect();
+                assert_eq!(verbs.len(), before + 1);
+                assert!(matches!(verbs.last(), Some(Verb::LineTo(70.0, 80.0))));
+
+                // On an empty path the guard must also fire before the
+                // implicit move_to(0, 0) is inserted.
+                let mut empty = Path::new();
+                empty.svg_arc_to(args[0], args[1], args[2], true, false, args[3], args[4]);
+                assert!(
+                    empty.is_empty(),
+                    "non-finite arg {arg_index} ({bad}) must not add an implicit move_to"
+                );
+            }
         }
     }
 

--- a/src/path.rs
+++ b/src/path.rs
@@ -453,18 +453,26 @@ impl Path {
 
         // F.6.6 step 1 / F.6.2: a zero radius degrades to a straight line.
         // F.6.2: negative radii drop their sign.
-        let mut rx = rx.abs();
-        let mut ry = ry.abs();
+        //
+        // The endpoint-to-center conversion below runs in f64: the squared
+        // terms of F.6.6's lambda and the F.6.5.2 quotient overflow f32's
+        // exponent range long before the resulting arc geometry itself leaves
+        // f32 range (e.g. lambda for rx = 1e-30 radii that merely need to be
+        // scaled up, or (1e30)^2 midpoint terms for large translations).
+        // Reference SVG arc implementations (resvg via kurbo, Batik) perform
+        // this conversion in f64 for the same reason.
+        let mut rx = f64::from(rx).abs();
+        let mut ry = f64::from(ry).abs();
         if rx == 0.0 || ry == 0.0 {
             self.line_to(end.x, end.y);
             return;
         }
 
-        let (sin_phi, cos_phi) = x_axis_rotation.sin_cos();
+        let (sin_phi, cos_phi) = f64::from(x_axis_rotation).sin_cos();
 
         // F.6.5.1: midpoint translation followed by rotation by -phi.
-        let dx2 = (start.x - end.x) * 0.5;
-        let dy2 = (start.y - end.y) * 0.5;
+        let dx2 = (f64::from(start.x) - f64::from(end.x)) * 0.5;
+        let dy2 = (f64::from(start.y) - f64::from(end.y)) * 0.5;
         let x1p = cos_phi * dx2 + sin_phi * dy2;
         let y1p = -sin_phi * dx2 + cos_phi * dy2;
 
@@ -492,8 +500,8 @@ impl Path {
         let cyp = coef * -(ry * x1p / rx);
 
         // F.6.5.3: transform the center back to the original frame.
-        let cx = cos_phi * cxp - sin_phi * cyp + (start.x + end.x) * 0.5;
-        let cy = sin_phi * cxp + cos_phi * cyp + (start.y + end.y) * 0.5;
+        let cx = cos_phi * cxp - sin_phi * cyp + (f64::from(start.x) + f64::from(end.x)) * 0.5;
+        let cy = sin_phi * cxp + cos_phi * cyp + (f64::from(start.y) + f64::from(end.y)) * 0.5;
 
         // F.6.5.5 / F.6.5.6: starting angle and swept angle via the angle helper.
         let ux = (x1p - cxp) / rx;
@@ -506,14 +514,14 @@ impl Path {
 
         // Enforce the sweep flag direction (F.6.5.6 modulo rule).
         if !sweep && delta > 0.0 {
-            delta -= PI * 2.0;
+            delta -= std::f64::consts::PI * 2.0;
         } else if sweep && delta < 0.0 {
-            delta += PI * 2.0;
+            delta += std::f64::consts::PI * 2.0;
         }
 
         // Split into segments of at most 90 degrees and emit cubic beziers.
-        let ndivs = (delta.abs() / (PI * 0.5)).ceil().max(1.0) as i32;
-        let seg = delta / ndivs as f32;
+        let ndivs = (delta.abs() / (std::f64::consts::PI * 0.5)).ceil().max(1.0) as i32;
+        let seg = delta / f64::from(ndivs);
         // Maisonobe per-segment handle length matching the kappa technique used
         // by arc()/ellipse(): alpha = sin(seg) * (sqrt(4 + 3 tan(seg/2)^2) - 1) / 3.
         let half = seg * 0.5;
@@ -523,36 +531,57 @@ impl Path {
         let mut coords = Vec::with_capacity(ndivs as usize * 3);
 
         // Point and derivative of the rotated ellipse at parametric angle t.
-        let point = |t: f32| -> Position {
+        let point = |t: f64| -> (f64, f64) {
             let (sin_t, cos_t) = t.sin_cos();
-            Position {
-                x: cx + rx * cos_phi * cos_t - ry * sin_phi * sin_t,
-                y: cy + rx * sin_phi * cos_t + ry * cos_phi * sin_t,
-            }
+            (
+                cx + rx * cos_phi * cos_t - ry * sin_phi * sin_t,
+                cy + rx * sin_phi * cos_t + ry * cos_phi * sin_t,
+            )
         };
-        let derivative = |t: f32| -> Vector {
+        let derivative = |t: f64| -> (f64, f64) {
             let (sin_t, cos_t) = t.sin_cos();
-            Vector {
-                x: -rx * cos_phi * sin_t - ry * sin_phi * cos_t,
-                y: -rx * sin_phi * sin_t + ry * cos_phi * cos_t,
-            }
+            (
+                -rx * cos_phi * sin_t - ry * sin_phi * cos_t,
+                -rx * sin_phi * sin_t + ry * cos_phi * cos_t,
+            )
+        };
+        let to_position = |p: (f64, f64)| Position {
+            x: p.0 as f32,
+            y: p.1 as f32,
         };
 
         for i in 0..ndivs {
-            let t1 = theta1 + seg * i as f32;
+            let t1 = theta1 + seg * f64::from(i);
             let t2 = t1 + seg;
             let p1 = point(t1);
             let p2 = point(t2);
-            let c1 = p1 + derivative(t1) * alpha;
-            let c2 = p2 - derivative(t2) * alpha;
+            let d1 = derivative(t1);
+            let d2 = derivative(t2);
+            let c1 = (p1.0 + d1.0 * alpha, p1.1 + d1.1 * alpha);
+            let c2 = (p2.0 - d2.0 * alpha, p2.1 - d2.1 * alpha);
 
             commands.push(PackedVerb::BezierTo);
-            coords.extend_from_slice(&[c1, c2, p2]);
+            coords.extend_from_slice(&[to_position(c1), to_position(c2), to_position(p2)]);
         }
 
         // Guarantee the path endpoint lands exactly on the requested point.
         if let Some(last) = coords.last_mut() {
             *last = end;
+        }
+
+        // Extreme (but finite) inputs can describe arc geometry that exceeds
+        // f32 range even though both endpoints are representable (e.g. F.6.6
+        // scaling of wildly mismatched radii yields a control point beyond
+        // f32::MAX). Degrade to the chord rather than emit non-finite vertices
+        // that would poison downstream tessellation; this preserves the
+        // invariant that the path always continues to the requested endpoint
+        // with finite geometry.
+        if coords
+            .iter()
+            .any(|position| !position.x.is_finite() || !position.y.is_finite())
+        {
+            self.line_to(end.x, end.y);
+            return;
         }
 
         self.append(&commands, &coords);
@@ -807,14 +836,16 @@ impl<'a> DashCursor<'a> {
 ///
 /// The cross product is treated as a strict two-way sign so that a zero cross
 /// product takes the positive branch. For collinear-opposite vectors the cross
-/// product is zero and F.6.5.4 requires `+π` (not 0). `f32::signum` is unsuitable
+/// product is zero and F.6.5.4 requires `+π` (not 0). `signum()` is unsuitable
 /// here: it never returns 0 but returns `-1.0` for a `-0.0` input, and the cross
 /// product of e.g. `(-1, 0)` and `(1, 0)` evaluates to `-0.0`, which would give
 /// `-π` and violate the spec for that semicircle. The `< 0.0 → -1 else +1` rule
 /// treats both `+0.0` and `-0.0` as positive, yielding `+π`; the F.6.5.6
 /// sweep-modulo rule downstream then flips `+π` to `−π` when the sweep flag is
 /// unset, so both semicircle directions render correctly.
-fn svg_arc_angle(ux: f32, uy: f32, vx: f32, vy: f32) -> f32 {
+///
+/// Operates in f64 like the rest of the endpoint-to-center conversion.
+fn svg_arc_angle(ux: f64, uy: f64, vx: f64, vy: f64) -> f64 {
     let dot = ux * vx + uy * vy;
     let len = (ux * ux + uy * uy).sqrt() * (vx * vx + vy * vy).sqrt();
     let mut cos = if len == 0.0 { 0.0 } else { dot / len };
@@ -1406,13 +1437,13 @@ mod tests {
         // has a +0.0 cross product and is +PI under both rules.)
         let angle = svg_arc_angle(-1.0, 0.0, 1.0, 0.0);
         assert!(
-            (angle - PI).abs() < 1e-6,
+            (angle - std::f64::consts::PI).abs() < 1e-6,
             "collinear-opposite angle should be +PI, got {angle}"
         );
 
         let reciprocal = svg_arc_angle(1.0, 0.0, -1.0, 0.0);
         assert!(
-            (reciprocal - PI).abs() < 1e-6,
+            (reciprocal - std::f64::consts::PI).abs() < 1e-6,
             "reciprocal collinear-opposite angle should be +PI, got {reciprocal}"
         );
     }
@@ -1477,6 +1508,68 @@ mod tests {
                 "semicircle point ({px}, {py}) off radius-50 circle, residual {resid}"
             );
         }
+    }
+
+    #[test]
+    fn svg_arc_tiny_radii_scale_up_without_overflow() {
+        // Minimized from the deterministic fuzz (iteration 78 of seed
+        // 0x5eed_1e57_ab1e_f00d): radii far smaller than the chord must be
+        // scaled up per F.6.6, but computing lambda = (x1p/rx)^2 + (y1p/ry)^2
+        // in f32 overflows to infinity for rx = ry = 1e-30, which then poisons
+        // the center parametrization into NaN control points. The spec-correct
+        // result is a half-circle spanning the chord, exactly as if the radii
+        // had been given as chord/2.
+        let mut path = Path::new();
+        path.move_to(0.0, 0.0);
+        path.svg_arc_to(1e-30, 1e-30, 0.0, false, true, 100.0, 0.0);
+
+        let (points, endpoint) = sample_path(&path);
+        assert!(!points.is_empty());
+        assert!((endpoint.0 - 100.0).abs() < 1e-3 && endpoint.1.abs() < 1e-3);
+        for (px, py) in points {
+            assert!(px.is_finite() && py.is_finite(), "non-finite point ({px}, {py})");
+            let residual = ellipse_residual(px, py, 50.0, 0.0, 50.0, 50.0, 0.0);
+            assert!(
+                residual.abs() < ELLIPSE_RESIDUAL_TOL,
+                "tiny-radii point ({px}, {py}) off scaled half-circle, residual {residual}"
+            );
+        }
+    }
+
+    #[test]
+    fn svg_arc_huge_coordinates_stay_finite() {
+        // Squaring f32-range coordinates in the F.6.5.1 midpoint terms
+        // overflows f32 ((1e30)^2 = 1e60 > f32::MAX) even though the resulting
+        // arc geometry itself is comfortably representable. The center math
+        // must not hand non-finite control points to the path.
+        let mut path = Path::new();
+        path.move_to(-1e30, 0.0);
+        path.svg_arc_to(2e30, 2e30, 0.0, false, true, 1e30, 0.0);
+
+        let (points, endpoint) = sample_path(&path);
+        assert!(!points.is_empty());
+        for (px, py) in &points {
+            assert!(px.is_finite() && py.is_finite(), "non-finite point ({px}, {py})");
+        }
+        let tolerance = 1e30 * 1e-2;
+        assert!((endpoint.0 - 1e30).abs() < tolerance && endpoint.1.abs() < tolerance);
+    }
+
+    #[test]
+    fn svg_arc_unrepresentable_geometry_degrades_to_chord() {
+        // F.6.6 scaling of wildly mismatched radii (rx = 1e30, ry = 1e-30 with
+        // a ~141-unit chord) yields an effective rx of ~5e61: the arc's control
+        // points exceed f32 range even though both endpoints are finite. The
+        // builder must degrade to the chord rather than emit non-finite
+        // vertices.
+        let mut path = Path::new();
+        path.move_to(0.0, 0.0);
+        path.svg_arc_to(1e30, 1e-30, 0.0, true, true, 100.0, 100.0);
+
+        let verbs: Vec<_> = path.verbs().collect();
+        assert_eq!(verbs.len(), 2, "expected move_to + line_to, got {verbs:?}");
+        assert!(matches!(verbs[0], Verb::MoveTo(0.0, 0.0)));
+        assert!(matches!(verbs[1], Verb::LineTo(100.0, 100.0)));
     }
 
     #[test]

--- a/src/path.rs
+++ b/src/path.rs
@@ -795,13 +795,23 @@ impl<'a> DashCursor<'a> {
 
 /// Signed angle between vectors `(ux, uy)` and `(vx, vy)` as defined by the W3C
 /// SVG implementation notes F.6.5.4: `±arccos((u·v)/(|u||v|))` where the sign is
-/// that of `ux*vy − uy*vx`.
+/// `+` when `ux*vy − uy*vx ≥ 0` and `−` otherwise.
+///
+/// The cross product is treated as a strict two-way sign so that a zero cross
+/// product takes the positive branch. For collinear-opposite vectors the cross
+/// product is zero and F.6.5.4 requires `+π` (not 0). `f32::signum` is unsuitable
+/// here: it never returns 0 but returns `-1.0` for a `-0.0` input, and the cross
+/// product of e.g. `(-1, 0)` and `(1, 0)` evaluates to `-0.0`, which would give
+/// `-π` and violate the spec for that semicircle. The `< 0.0 → -1 else +1` rule
+/// treats both `+0.0` and `-0.0` as positive, yielding `+π`; the F.6.5.6
+/// sweep-modulo rule downstream then flips `+π` to `−π` when the sweep flag is
+/// unset, so both semicircle directions render correctly.
 fn svg_arc_angle(ux: f32, uy: f32, vx: f32, vy: f32) -> f32 {
     let dot = ux * vx + uy * vy;
     let len = (ux * ux + uy * uy).sqrt() * (vx * vx + vy * vy).sqrt();
     let mut cos = if len == 0.0 { 0.0 } else { dot / len };
     cos = cos.clamp(-1.0, 1.0);
-    let sign = (ux * vy - uy * vx).signum();
+    let sign = if (ux * vy - uy * vx) < 0.0 { -1.0 } else { 1.0 };
     sign * cos.acos()
 }
 
@@ -964,7 +974,7 @@ impl ttf_parser::OutlineBuilder for Path {
 
 #[cfg(test)]
 mod tests {
-    use super::{Path, Verb};
+    use super::{svg_arc_angle, Path, Verb, PI};
 
     fn line_path(length: f32) -> Path {
         let mut path = Path::new();
@@ -1371,5 +1381,142 @@ mod tests {
         let (_, endpoint) = sample_path(&path);
         assert!((endpoint.0 - 100.0).abs() < 1e-3);
         assert!((endpoint.1).abs() < 1e-3);
+    }
+
+    #[test]
+    fn svg_arc_angle_collinear_opposite_is_positive_pi() {
+        // F.6.5.4 boundary: for collinear-opposite vectors the cross product
+        // ux*vy - uy*vx is zero and the spec mandates the POSITIVE branch, i.e.
+        // +PI. This is exactly the start->end radius-vector pair of the standard
+        // `move_to(0,0); svg_arc_to(50,50,0,_,_,100,0)` semicircle, where the
+        // start vector is (-1, 0) and the end vector is (1, 0).
+        //
+        // The product `(-1)*0 - 0*1` evaluates to floating-point -0.0, so a
+        // `signum()`-based sign returns -1.0 and yields -PI here, violating the
+        // spec. The corrected `< 0.0 -> -1 else +1` rule treats -0.0 as the
+        // positive branch and returns +PI. (The reciprocal pair (1,0)->(-1,0)
+        // has a +0.0 cross product and is +PI under both rules.)
+        let angle = svg_arc_angle(-1.0, 0.0, 1.0, 0.0);
+        assert!(
+            (angle - PI).abs() < 1e-6,
+            "collinear-opposite angle should be +PI, got {angle}"
+        );
+
+        let reciprocal = svg_arc_angle(1.0, 0.0, -1.0, 0.0);
+        assert!(
+            (reciprocal - PI).abs() < 1e-6,
+            "reciprocal collinear-opposite angle should be +PI, got {reciprocal}"
+        );
+    }
+
+    #[test]
+    fn svg_arc_small_semicircle_reaches_apex_both_directions() {
+        // A 180-degree arc is the boundary case where the start and end radius
+        // vectors are collinear and opposite, so the F.6.5.4 cross product is
+        // zero (see svg_arc_angle_collinear_opposite_is_positive_pi). Both sweep
+        // directions of `move_to(0,0); svg_arc_to(50,50,0,false,_,100,0)` must
+        // trace a genuine semicircle of radius 50 centered at (50, 0) rather than
+        // collapsing onto the chord.
+        let start = (0.0, 0.0);
+        let end = (100.0, 0.0);
+        let r = 50.0;
+        let center = (50.0, 0.0);
+
+        let semicircle = |sweep: bool| -> (Vec<(f32, f32)>, (f32, f32), (f32, f32)) {
+            let mut path = Path::new();
+            path.move_to(start.0, start.1);
+            path.svg_arc_to(r, r, 0.0, false, sweep, end.0, end.1);
+            let (points, endpoint) = sample_path(&path);
+            let mid = points[points.len() / 2];
+            (points, mid, endpoint)
+        };
+
+        let (sweep_pts, sweep_mid, sweep_end) = semicircle(true);
+        let (nsweep_pts, nsweep_mid, nsweep_end) = semicircle(false);
+
+        // Both directions must actually reach the requested endpoint.
+        assert!((sweep_end.0 - end.0).abs() < 1e-3 && (sweep_end.1 - end.1).abs() < 1e-3);
+        assert!((nsweep_end.0 - end.0).abs() < 1e-3 && (nsweep_end.1 - end.1).abs() < 1e-3);
+
+        // The apex of a true semicircle is the chord midpoint offset by the
+        // radius perpendicular to the chord: (50, +-50). A collapsed (chord)
+        // arc would instead leave the midpoint at (50, 0), so the apex distance
+        // from the chord guards against any future regression to a degenerate
+        // 180-degree arc. The sweep flag picks the half-plane: sweep=true bulges
+        // to -y, sweep=false to +y.
+        assert!(
+            (sweep_mid.0 - center.0).abs() < 0.5 && (sweep_mid.1 + r).abs() < 0.5,
+            "sweep=true semicircle midpoint {sweep_mid:?} should reach apex (50, -50)"
+        );
+        assert!(
+            (nsweep_mid.0 - center.0).abs() < 0.5 && (nsweep_mid.1 - r).abs() < 0.5,
+            "sweep=false semicircle midpoint {nsweep_mid:?} should reach apex (50, 50)"
+        );
+
+        // The two sweep directions must bulge into opposite half-planes.
+        let sweep_side = chord_bulge_side(start, end, sweep_mid);
+        let nsweep_side = chord_bulge_side(start, end, nsweep_mid);
+        assert!(
+            sweep_side * nsweep_side < 0.0,
+            "semicircles must bulge to opposite sides: {sweep_side} vs {nsweep_side}"
+        );
+
+        // Every sampled point of both arcs lies on the radius-50 circle.
+        for (px, py) in sweep_pts.into_iter().chain(nsweep_pts.into_iter()) {
+            let resid = ellipse_residual(px, py, center.0, center.1, r, r, 0.0);
+            assert!(
+                resid.abs() < ELLIPSE_RESIDUAL_TOL,
+                "semicircle point ({px}, {py}) off radius-50 circle, residual {resid}"
+            );
+        }
+    }
+
+    #[test]
+    fn svg_arc_large_semicircle_sweeps_the_long_way() {
+        // The SVG path `A 50 50 0 1 1 100 0` from (0,0): rx=ry=50 exactly spans
+        // the 100-unit chord, so the large-arc flag still yields a 180-degree
+        // semicircle, with the large+sweep flags forcing the long way around.
+        // This exercises the same collinear-opposite F.6.5.4 boundary as the
+        // small form. The apex must reach (50, -50) and the endpoint (100, 0).
+        let start = (0.0, 0.0);
+        let end = (100.0, 0.0);
+        let r = 50.0;
+        let center = (50.0, 0.0);
+
+        let mut path = Path::new();
+        path.move_to(start.0, start.1);
+        path.svg_arc_to(r, r, 0.0, true, true, end.0, end.1);
+
+        let (points, endpoint) = sample_path(&path);
+        assert!(
+            (endpoint.0 - end.0).abs() < 1e-3 && (endpoint.1 - end.1).abs() < 1e-3,
+            "large-arc semicircle endpoint {endpoint:?} should reach (100, 0)"
+        );
+
+        let mid = points[points.len() / 2];
+        assert!(
+            (mid.0 - center.0).abs() < 0.5 && (mid.1 + r).abs() < 0.5,
+            "large-arc semicircle midpoint {mid:?} should reach apex (50, -50)"
+        );
+
+        // Total polyline length must be close to a half-circumference (pi*r),
+        // confirming it swept ~180 degrees rather than collapsing to the chord.
+        let length: f32 = points
+            .windows(2)
+            .map(|w| (w[1].0 - w[0].0).hypot(w[1].1 - w[0].1))
+            .sum();
+        let half_circumference = PI * r;
+        assert!(
+            (length - half_circumference).abs() < 1.0,
+            "swept length {length} should be ~pi*r ({half_circumference})"
+        );
+
+        for (px, py) in points {
+            let resid = ellipse_residual(px, py, center.0, center.1, r, r, 0.0);
+            assert!(
+                resid.abs() < ELLIPSE_RESIDUAL_TOL,
+                "large semicircle point ({px}, {py}) off radius-50 circle, residual {resid}"
+            );
+        }
     }
 }

--- a/src/path.rs
+++ b/src/path.rs
@@ -414,6 +414,142 @@ impl Path {
         self.arc(cpos.x, cpos.y, radius, a0 + PI / 2.0, a1 + PI / 2.0, dir);
     }
 
+    /// Adds an SVG elliptical arc (the path data `A`/`a` command) from the
+    /// current point to (`x`, `y`), emitting cubic bezier segments.
+    ///
+    /// `rx`/`ry` are the ellipse radii, `x_axis_rotation` is the rotation of the
+    /// ellipse's x-axis relative to the current coordinate system **in radians**
+    /// (the SVG attribute is in degrees), `large_arc` selects the larger of the
+    /// two possible arc sweeps, and `sweep` selects the positive-angle
+    /// (clockwise in SVG's y-down system) direction.
+    ///
+    /// If the path is empty the arc starts from the origin, matching how the
+    /// other arc builders treat an empty current point. Following the W3C SVG
+    /// implementation notes (section F.6): identical start/end points omit the
+    /// arc, a zero radius degrades to a straight line, negative radii use their
+    /// absolute value, and radii too small to span the endpoints are scaled up.
+    pub fn svg_arc_to(&mut self, rx: f32, ry: f32, x_axis_rotation: f32, large_arc: bool, sweep: bool, x: f32, y: f32) {
+        let start = if self.verbs.is_empty() {
+            let origin = Position { x: 0.0, y: 0.0 };
+            self.move_to(origin.x, origin.y);
+            origin
+        } else {
+            self.last_pos
+        };
+        let end = Position { x, y };
+
+        // F.6.2: identical endpoints omit the arc entirely.
+        if start.x == end.x && start.y == end.y {
+            return;
+        }
+
+        // F.6.6 step 1 / F.6.2: a zero radius degrades to a straight line.
+        // F.6.2: negative radii drop their sign.
+        let mut rx = rx.abs();
+        let mut ry = ry.abs();
+        if rx == 0.0 || ry == 0.0 {
+            self.line_to(end.x, end.y);
+            return;
+        }
+
+        let (sin_phi, cos_phi) = x_axis_rotation.sin_cos();
+
+        // F.6.5.1: midpoint translation followed by rotation by -phi.
+        let dx2 = (start.x - end.x) * 0.5;
+        let dy2 = (start.y - end.y) * 0.5;
+        let x1p = cos_phi * dx2 + sin_phi * dy2;
+        let y1p = -sin_phi * dx2 + cos_phi * dy2;
+
+        // F.6.6 step 3: scale the radii up if they cannot span the endpoints.
+        let lambda = (x1p * x1p) / (rx * rx) + (y1p * y1p) / (ry * ry);
+        if lambda > 1.0 {
+            let s = lambda.sqrt();
+            rx *= s;
+            ry *= s;
+        }
+
+        // F.6.5.2: center in the rotated/translated frame.
+        let rx2 = rx * rx;
+        let ry2 = ry * ry;
+        let x1p2 = x1p * x1p;
+        let y1p2 = y1p * y1p;
+        let numerator = (rx2 * ry2 - rx2 * y1p2 - ry2 * x1p2).max(0.0);
+        let denominator = rx2 * y1p2 + ry2 * x1p2;
+        let mut coef = (numerator / denominator).sqrt();
+        // The sign is positive when the flags differ, negative when they match.
+        if large_arc == sweep {
+            coef = -coef;
+        }
+        let cxp = coef * (rx * y1p / ry);
+        let cyp = coef * -(ry * x1p / rx);
+
+        // F.6.5.3: transform the center back to the original frame.
+        let cx = cos_phi * cxp - sin_phi * cyp + (start.x + end.x) * 0.5;
+        let cy = sin_phi * cxp + cos_phi * cyp + (start.y + end.y) * 0.5;
+
+        // F.6.5.5 / F.6.5.6: starting angle and swept angle via the angle helper.
+        let ux = (x1p - cxp) / rx;
+        let uy = (y1p - cyp) / ry;
+        let vx = (-x1p - cxp) / rx;
+        let vy = (-y1p - cyp) / ry;
+
+        let theta1 = svg_arc_angle(1.0, 0.0, ux, uy);
+        let mut delta = svg_arc_angle(ux, uy, vx, vy);
+
+        // Enforce the sweep flag direction (F.6.5.6 modulo rule).
+        if !sweep && delta > 0.0 {
+            delta -= PI * 2.0;
+        } else if sweep && delta < 0.0 {
+            delta += PI * 2.0;
+        }
+
+        // Split into segments of at most 90 degrees and emit cubic beziers.
+        let ndivs = (delta.abs() / (PI * 0.5)).ceil().max(1.0) as i32;
+        let seg = delta / ndivs as f32;
+        // Maisonobe per-segment handle length matching the kappa technique used
+        // by arc()/ellipse(): alpha = sin(seg) * (sqrt(4 + 3 tan(seg/2)^2) - 1) / 3.
+        let half = seg * 0.5;
+        let alpha = seg.sin() * ((4.0 + 3.0 * half.tan() * half.tan()).sqrt() - 1.0) / 3.0;
+
+        let mut commands = Vec::with_capacity(ndivs as usize);
+        let mut coords = Vec::with_capacity(ndivs as usize * 3);
+
+        // Point and derivative of the rotated ellipse at parametric angle t.
+        let point = |t: f32| -> Position {
+            let (sin_t, cos_t) = t.sin_cos();
+            Position {
+                x: cx + rx * cos_phi * cos_t - ry * sin_phi * sin_t,
+                y: cy + rx * sin_phi * cos_t + ry * cos_phi * sin_t,
+            }
+        };
+        let derivative = |t: f32| -> Vector {
+            let (sin_t, cos_t) = t.sin_cos();
+            Vector {
+                x: -rx * cos_phi * sin_t - ry * sin_phi * cos_t,
+                y: -rx * sin_phi * sin_t + ry * cos_phi * cos_t,
+            }
+        };
+
+        for i in 0..ndivs {
+            let t1 = theta1 + seg * i as f32;
+            let t2 = t1 + seg;
+            let p1 = point(t1);
+            let p2 = point(t2);
+            let c1 = p1 + derivative(t1) * alpha;
+            let c2 = p2 - derivative(t2) * alpha;
+
+            commands.push(PackedVerb::BezierTo);
+            coords.extend_from_slice(&[c1, c2, p2]);
+        }
+
+        // Guarantee the path endpoint lands exactly on the requested point.
+        if let Some(last) = coords.last_mut() {
+            *last = end;
+        }
+
+        self.append(&commands, &coords);
+    }
+
     /// Creates a new rectangle shaped sub-path.
     pub fn rect(&mut self, x: f32, y: f32, w: f32, h: f32) {
         self.append(
@@ -657,6 +793,18 @@ impl<'a> DashCursor<'a> {
     }
 }
 
+/// Signed angle between vectors `(ux, uy)` and `(vx, vy)` as defined by the W3C
+/// SVG implementation notes F.6.5.4: `±arccos((u·v)/(|u||v|))` where the sign is
+/// that of `ux*vy − uy*vx`.
+fn svg_arc_angle(ux: f32, uy: f32, vx: f32, vy: f32) -> f32 {
+    let dot = ux * vx + uy * vy;
+    let len = (ux * ux + uy * uy).sqrt() * (vx * vx + vy * vy).sqrt();
+    let mut cos = if len == 0.0 { 0.0 } else { dot / len };
+    cos = cos.clamp(-1.0, 1.0);
+    let sign = (ux * vy - uy * vx).signum();
+    sign * cos.acos()
+}
+
 fn normalize_dash_pattern(dash: &[f32]) -> Vec<f32> {
     if dash.is_empty() || dash.iter().any(|value| !value.is_finite() || *value < 0.0) {
         return Vec::new();
@@ -896,5 +1044,332 @@ mod tests {
             format!("{:?}", path.verbs().collect::<Vec<_>>()),
             format!("{:?}", dashed.verbs().collect::<Vec<_>>())
         );
+    }
+
+    // ---- SVG elliptical arc (svg_arc_to) tests ----
+
+    /// Evaluates a cubic bezier at parameter `s` in [0, 1].
+    fn bezier_point(p0: (f32, f32), c1: (f32, f32), c2: (f32, f32), p3: (f32, f32), s: f32) -> (f32, f32) {
+        let u = 1.0 - s;
+        let w0 = u * u * u;
+        let w1 = 3.0 * u * u * s;
+        let w2 = 3.0 * u * s * s;
+        let w3 = s * s * s;
+        (
+            w0 * p0.0 + w1 * c1.0 + w2 * c2.0 + w3 * p3.0,
+            w0 * p0.1 + w1 * c1.1 + w2 * c2.1 + w3 * p3.1,
+        )
+    }
+
+    /// Densely samples every bezier segment of `path`, returning the sampled
+    /// points along with the final endpoint of the path.
+    fn sample_path(path: &Path) -> (Vec<(f32, f32)>, (f32, f32)) {
+        let mut points = Vec::new();
+        let mut cur = (0.0_f32, 0.0_f32);
+        let mut endpoint = (0.0_f32, 0.0_f32);
+
+        for verb in path.verbs() {
+            match verb {
+                Verb::MoveTo(x, y) => {
+                    cur = (x, y);
+                    endpoint = cur;
+                }
+                Verb::LineTo(x, y) => {
+                    for i in 0..=16 {
+                        let s = i as f32 / 16.0;
+                        points.push((cur.0 + (x - cur.0) * s, cur.1 + (y - cur.1) * s));
+                    }
+                    cur = (x, y);
+                    endpoint = cur;
+                }
+                Verb::BezierTo(c1x, c1y, c2x, c2y, x, y) => {
+                    let p3 = (x, y);
+                    for i in 0..=32 {
+                        let s = i as f32 / 32.0;
+                        points.push(bezier_point(cur, (c1x, c1y), (c2x, c2y), p3, s));
+                    }
+                    cur = p3;
+                    endpoint = cur;
+                }
+                Verb::Close | Verb::Solid | Verb::Hole => {}
+            }
+        }
+
+        (points, endpoint)
+    }
+
+    /// Implicit-form residual of a rotated ellipse for the point (px, py): zero
+    /// when the point lies exactly on the ellipse boundary.
+    ///
+    /// Cubic beziers only approximate an elliptical arc; with the per-segment
+    /// (Maisonobe) handle length used here a full 90-degree segment deviates from
+    /// the true ellipse by at most ~4e-3 in this residual (≈0.12px on a 60px
+    /// radius), matching the accuracy of the existing `arc()`/`ellipse()`
+    /// builders. Tests allow a little headroom over that worst case.
+    const ELLIPSE_RESIDUAL_TOL: f32 = 5e-3;
+
+    fn ellipse_residual(px: f32, py: f32, cx: f32, cy: f32, rx: f32, ry: f32, phi: f32) -> f32 {
+        let (sin_phi, cos_phi) = phi.sin_cos();
+        let dx = px - cx;
+        let dy = py - cy;
+        // Rotate the offset back into the ellipse's local axes.
+        let u = cos_phi * dx + sin_phi * dy;
+        let v = -sin_phi * dx + cos_phi * dy;
+        (u * u) / (rx * rx) + (v * v) / (ry * ry) - 1.0
+    }
+
+    #[test]
+    fn svg_arc_endpoint_is_exact() {
+        let mut path = Path::new();
+        path.move_to(100.0, 100.0);
+        path.svg_arc_to(60.0, 40.0, 0.5, true, false, 240.0, 180.0);
+
+        let (_, endpoint) = sample_path(&path);
+        assert!((endpoint.0 - 240.0).abs() < 1e-3, "x endpoint {}", endpoint.0);
+        assert!((endpoint.1 - 180.0).abs() < 1e-3, "y endpoint {}", endpoint.1);
+    }
+
+    #[test]
+    fn svg_arc_points_lie_on_axis_aligned_ellipse() {
+        let cx = 100.0;
+        let cy = 100.0;
+        let rx = 60.0;
+        let ry = 40.0;
+
+        // Start on the ellipse at angle 0, end at the top; the arc bulges out.
+        let start = (cx + rx, cy);
+        let end = (cx, cy - ry);
+
+        let mut path = Path::new();
+        path.move_to(start.0, start.1);
+        path.svg_arc_to(rx, ry, 0.0, false, false, end.0, end.1);
+
+        let (points, _) = sample_path(&path);
+        assert!(!points.is_empty());
+        for (px, py) in points {
+            let r = ellipse_residual(px, py, cx, cy, rx, ry, 0.0);
+            assert!(
+                r.abs() < ELLIPSE_RESIDUAL_TOL,
+                "point ({px}, {py}) off ellipse, residual {r}"
+            );
+        }
+    }
+
+    #[test]
+    fn svg_arc_points_lie_on_rotated_ellipse() {
+        let cx = 50.0;
+        let cy = 70.0;
+        let rx = 80.0;
+        let ry = 30.0;
+        let phi = 0.7_f32; // radians
+
+        // Derive endpoints that genuinely lie on the rotated ellipse.
+        let on_ellipse = |t: f32| -> (f32, f32) {
+            let (sin_phi, cos_phi) = phi.sin_cos();
+            let (sin_t, cos_t) = t.sin_cos();
+            (
+                cx + rx * cos_phi * cos_t - ry * sin_phi * sin_t,
+                cy + rx * sin_phi * cos_t + ry * cos_phi * sin_t,
+            )
+        };
+        let start = on_ellipse(0.3);
+        let end = on_ellipse(2.4);
+
+        let mut path = Path::new();
+        path.move_to(start.0, start.1);
+        path.svg_arc_to(rx, ry, phi, false, true, end.0, end.1);
+
+        let (points, _) = sample_path(&path);
+        assert!(!points.is_empty());
+        for (px, py) in points {
+            let r = ellipse_residual(px, py, cx, cy, rx, ry, phi);
+            assert!(
+                r.abs() < ELLIPSE_RESIDUAL_TOL,
+                "point ({px}, {py}) off rotated ellipse, residual {r}"
+            );
+        }
+    }
+
+    /// Signed perpendicular offset of the arc's midpoint from the chord
+    /// (start -> end). Its sign tells us which side of the chord the arc bulges
+    /// toward; positive and negative are the two half-planes.
+    fn chord_bulge_side(start: (f32, f32), end: (f32, f32), mid: (f32, f32)) -> f32 {
+        let cx = end.0 - start.0;
+        let cy = end.1 - start.1;
+        let mx = mid.0 - start.0;
+        let my = mid.1 - start.1;
+        cx * my - cy * mx
+    }
+
+    #[test]
+    fn svg_arc_flag_combinations_are_distinct() {
+        let start = (100.0, 100.0);
+        let end = (200.0, 150.0);
+        let rx = 80.0;
+        let ry = 80.0;
+
+        let cases = [(false, false), (false, true), (true, false), (true, true)];
+        let mut midpoints = Vec::new();
+        let mut sides = Vec::new();
+        for &(large, sweep) in &cases {
+            let mut path = Path::new();
+            path.move_to(start.0, start.1);
+            path.svg_arc_to(rx, ry, 0.0, large, sweep, end.0, end.1);
+            let (points, _) = sample_path(&path);
+            let mid = points[points.len() / 2];
+            midpoints.push(mid);
+            sides.push(chord_bulge_side(start, end, mid));
+        }
+
+        // The four arcs must reach four distinct midpoints.
+        for i in 0..cases.len() {
+            for j in (i + 1)..cases.len() {
+                let d = (midpoints[i].0 - midpoints[j].0).hypot(midpoints[i].1 - midpoints[j].1);
+                assert!(
+                    d > 1.0,
+                    "arcs {:?} and {:?} have coincident midpoints",
+                    cases[i],
+                    cases[j]
+                );
+            }
+        }
+
+        // The sweep flag controls which side of the chord the arc bulges to, so
+        // for a fixed large_arc flag the two sweep values must land on opposite
+        // half-planes. sides indices: 0=(F,F) 1=(F,T) 2=(T,F) 3=(T,T).
+        assert!(
+            sides[0] * sides[1] < 0.0,
+            "small arcs should bulge to opposite sides: {:?}",
+            sides
+        );
+        assert!(
+            sides[2] * sides[3] < 0.0,
+            "large arcs should bulge to opposite sides: {:?}",
+            sides
+        );
+    }
+
+    #[test]
+    fn svg_arc_large_flag_selects_longer_sweep() {
+        let start = (100.0, 100.0);
+        let end = (160.0, 100.0);
+        let rx = 50.0;
+        let ry = 50.0;
+
+        let arc_length = |large: bool| -> f32 {
+            let mut path = Path::new();
+            path.move_to(start.0, start.1);
+            path.svg_arc_to(rx, ry, 0.0, large, true, end.0, end.1);
+            let (points, _) = sample_path(&path);
+            points
+                .windows(2)
+                .map(|w| (w[1].0 - w[0].0).hypot(w[1].1 - w[0].1))
+                .sum()
+        };
+
+        let small = arc_length(false);
+        let large = arc_length(true);
+        assert!(
+            large > small,
+            "large arc ({large}) should be longer than small ({small})"
+        );
+    }
+
+    #[test]
+    fn svg_arc_out_of_range_radii_are_scaled() {
+        // Endpoints 200 apart but radius only 10: F.6.6 must scale the radii up
+        // so the arc still reaches the endpoint exactly.
+        let start = (0.0, 0.0);
+        let end = (200.0, 0.0);
+
+        let mut path = Path::new();
+        path.move_to(start.0, start.1);
+        path.svg_arc_to(10.0, 10.0, 0.0, false, true, end.0, end.1);
+
+        let (points, endpoint) = sample_path(&path);
+        assert!((endpoint.0 - end.0).abs() < 1e-3);
+        assert!((endpoint.1 - end.1).abs() < 1e-3);
+
+        // With radii scaled to exactly span the chord, the arc is a half-circle of
+        // radius 100 centered at (100, 0); every sampled point must lie on it.
+        for (px, py) in points {
+            let r = ellipse_residual(px, py, 100.0, 0.0, 100.0, 100.0, 0.0);
+            assert!(
+                r.abs() < ELLIPSE_RESIDUAL_TOL,
+                "scaled-radii point ({px}, {py}) off circle, residual {r}"
+            );
+        }
+    }
+
+    #[test]
+    fn svg_arc_zero_radius_is_straight_line() {
+        let mut path = Path::new();
+        path.move_to(10.0, 20.0);
+        path.svg_arc_to(0.0, 40.0, 0.0, true, true, 80.0, 90.0);
+
+        let verbs: Vec<_> = path.verbs().collect();
+        // move_to + a single line_to, no bezier segments.
+        assert_eq!(verbs.len(), 2);
+        assert!(matches!(verbs[0], Verb::MoveTo(10.0, 20.0)));
+        assert!(matches!(verbs[1], Verb::LineTo(80.0, 90.0)));
+    }
+
+    #[test]
+    fn svg_arc_identical_endpoints_add_nothing() {
+        let mut path = Path::new();
+        path.move_to(30.0, 30.0);
+        let before = path.verbs().count();
+        path.svg_arc_to(50.0, 50.0, 0.0, true, true, 30.0, 30.0);
+        let after = path.verbs().count();
+        assert_eq!(before, after, "identical endpoints must not add any verbs");
+    }
+
+    #[test]
+    fn svg_arc_negative_radii_use_absolute_value() {
+        let rx = 70.0;
+        let ry = 45.0;
+        let start = (rx, 0.0);
+        let end = (0.0, ry);
+
+        // Negative radii must drop their sign (F.6.2), producing geometry
+        // identical to the equivalent positive-radii arc.
+        let mut neg = Path::new();
+        neg.move_to(start.0, start.1);
+        neg.svg_arc_to(-rx, -ry, 0.0, false, true, end.0, end.1);
+
+        let mut pos = Path::new();
+        pos.move_to(start.0, start.1);
+        pos.svg_arc_to(rx, ry, 0.0, false, true, end.0, end.1);
+
+        let (neg_pts, _) = sample_path(&neg);
+        let (pos_pts, _) = sample_path(&pos);
+        assert_eq!(neg_pts.len(), pos_pts.len());
+        for (n, p) in neg_pts.iter().zip(pos_pts.iter()) {
+            assert!((n.0 - p.0).abs() < 1e-5 && (n.1 - p.1).abs() < 1e-5);
+        }
+
+        // ...and that geometry lies on the origin-centered ellipse.
+        for (px, py) in pos_pts {
+            let r = ellipse_residual(px, py, 0.0, 0.0, rx, ry, 0.0);
+            assert!(
+                r.abs() < ELLIPSE_RESIDUAL_TOL,
+                "negative-radii point ({px}, {py}) off ellipse, residual {r}"
+            );
+        }
+    }
+
+    #[test]
+    fn svg_arc_on_empty_path_starts_at_origin() {
+        let mut path = Path::new();
+        path.svg_arc_to(50.0, 50.0, 0.0, false, true, 100.0, 0.0);
+
+        let verbs: Vec<_> = path.verbs().collect();
+        // An implicit move_to(0, 0) is inserted before the bezier segments.
+        assert!(matches!(verbs[0], Verb::MoveTo(0.0, 0.0)));
+        assert!(verbs.len() > 1);
+
+        let (_, endpoint) = sample_path(&path);
+        assert!((endpoint.0 - 100.0).abs() < 1e-3);
+        assert!((endpoint.1).abs() < 1e-3);
     }
 }

--- a/src/path.rs
+++ b/src/path.rs
@@ -440,6 +440,10 @@ impl Path {
     /// implementation notes (section F.6): identical start/end points omit the
     /// arc, a zero radius degrades to a straight line, negative radii use their
     /// absolute value, and radii too small to span the endpoints are scaled up.
+    // The seven parameters mirror the SVG path arc command `A rx ry
+    // x-axis-rotation large-arc-flag sweep-flag x y` one-to-one, so the count is
+    // fixed by the spec rather than a design choice.
+    #[allow(clippy::too_many_arguments)]
     pub fn svg_arc_to(&mut self, rx: f32, ry: f32, x_axis_rotation: f32, large_arc: bool, sweep: bool, x: f32, y: f32) {
         // The HTML Canvas path primitives (`ellipse()`, `arc()`, `arcTo()`)
         // return early without changing the path "if any of the arguments are

--- a/src/path.rs
+++ b/src/path.rs
@@ -1262,6 +1262,72 @@ mod tests {
         cx * my - cy * mx
     }
 
+    /// Total angle swept by `points` about the ellipse (cx, cy, rx, ry, phi),
+    /// measured in the ellipse's parametric angle and unwrapped increment by
+    /// increment. Consecutive samples along the emitted beziers are at most a
+    /// few degrees apart — far from the +-pi wrap-around — so the sum recovers
+    /// the true swept angle including direction and extra revolutions, which
+    /// on-ellipse residual checks are blind to.
+    fn swept_parametric_angle(points: &[(f64, f64)], cx: f64, cy: f64, rx: f64, ry: f64, phi: f64) -> f64 {
+        let (sin_phi, cos_phi) = phi.sin_cos();
+        let angle = |p: (f64, f64)| -> f64 {
+            let dx = p.0 - cx;
+            let dy = p.1 - cy;
+            let u = (cos_phi * dx + sin_phi * dy) / rx;
+            let v = (-sin_phi * dx + cos_phi * dy) / ry;
+            v.atan2(u)
+        };
+        let mut total = 0.0;
+        for pair in points.windows(2) {
+            let mut increment = angle(pair[1]) - angle(pair[0]);
+            if increment > std::f64::consts::PI {
+                increment -= 2.0 * std::f64::consts::PI;
+            } else if increment < -std::f64::consts::PI {
+                increment += 2.0 * std::f64::consts::PI;
+            }
+            total += increment;
+        }
+        total
+    }
+
+    #[test]
+    fn svg_arc_flags_select_sweep_angle_and_direction() {
+        // On the radius-50 circle the chord from (150, 100) to (100, 150)
+        // subtends 90 degrees: large_arc=false must sweep exactly a quarter
+        // turn and large_arc=true exactly three quarters, while the sweep flag
+        // picks the direction (F.6.5.6: sweep=true is the positive-angle
+        // direction). This pins down the swept angle itself, which endpoint
+        // and on-ellipse checks cannot: an arc that takes an extra full
+        // revolution or runs the long way in the wrong direction (e.g. a
+        // broken F.6.5.6 modulo adjustment) still keeps every sample on the
+        // ellipse and still lands exactly on the endpoint.
+        let start = (150.0, 100.0);
+        let end = (100.0, 150.0);
+        let r = 50.0;
+
+        for (large_arc, sweep) in [(false, false), (false, true), (true, false), (true, true)] {
+            let mut path = Path::new();
+            path.move_to(start.0, start.1);
+            path.svg_arc_to(r, r, 0.0, large_arc, sweep, end.0, end.1);
+
+            let (points, _) = sample_path(&path);
+            let points: Vec<(f64, f64)> = points.iter().map(|p| (f64::from(p.0), f64::from(p.1))).collect();
+            let (cx, cy, srx, sry) = svg_arc_center_f64(start, end, r, r, 0.0, large_arc, sweep);
+            let total = swept_parametric_angle(&points, cx, cy, srx, sry, 0.0);
+
+            let magnitude = if large_arc {
+                1.5 * std::f64::consts::PI
+            } else {
+                0.5 * std::f64::consts::PI
+            };
+            let expected = if sweep { magnitude } else { -magnitude };
+            assert!(
+                (total - expected).abs() < 0.02,
+                "large_arc={large_arc} sweep={sweep}: swept {total} rad, expected {expected}"
+            );
+        }
+    }
+
     #[test]
     fn svg_arc_flag_combinations_are_distinct() {
         let start = (100.0, 100.0);
@@ -1734,6 +1800,7 @@ mod tests {
                     let point_scale = cx.abs() + cy.abs() + srx + sry;
                     let min_radius = srx.min(sry);
                     let tolerance = 5e-3 + 8.0 * f64::from(f32::EPSILON) * point_scale / min_radius;
+                    let mut sampled = Vec::new();
                     for (p0, c1, c2, p3) in &segments {
                         for step in 0..=4 {
                             let s = f64::from(step) / 4.0;
@@ -1745,7 +1812,37 @@ mod tests {
                                 "sampled point ({px}, {py}) at s={s} off ground-truth ellipse \
                                  (residual {residual}, tolerance {tolerance}) for {case}"
                             );
+                            sampled.push((px, py));
                         }
+                    }
+
+                    // (e) the swept angle obeys the flags. On-ellipse
+                    // residuals and the exact endpoint are blind to an arc
+                    // that circles the wrong way around or takes an extra
+                    // full revolution (both stay on the ellipse and reach the
+                    // endpoint), so measure the sweep itself: never more than
+                    // a full turn, direction matching the sweep flag, and
+                    // magnitude relative to pi matching the large_arc flag
+                    // (F.6.5.6). Sweeps close to the boundaries are skipped:
+                    // near-zero or near-pi magnitudes cannot discriminate.
+                    let total = swept_parametric_angle(&sampled, cx, cy, srx, sry, f64::from(phi));
+                    assert!(
+                        total.abs() < 2.0 * std::f64::consts::PI + 0.1,
+                        "swept more than a full turn ({total} rad) for {case}"
+                    );
+                    if total.abs() > 0.05 {
+                        assert_eq!(
+                            total > 0.0,
+                            sweep,
+                            "sweep direction violated (swept {total} rad) for {case}"
+                        );
+                    }
+                    if (total.abs() - std::f64::consts::PI).abs() > 0.05 {
+                        assert_eq!(
+                            total.abs() > std::f64::consts::PI,
+                            large_arc,
+                            "large_arc magnitude violated (swept {total} rad) for {case}"
+                        );
                     }
                 }
             }

--- a/src/path.rs
+++ b/src/path.rs
@@ -532,15 +532,22 @@ impl Path {
         }
 
         // Split into segments of at most 90 degrees and emit cubic beziers.
-        let ndivs = (delta.abs() / (std::f64::consts::PI * 0.5)).ceil().max(1.0) as i32;
-        let seg = delta / f64::from(ndivs);
+        // The sweep never exceeds a full turn (|delta| <= 2*pi), so at most four
+        // 90-degree segments are ever emitted; the extra headroom only guards
+        // against floating-point spill past the exact quarter-turn boundaries.
+        const MAX_SEGMENTS: usize = 8;
+        let ndivs = ((delta.abs() / (std::f64::consts::PI * 0.5)).ceil() as usize).clamp(1, MAX_SEGMENTS);
+        let seg = delta / ndivs as f64;
         // Maisonobe per-segment handle length matching the kappa technique used
         // by arc()/ellipse(): alpha = sin(seg) * (sqrt(4 + 3 tan(seg/2)^2) - 1) / 3.
         let half = seg * 0.5;
         let alpha = seg.sin() * ((4.0 + 3.0 * half.tan() * half.tan()).sqrt() - 1.0) / 3.0;
 
-        let mut commands = Vec::with_capacity(ndivs as usize);
-        let mut coords = Vec::with_capacity(ndivs as usize * 3);
+        // The segment chain is staged on the stack: emission must stay
+        // transactional (the finite-output guard below inspects the whole chain
+        // before anything is appended to the path), and the bounded segment
+        // count makes that possible without a per-call heap allocation.
+        let mut coords = [Position { x: 0.0, y: 0.0 }; MAX_SEGMENTS * 3];
 
         // Point and derivative of the rotated ellipse at parametric angle t.
         let point = |t: f64| -> (f64, f64) {
@@ -563,7 +570,7 @@ impl Path {
         };
 
         for i in 0..ndivs {
-            let t1 = theta1 + seg * f64::from(i);
+            let t1 = theta1 + seg * i as f64;
             let t2 = t1 + seg;
             let p1 = point(t1);
             let p2 = point(t2);
@@ -572,14 +579,14 @@ impl Path {
             let c1 = (p1.0 + d1.0 * alpha, p1.1 + d1.1 * alpha);
             let c2 = (p2.0 - d2.0 * alpha, p2.1 - d2.1 * alpha);
 
-            commands.push(PackedVerb::BezierTo);
-            coords.extend_from_slice(&[to_position(c1), to_position(c2), to_position(p2)]);
+            coords[i * 3] = to_position(c1);
+            coords[i * 3 + 1] = to_position(c2);
+            coords[i * 3 + 2] = to_position(p2);
         }
+        let coords = &mut coords[..ndivs * 3];
 
         // Guarantee the path endpoint lands exactly on the requested point.
-        if let Some(last) = coords.last_mut() {
-            *last = end;
-        }
+        coords[ndivs * 3 - 1] = end;
 
         // Extreme (but finite) inputs can describe arc geometry that exceeds
         // f32 range even though both endpoints are representable (e.g. F.6.6
@@ -596,7 +603,7 @@ impl Path {
             return;
         }
 
-        self.append(&commands, &coords);
+        self.append(&[PackedVerb::BezierTo; MAX_SEGMENTS][..ndivs], coords);
     }
 
     /// Creates a new rectangle shaped sub-path.

--- a/src/path.rs
+++ b/src/path.rs
@@ -92,6 +92,18 @@ impl Verb {
 
 /// A collection of verbs (`move_to()`, `line_to()`, `bezier_to()`, etc.)
 /// describing one or more contours.
+///
+/// A `Path` is `Send` but intentionally not `Sync`: the interior tessellation
+/// cache uses a [`RefCell`], so sharing a `&Path` between threads is rejected
+/// at compile time. Move (or clone) a `Path` into each thread instead.
+///
+/// ```compile_fail
+/// let path = femtovg::Path::new();
+/// std::thread::scope(|scope| {
+///     // ERROR: `&Path` is not `Send` because `Path` is not `Sync`.
+///     scope.spawn(|| path.is_empty());
+/// });
+/// ```
 #[derive(Default, Clone, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Path {

--- a/src/path.rs
+++ b/src/path.rs
@@ -2079,4 +2079,215 @@ mod tests {
             );
         }
     }
+
+    /// Control points for a single-segment arc, from the web platform test
+    /// `svg/path/interfaces/getPathData-normalize.html`, which pins the
+    /// normalized output of `M 6 10 A 10 10 10 0 0 15 10` to within 0.0005.
+    ///
+    /// This is the tightest available oracle for the per-segment handle length:
+    /// the reference values follow from `4/3 * tan(sweep/4)`, the same kappa
+    /// `arc()` and `ellipse()` use, and a coarser handle length misses them by
+    /// several thousandths.
+    #[test]
+    fn svg_arc_control_points_match_the_web_platform_test() {
+        let mut path = Path::new();
+        path.move_to(6.0, 10.0);
+        path.svg_arc_to(10.0, 10.0, 10.0_f32.to_radians(), false, false, 15.0, 10.0);
+
+        let curves: Vec<_> = path
+            .verbs()
+            .filter_map(|verb| match verb {
+                Verb::BezierTo(a, b, c, d, e, f) => Some((a, b, c, d, e, f)),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(curves.len(), 1, "a 51 degree sweep is one segment");
+
+        let (c1x, c1y, c2x, c2y, ex, ey) = curves[0];
+        let expected = [8.8305, 11.4263, 12.1695, 11.4263, 15.0, 10.0];
+        for (actual, want) in [c1x, c1y, c2x, c2y, ex, ey].iter().zip(expected.iter()) {
+            assert!(
+                (actual - *want).abs() < 5e-4,
+                "control points {:?} should match the web platform test {expected:?}",
+                [c1x, c1y, c2x, c2y, ex, ey]
+            );
+        }
+    }
+
+    /// A quarter turn reduces to the circular kappa the other builders share:
+    /// the handles sit at `KAPPA90` along each tangent. Deriving the value
+    /// independently of the constant keeps this honest if `KAPPA90` ever moves.
+    #[test]
+    fn svg_arc_quarter_turn_uses_the_shared_kappa() {
+        let mut path = Path::new();
+        path.move_to(0.0, 0.0);
+        path.svg_arc_to(1.0, 1.0, 0.0, false, true, 1.0, 1.0);
+
+        let curve = path
+            .verbs()
+            .find_map(|verb| match verb {
+                Verb::BezierTo(a, b, c, d, e, f) => Some((a, b, c, d, e, f)),
+                _ => None,
+            })
+            .expect("one cubic");
+
+        let k = super::KAPPA90;
+        for (actual, want) in
+            [curve.0, curve.1, curve.2, curve.3, curve.4, curve.5]
+                .iter()
+                .zip([k, 0.0, 1.0, 1.0 - k, 1.0, 1.0])
+        {
+            assert!((actual - want).abs() < 1e-5, "quarter turn handles: got {curve:?}");
+        }
+    }
+
+    /// The same endpoints with only the sweep flag flipped must pick the other
+    /// centre, so the two arcs bow to opposite sides. This is the sign choice in
+    /// F.6.5.2, which a lost minus renders as a mirrored arc that still has the
+    /// right endpoints and so survives every endpoint-only assertion.
+    #[test]
+    fn svg_arc_sweep_flag_selects_the_other_centre() {
+        let mut sweep = Path::new();
+        sweep.move_to(0.0, 0.0);
+        sweep.svg_arc_to(1.0, 1.0, 0.0, false, true, 1.0, 1.0);
+
+        let mut against = Path::new();
+        against.move_to(0.0, 0.0);
+        against.svg_arc_to(1.0, 1.0, 0.0, false, false, 1.0, 1.0);
+
+        // Centre (0, 1) bows the arc right and down; centre (1, 0) bows it up.
+        for (px, py) in sample_path(&sweep).0 {
+            let resid = ellipse_residual(px, py, 0.0, 1.0, 1.0, 1.0, 0.0);
+            assert!(resid.abs() < ELLIPSE_RESIDUAL_TOL, "sweep arc off centre (0, 1)");
+        }
+        for (px, py) in sample_path(&against).0 {
+            let resid = ellipse_residual(px, py, 1.0, 0.0, 1.0, 1.0, 0.0);
+            assert!(
+                resid.abs() < ELLIPSE_RESIDUAL_TOL,
+                "counter-sweep arc off centre (1, 0)"
+            );
+        }
+    }
+
+    /// Radii too small to span the endpoints are scaled by exactly sqrt(lambda)
+    /// per F.6.6.2. Chosen so the arithmetic is exact: a unit circle asked to
+    /// span four units gives lambda = 4 and a scale of exactly 2, leaving a
+    /// half-circle of radius 2 centred midway.
+    #[test]
+    fn svg_arc_out_of_range_radii_scale_by_exactly_sqrt_lambda() {
+        let mut path = Path::new();
+        path.move_to(0.0, 0.0);
+        path.svg_arc_to(1.0, 1.0, 0.0, false, false, 4.0, 0.0);
+
+        let (points, endpoint) = sample_path(&path);
+        assert!((endpoint.0 - 4.0).abs() < 1e-4 && endpoint.1.abs() < 1e-4);
+        for (px, py) in points {
+            let resid = ellipse_residual(px, py, 2.0, 0.0, 2.0, 2.0, 0.0);
+            assert!(
+                resid.abs() < ELLIPSE_RESIDUAL_TOL,
+                "point ({px}, {py}) should lie on the radius-2 circle that sqrt(lambda) = 2 produces"
+            );
+        }
+    }
+
+    /// Lambda has to be computed from the endpoint offset *after* rotating it
+    /// into the ellipse's own axes. Taking it from the unrotated offset is a
+    /// silent bug: the arc still joins its endpoints, just through radii around
+    /// a quarter too small. Here the correct scale is 4.0697 and the unrotated
+    /// one would be 3.1623.
+    #[test]
+    fn svg_arc_lambda_is_measured_in_the_rotated_frame() {
+        let mut path = Path::new();
+        path.move_to(0.0, 0.0);
+        path.svg_arc_to(10.0, 40.0, 90.0_f32.to_radians(), false, true, 60.0, 80.0);
+
+        let scale = 4.069_705_1_f32;
+        for (px, py) in sample_path(&path).0 {
+            let resid = ellipse_residual(px, py, 30.0, 40.0, 10.0 * scale, 40.0 * scale, 90.0_f32.to_radians());
+            assert!(
+                resid.abs() < ELLIPSE_RESIDUAL_TOL,
+                "point ({px}, {py}) off the ellipse that the rotated-frame lambda gives"
+            );
+        }
+    }
+
+    /// Two half turns must close a circle exactly, the construction an SVG uses
+    /// when it has no circle element to hand. From Gecko's
+    /// `layout/reftests/svg/path-05.svg` (bug 657862), which paints this over a
+    /// radius-79 disc and under a radius-81 one and demands neither shows.
+    #[test]
+    fn svg_arc_two_half_turns_close_a_circle() {
+        let mut path = Path::new();
+        path.move_to(20.0, 100.0);
+        path.svg_arc_to(80.0, 80.0, 0.0, false, true, 180.0, 100.0);
+        path.svg_arc_to(80.0, 80.0, 0.0, false, true, 20.0, 100.0);
+
+        let (points, endpoint) = sample_path(&path);
+        assert!(
+            (endpoint.0 - 20.0).abs() < 1e-3 && (endpoint.1 - 100.0).abs() < 1e-3,
+            "the second half turn must return to the start, got {endpoint:?}"
+        );
+        for (px, py) in points {
+            let resid = ellipse_residual(px, py, 100.0, 100.0, 80.0, 80.0, 0.0);
+            assert!(
+                resid.abs() < ELLIPSE_RESIDUAL_TOL,
+                "point ({px}, {py}) off the radius-80 circle, residual {resid}"
+            );
+        }
+    }
+
+    /// Radii large enough that the sweep underflows must not throw the geometry
+    /// across the canvas. From Gecko bug 1988564, whose reduced case is
+    /// `a56270558080367.86,56270558080367.86,0,0,1,-1.2,1.4`; before the fix
+    /// Firefox put the endpoint at x = -171085 instead of 77.2, and its reftest
+    /// `bad-arc.html` expects nothing visible at all.
+    #[test]
+    fn svg_arc_radii_far_larger_than_the_chord_stay_put() {
+        let mut path = Path::new();
+        path.move_to(78.4, 207.2);
+        path.svg_arc_to(
+            56_270_558_080_367.86,
+            56_270_558_080_367.86,
+            0.0,
+            false,
+            true,
+            77.2,
+            208.6,
+        );
+
+        let (points, endpoint) = sample_path(&path);
+        assert!(
+            (endpoint.0 - 77.2).abs() < 1e-2 && (endpoint.1 - 208.6).abs() < 1e-2,
+            "endpoint {endpoint:?} should stay at the requested point"
+        );
+        for (px, py) in points {
+            assert!(px.is_finite() && py.is_finite(), "non-finite point ({px}, {py})");
+            // The chord is under 2 units long; nothing may wander far from it.
+            assert!(
+                (77.0..=79.0).contains(&px) && (207.0..=209.0).contains(&py),
+                "point ({px}, {py}) left the neighbourhood of a 1.8 unit chord"
+            );
+        }
+    }
+
+    /// The first arc of the SVG 1.1 specification's own `arcs01.svg`. Its radii
+    /// need the F.6.6.2 correction, and afterwards the term under the root in
+    /// F.6.5.2 lands a hair below zero in exact arithmetic, so an implementation
+    /// that does not clamp it emits NaN for the whole shape.
+    #[test]
+    fn svg_arc_spec_example_with_a_negative_radicand_stays_finite() {
+        let mut path = Path::new();
+        path.move_to(650.0, 325.0);
+        path.svg_arc_to(25.0, 25.0, -30.0_f32.to_radians(), false, true, 700.0, 300.0);
+
+        let (points, endpoint) = sample_path(&path);
+        assert!(!points.is_empty(), "the arc must emit geometry");
+        assert!(
+            (endpoint.0 - 700.0).abs() < 1e-2 && (endpoint.1 - 300.0).abs() < 1e-2,
+            "endpoint {endpoint:?} should reach (700, 300)"
+        );
+        for (px, py) in points {
+            assert!(px.is_finite() && py.is_finite(), "non-finite point ({px}, {py})");
+        }
+    }
 }

--- a/src/path.rs
+++ b/src/path.rs
@@ -542,10 +542,14 @@ impl Path {
         const MAX_SEGMENTS: usize = 8;
         let ndivs = ((delta.abs() / (std::f64::consts::PI * 0.5)).ceil() as usize).clamp(1, MAX_SEGMENTS);
         let seg = delta / ndivs as f64;
-        // Maisonobe per-segment handle length matching the kappa technique used
-        // by arc()/ellipse(): alpha = sin(seg) * (sqrt(4 + 3 tan(seg/2)^2) - 1) / 3.
-        let half = seg * 0.5;
-        let alpha = seg.sin() * ((4.0 + 3.0 * half.tan() * half.tan()).sqrt() - 1.0) / 3.0;
+        // Per-segment handle length: the same kappa `arc()` and `ellipse()` use,
+        // 4/3 * tan(seg/4), which puts the curve through the midpoint of its own
+        // segment. `arc()` spells it 4/3 * (1 - cos(seg/2)) / sin(seg/2), the
+        // same value by the half-angle identity; the tangent form is used here
+        // because it carries the sign of `seg`, so a negative sweep gets a handle
+        // pointing back along the derivative without a separate branch. At a
+        // quarter turn it is the KAPPA90 the other primitives are built from.
+        let alpha = 4.0 / 3.0 * (seg * 0.25).tan();
 
         // The segment chain is staged on the stack: emission must stay
         // transactional (the finite-output guard below inspects the whole chain
@@ -1235,12 +1239,13 @@ mod tests {
     /// Implicit-form residual of a rotated ellipse for the point (px, py): zero
     /// when the point lies exactly on the ellipse boundary.
     ///
-    /// Cubic beziers only approximate an elliptical arc; with the per-segment
-    /// (Maisonobe) handle length used here a full 90-degree segment deviates from
-    /// the true ellipse by at most ~4e-3 in this residual (≈0.12px on a 60px
-    /// radius), matching the accuracy of the existing `arc()`/`ellipse()`
-    /// builders. Tests allow a little headroom over that worst case.
-    const ELLIPSE_RESIDUAL_TOL: f32 = 5e-3;
+    /// Cubic beziers only approximate an elliptical arc; with the 4/3*tan(seg/4)
+    /// handle length shared with `arc()`/`ellipse()`, a full 90-degree segment
+    /// deviates from the true ellipse by at most ~5.5e-4 in this residual
+    /// (≈0.017px on a 60px radius). Tests allow a little headroom over that worst
+    /// case, but stay well inside the ~4e-3 a coarser handle length would give,
+    /// so the tolerance keeps pinning the handle length and not just the sweep.
+    const ELLIPSE_RESIDUAL_TOL: f32 = 1e-3;
 
     fn ellipse_residual(px: f32, py: f32, cx: f32, cy: f32, rx: f32, ry: f32, phi: f32) -> f32 {
         let (sin_phi, cos_phi) = phi.sin_cos();
@@ -1866,13 +1871,14 @@ mod tests {
                         !segments.is_empty(),
                         "well-conditioned arc must emit bezier segments for {case}"
                     );
-                    // Base tolerance matches ELLIPSE_RESIDUAL_TOL (Maisonobe
-                    // segment error); the second term covers f32 quantization
-                    // of coordinates of magnitude ~point_scale amplified by
-                    // the implicit-form gradient (~1/min_radius).
+                    // Base tolerance matches ELLIPSE_RESIDUAL_TOL (the worst-case
+                    // per-segment handle error); the second term covers f32
+                    // quantization of coordinates of magnitude ~point_scale
+                    // amplified by the implicit-form gradient (~1/min_radius).
                     let point_scale = cx.abs() + cy.abs() + srx + sry;
                     let min_radius = srx.min(sry);
-                    let tolerance = 5e-3 + 8.0 * f64::from(f32::EPSILON) * point_scale / min_radius;
+                    let tolerance =
+                        f64::from(ELLIPSE_RESIDUAL_TOL) + 8.0 * f64::from(f32::EPSILON) * point_scale / min_radius;
                     let mut sampled = Vec::new();
                     for (p0, c1, c2, p3) in &segments {
                         for step in 0..=4 {


### PR DESCRIPTION
Adds `Path::svg_arc_to(rx, ry, x_axis_rotation, large_arc, sweep, x, y)` — the endpoint parameterization of the SVG path `A` command — emitting cubic béziers through the existing tessellation pipeline. Pure path-building code: no shader/uniform surface, no new dependencies.

Previously `arc()`/`arc_to()` were circular-only, so consumers of SVG path data (or Canvas `Path2D` arcs) had to re-derive the endpoint→center conversion themselves.

Implements W3C SVG 1.1 §F.6: endpoint→center conversion (F.6.5), out-of-range radii correction (F.6.6), the degenerate rules (F.6.2), and the F.6.5.4 sign convention at the 180° boundary (a zero cross product takes the positive angle). Non-finite arguments are rejected with an early return, matching the Canvas rule for path methods. The center parameterization is computed in f64 (as in resvg/kurbo/Batik): fuzzing found two f32 overflow cases — spec-valid tiny radii (F.6.6 scale-up of rx=ry=1e-30 across a 100-unit chord) and huge endpoint coordinates (±1e30) — that emitted NaN control points; both are fixed and kept as regression tests, with a finite-output chord fallback for geometry unrepresentable even in f64.

### Validation
- **Pixel comparison vs Chrome Canary** (`Path2D('A 100 60 30 1 0 …')`, headless, dpr=1) plus a 12-case sweep over all large-arc/sweep combinations, rotated and flat ellipses, radius scaling, semicircles, and negative rotation: zero true coverage-gap pixels; only stroke-AA fringe differs.

  ![arc comparison](https://raw.githubusercontent.com/rebeckerspecialties/femtovg/pixel-comparisons/comparisons/arc.png)

- **Deterministic property fuzz**: 20,000 seeded iterations (coords ±1e4, radii 0–2e3, rotations ±10 rad, all flags, with extreme-magnitude injections) asserting no panics, finite output, endpoint reached, sampled points on the rotated ellipse, and sweep direction/magnitude consistent with the flags. Runs in ~0.06 s as a normal unit test.
- **Mutation pass**: 7 hand-applied mutations of the F.6 math (sign rule, radius scaling, rotation, sweep-modulo, kappa handles, angle sign, rx/ry swap) — all killed by the committed test suite. The one initial survivor (swapped sweep-modulo, which stays on the correct ellipse but sweeps the complementary direction with an extra revolution) is now killed by a parametric-angle-unwrapping test covering all four flag combinations.
- **Cross-surface isolation**: tests cover one `Path` shared by two canvases with different transforms (interleaved, byte-identical per-canvas output), render-target interleaving (Image/Screen), and multi-threaded per-thread usage; a `compile_fail` doctest documents that `Path` is intentionally `!Sync`.

### Checks
- `cargo fmt --check`
- `cargo build` / `cargo build --features wgpu`
- `cargo test --features "wgpu textlayout"` (77 tests)

Rebased onto current master (which now contains #285 / #292 / #294); this PR is `src/path.rs` + tests only, no overlap with those. Ready for review.

