### PR TITLE
Expose subscript, superscript and typographic font metrics

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,7 @@ textlayout = ["dep:rustybuzz", "dep:unicode-bidi", "dep:unicode-segmentation", "
 swash = ["dep:swash"]
 
 [dev-dependencies]
+serde_json = "1.0"
 winit = { version = "0.30.12" }
 euclid = "0.22.3"
 rand = "0.10"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,6 +60,7 @@ use geometry::*;
 
 mod paint;
 pub use paint::Paint;
+pub use paint::TextDecoration;
 use paint::{GlyphTexture, PaintFlavor, StrokeSettings};
 
 mod path;
@@ -1923,27 +1924,55 @@ where
             text::normalize_variations(&text_context, &paint.text.font_ids, &paint.text.font_variations)
         };
 
+        // Captured in scaled shaping space; decorations hang off it below.
+        let baseline_scaled = run_baseline(&layout.glyphs);
+
         // Draw the drop shadow (if any) under the text. The shaped layout gives a
         // user-space box; transform its corners by the CTM to obtain device-space
         // bounds and let render_shadow re-enter draw_text with the shadow tint.
-        // (render_shadow disables shadows in the state so this does not recurse.)
+        // The re-entered draw_text draws glyphs *and* decoration lines (with
+        // shadows suppressed), so a single shadow covers the whole painting
+        // operation, matching the drawing model — decorations are not shadowed
+        // separately. (render_shadow disables shadows in the state so this does
+        // not recurse.)
         if self.shadow_enabled() {
             // Layout metrics are in the scaled shaping space; bring them back to
-            // user space. The horizontal extent is derived from the union of the
-            // glyph boxes rather than the advance-summed layout width: negative
-            // letter spacing can collapse the summed width to zero while ink is
-            // still painted, and the shadow must cover everything that is drawn.
-            // Expand by the line height on all sides so bearings, overhang,
-            // ascenders, descenders and diacritics are fully covered.
+            // user space. The horizontal extent unions the glyph ink boxes with
+            // the run's advance box (layout.x .. layout.x + width): negative letter
+            // spacing can collapse the advance width while ink is still painted,
+            // yet the decoration lines are drawn across that advance box, so the
+            // shadow must cover both.
             let (mut gx0, mut gx1) = (f32::INFINITY, f32::NEG_INFINITY);
             for glyph in &layout.glyphs {
                 gx0 = gx0.min(glyph.x);
                 gx1 = gx1.max(glyph.x + glyph.width);
             }
-            let ly = layout.y * invscale;
-            let lh = layout.height() * invscale;
             let (ux0, uy0, ux1, uy1) = if gx0 <= gx1 {
-                (gx0 * invscale - lh, ly - lh, gx1 * invscale + lh, ly + lh + lh)
+                let rx0 = layout.x.min(layout.x + layout.width());
+                let rx1 = layout.x.max(layout.x + layout.width());
+                let x0 = (gx0 * invscale).min(rx0 * invscale);
+                let x1 = (gx1 * invscale).max(rx1 * invscale);
+                // The vertical extent is the font's line box (baseline - ascent ..
+                // baseline - descent), not the glyph ink box: the overline sits at
+                // the ascent and the underline below the baseline, so an ink-box
+                // extent clips the decoration shadows of short (x-height-only)
+                // runs like "www". Deriving it from the metrics covers glyphs,
+                // decorations, ascenders, descenders and diacritics alike.
+                let baseline = baseline_scaled.map_or(layout.y * invscale, |b| b * invscale);
+                let (ascent, descent) = {
+                    let text_context = self.text_context.borrow();
+                    text_context
+                        .measure_font(paint.text.font_size, &paint.text.font_ids, &paint.text.font_variations)
+                        .map_or((0.0, 0.0), |m| (m.ascender(), m.descender()))
+                };
+                // A little slack for the overline nudge and antialiased edges.
+                let margin = paint.text.font_size * 0.2;
+                (
+                    x0 - margin,
+                    baseline - ascent - margin,
+                    x1 + margin,
+                    baseline - descent + margin,
+                )
             } else {
                 // No drawable glyphs: nothing painted, nothing to shadow.
                 (0.0, 0.0, 0.0, 0.0)
@@ -2004,12 +2033,84 @@ where
             }
         }
 
+        layout.scale(invscale);
+
+        // Text decorations are an SVG/CSS extension (Canvas 2D has none). They are
+        // emitted as plain filled rectangles in user space — the same coordinate
+        // space as the `* invscale` glyph positions handed to `draw_glyph_run` —
+        // so `fill_path` runs them through the identical canvas transform the
+        // glyph runs use. That keeps the lines aligned with the glyphs across the
+        // direct-outline, atlas, and scale-baked-atlas paths alike.
+        //
+        // They are drawn while shadows are still suppressed: the run-level shadow
+        // pass above already rendered the decorations into its coverage (it
+        // re-enters draw_text, which draws them), so glyphs and decorations share
+        // a single shadow and the lines must not cast a second one.
+        if glyph_run_result.is_ok() && !paint.text.text_decoration.is_none() {
+            if let Some(baseline_scaled) = baseline_scaled {
+                self.draw_text_decorations(paint, baseline_scaled * invscale, layout.x, layout.width());
+            }
+        }
+
+        // Restore the shadow state on the success and error paths alike.
         self.state_mut().shadow_color = saved_shadow_color;
         glyph_run_result?;
 
-        layout.scale(invscale);
-
         Ok(layout)
+    }
+
+    /// Emits the enabled text-decoration lines for a run as filled rectangles in
+    /// user space. `baseline` is the run baseline (user space, +y down), `x` the
+    /// run's left edge, and `width` its advance width.
+    #[cfg(feature = "textlayout")]
+    fn draw_text_decorations(&mut self, paint: &Paint, baseline: f32, x: f32, width: f32) {
+        let decoration = paint.text.text_decoration;
+
+        // Metrics in user-space units (scaled for the unscaled font size) so the
+        // offsets match the user-space baseline. `measure_font` reads the primary
+        // font with the same variations the run was shaped with.
+        let metrics = {
+            let text_context = self.text_context.borrow();
+            text_context.measure_font(paint.text.font_size, &paint.text.font_ids, &paint.text.font_variations)
+        };
+        let Ok(metrics) = metrics else {
+            return;
+        };
+
+        // The decoration takes the text paint's color, matching SVG where the
+        // decoration uses the text fill. The full paint flavor (gradient/image)
+        // is reused as-is so a gradient-filled run gets a gradient-filled line.
+        let line_paint = paint.clone();
+
+        let emit = |this: &mut Self, center_y: f32, thickness: f32| {
+            let thickness = thickness.max(1.0);
+            let mut path = Path::new();
+            path.rect(x, center_y - thickness / 2.0, width, thickness);
+            this.fill_path(&path, &line_paint);
+        };
+
+        // OpenType position values measure from the baseline with +y pointing up,
+        // while canvas y grows downward, so a line's center is `baseline - pos`.
+        if decoration.underline {
+            emit(
+                self,
+                baseline - metrics.underline_position(),
+                metrics.underline_thickness(),
+            );
+        }
+        if decoration.strikethrough {
+            emit(
+                self,
+                baseline - metrics.strikeout_position(),
+                metrics.strikeout_thickness(),
+            );
+        }
+        if decoration.overline {
+            // No dedicated metric; sit the line at the ascent with the underline
+            // thickness, nudged up by half its thickness so it clears the glyphs.
+            let thickness = metrics.underline_thickness().max(1.0);
+            emit(self, baseline - metrics.ascender() - thickness / 2.0, thickness);
+        }
     }
 
     fn draw_glyph_run(
@@ -2346,6 +2447,8 @@ pub use rgb;
 pub struct RecordingRenderer {
     /// Vector of the last commands submitted to the renderer.
     pub last_commands: Rc<RefCell<Vec<renderer::Command>>>,
+    /// Vertex buffer that accompanied the last submitted commands.
+    pub last_verts: Rc<RefCell<Vec<renderer::Vertex>>>,
 }
 
 #[cfg(test)]
@@ -2362,10 +2465,11 @@ impl Renderer for RecordingRenderer {
         &mut self,
         _output: impl Into<Self::RenderOutput>,
         _images: &mut ImageStore<Self::Image>,
-        _verts: &[renderer::Vertex],
+        verts: &[renderer::Vertex],
         commands: Vec<renderer::Command>,
     ) {
         *self.last_commands.borrow_mut() = commands;
+        *self.last_verts.borrow_mut() = verts.to_vec();
     }
 
     fn alloc_image(&mut self, info: crate::ImageInfo) -> Result<Self::Image, ErrorKind> {
@@ -3128,5 +3232,350 @@ fn outline_text_shadow_pass_count_is_glyph_count_invariant() {
         single, many,
         "shadow passes must not scale with glyph count: outline glyphs would each cast \
          their own shadow on top of the run-level one"
+    );
+}
+/// Collects the screen-space filled rectangles that text decoration emits.
+///
+/// A decoration line is a solid `ConvexFill` drawn to the screen with no glyph
+/// texture. (Atlas glyph rasterization also emits `ConvexFill`s, but those run
+/// while the render target is the atlas image, so tracking the active target
+/// discriminates them.) Returns the vertical `[min_y, max_y]` span of each such
+/// fill, in screen space.
+#[cfg(all(test, feature = "textlayout"))]
+fn recorded_decoration_spans(commands: &[renderer::Command], verts: &[renderer::Vertex]) -> Vec<(f32, f32)> {
+    use crate::paint::GlyphTexture;
+    use renderer::{CommandType, RenderTarget};
+
+    let mut target = RenderTarget::Screen;
+    let mut spans = Vec::new();
+
+    for cmd in commands {
+        match &cmd.cmd_type {
+            CommandType::SetRenderTarget(new_target) => target = *new_target,
+            CommandType::ConvexFill { .. }
+                if target == RenderTarget::Screen && matches!(cmd.glyph_texture, GlyphTexture::None) =>
+            {
+                let mut min_y = f32::INFINITY;
+                let mut max_y = f32::NEG_INFINITY;
+                for drawable in &cmd.drawables {
+                    if let Some((offset, len)) = drawable.fill_verts {
+                        for v in &verts[offset..offset + len] {
+                            min_y = min_y.min(v.y);
+                            max_y = max_y.max(v.y);
+                        }
+                    }
+                }
+                if min_y.is_finite() {
+                    spans.push((min_y, max_y));
+                }
+            }
+            _ => {}
+        }
+    }
+
+    spans
+}
+
+/// With a decoration enabled, `fill_text` emits exactly one extra solid rect per
+/// enabled line, positioned from the font's own metrics: underline below the
+/// baseline, strikethrough above it (through the text), overline near the ascent.
+/// With no decoration, no such rect is emitted.
+#[cfg(feature = "textlayout")]
+#[test]
+fn fill_text_emits_decoration_rects() {
+    let make_canvas = || {
+        let renderer = RecordingRenderer::default();
+        let commands = renderer.last_commands.clone();
+        let verts = renderer.last_verts.clone();
+        let mut canvas = Canvas::new(renderer).unwrap();
+        canvas.set_size(1000, 1000, 1.0);
+        let font = canvas
+            .add_font_mem(include_bytes!("../examples/assets/RobotoFlex-VariableFont.ttf"))
+            .expect("failed to load test font");
+        (canvas, commands, verts, font)
+    };
+
+    // Baseline::Alphabetic places the baseline exactly at the draw y, so the
+    // metric offsets are easy to reason about. A pure-translation transform keeps
+    // text on the cached-atlas path.
+    let baseline_y = 200.0_f32;
+
+    // Reference metrics for this font/size, in user space.
+    let metrics = {
+        let (canvas, _, _, font) = make_canvas();
+        let paint = Paint::color(Color::black()).with_font(&[font]).with_font_size(40.0);
+        canvas.measure_font(&paint).expect("metrics")
+    };
+    assert!(metrics.underline_thickness() > 0.0);
+    assert!(metrics.strikeout_thickness() > 0.0);
+
+    let base_paint = || {
+        Paint::color(Color::black())
+            .with_font_size(40.0)
+            .with_text_baseline(Baseline::Alphabetic)
+    };
+
+    // No decoration: no screen-space solid rects at all.
+    {
+        let (mut canvas, commands, verts, font) = make_canvas();
+        canvas
+            .fill_text(50.0, baseline_y, "Hello", &base_paint().with_font(&[font]))
+            .unwrap();
+        canvas.flush_to_output(());
+        let spans = recorded_decoration_spans(&commands.borrow(), &verts.borrow());
+        assert!(spans.is_empty(), "expected no decoration rect, got {spans:?}");
+    }
+
+    // Underline: one rect, centered below the baseline at -underline_position.
+    {
+        let (mut canvas, commands, verts, font) = make_canvas();
+        let paint = base_paint()
+            .with_font(&[font])
+            .with_text_decoration_lines(true, false, false);
+        canvas.fill_text(50.0, baseline_y, "Hello", &paint).unwrap();
+        canvas.flush_to_output(());
+        let spans = recorded_decoration_spans(&commands.borrow(), &verts.borrow());
+        assert_eq!(spans.len(), 1, "expected exactly one underline rect, got {spans:?}");
+        let (min_y, max_y) = spans[0];
+        let center = (min_y + max_y) / 2.0;
+        let expected = baseline_y - metrics.underline_position();
+        assert!(center > baseline_y, "underline should sit below the baseline");
+        assert!(
+            (center - expected).abs() <= 1.0,
+            "underline center {center} should be near {expected}"
+        );
+        assert!(
+            (max_y - min_y - metrics.underline_thickness()).abs() <= 1.0,
+            "underline thickness {} should be near {}",
+            max_y - min_y,
+            metrics.underline_thickness()
+        );
+    }
+
+    // Strikethrough: one rect, above the baseline at -strikeout_position.
+    {
+        let (mut canvas, commands, verts, font) = make_canvas();
+        let paint = base_paint()
+            .with_font(&[font])
+            .with_text_decoration_lines(false, true, false);
+        canvas.fill_text(50.0, baseline_y, "Hello", &paint).unwrap();
+        canvas.flush_to_output(());
+        let spans = recorded_decoration_spans(&commands.borrow(), &verts.borrow());
+        assert_eq!(spans.len(), 1, "expected exactly one strikethrough rect, got {spans:?}");
+        let (min_y, max_y) = spans[0];
+        let center = (min_y + max_y) / 2.0;
+        let expected = baseline_y - metrics.strikeout_position();
+        assert!(center < baseline_y, "strikethrough should sit above the baseline");
+        assert!(
+            (center - expected).abs() <= 1.0,
+            "strikethrough center {center} should be near {expected}"
+        );
+    }
+
+    // Overline: one rect, above the ascent.
+    {
+        let (mut canvas, commands, verts, font) = make_canvas();
+        let paint = base_paint()
+            .with_font(&[font])
+            .with_text_decoration_lines(false, false, true);
+        canvas.fill_text(50.0, baseline_y, "Hello", &paint).unwrap();
+        canvas.flush_to_output(());
+        let spans = recorded_decoration_spans(&commands.borrow(), &verts.borrow());
+        assert_eq!(spans.len(), 1, "expected exactly one overline rect, got {spans:?}");
+        let (_, max_y) = spans[0];
+        assert!(
+            max_y <= baseline_y - metrics.ascender() + 1.0,
+            "overline (bottom {max_y}) should sit at/above the ascent {}",
+            baseline_y - metrics.ascender()
+        );
+    }
+
+    // All three at once: three distinct rects.
+    {
+        let (mut canvas, commands, verts, font) = make_canvas();
+        let paint = base_paint()
+            .with_font(&[font])
+            .with_text_decoration_lines(true, true, true);
+        canvas.fill_text(50.0, baseline_y, "Hello", &paint).unwrap();
+        canvas.flush_to_output(());
+        let spans = recorded_decoration_spans(&commands.borrow(), &verts.borrow());
+        assert_eq!(spans.len(), 3, "expected three decoration rects, got {spans:?}");
+    }
+}
+
+/// Under a uniform-scale (scale-baked atlas) transform, the decoration rect must
+/// still line up with the glyphs: it is emitted in user space and run through the
+/// same canvas transform, so its screen-space center scales with the baseline.
+#[cfg(feature = "textlayout")]
+#[test]
+fn decoration_rect_tracks_scaled_atlas_transform() {
+    let renderer = RecordingRenderer::default();
+    let commands = renderer.last_commands.clone();
+    let verts = renderer.last_verts.clone();
+    let mut canvas = Canvas::new(renderer).unwrap();
+    canvas.set_size(2000, 2000, 1.0);
+    let font = canvas
+        .add_font_mem(include_bytes!("../examples/assets/RobotoFlex-VariableFont.ttf"))
+        .expect("failed to load test font");
+
+    let baseline_y = 150.0_f32;
+    let scale = 2.0_f32;
+
+    let metrics = {
+        let paint = Paint::color(Color::black()).with_font(&[font]).with_font_size(24.0);
+        canvas.measure_font(&paint).expect("metrics")
+    };
+
+    let paint = Paint::color(Color::black())
+        .with_font(&[font])
+        .with_font_size(24.0)
+        .with_text_baseline(Baseline::Alphabetic)
+        .with_text_decoration_lines(true, false, false);
+
+    canvas.scale(scale, scale);
+    canvas.fill_text(40.0, baseline_y, "Scaled", &paint).unwrap();
+    canvas.flush_to_output(());
+
+    let spans = recorded_decoration_spans(&commands.borrow(), &verts.borrow());
+    assert_eq!(spans.len(), 1, "expected one underline rect, got {spans:?}");
+    let (min_y, max_y) = spans[0];
+    let center = (min_y + max_y) / 2.0;
+    // User-space underline center is baseline - underline_position; on screen the
+    // whole thing is multiplied by the canvas scale.
+    let expected = (baseline_y - metrics.underline_position()) * scale;
+    assert!(
+        (center - expected).abs() <= 2.0,
+        "scaled underline center {center} should be near {expected}"
+    );
+}
+
+/// Rebuilds a sfnt/TrueType font byte buffer with the named 4-byte tables
+/// removed, so the fallback metric paths can be exercised on real assets.
+#[cfg(all(test, feature = "textlayout"))]
+fn font_without_tables(data: &[u8], drop_tags: &[&[u8; 4]]) -> Vec<u8> {
+    let read_u16 = |buf: &[u8], at: usize| u16::from_be_bytes([buf[at], buf[at + 1]]);
+    let read_u32 =
+        |buf: &[u8], at: usize| u32::from_be_bytes([buf[at], buf[at + 1], buf[at + 2], buf[at + 3]]) as usize;
+
+    let num_tables = read_u16(data, 4) as usize;
+
+    // Collect (tag, offset, length) for the tables we keep, in directory order.
+    let mut kept: Vec<([u8; 4], usize, usize)> = Vec::new();
+    for i in 0..num_tables {
+        let rec = 12 + i * 16;
+        let tag = [data[rec], data[rec + 1], data[rec + 2], data[rec + 3]];
+        if drop_tags.iter().any(|d| **d == tag) {
+            continue;
+        }
+        let offset = read_u32(data, rec + 8);
+        let length = read_u32(data, rec + 12);
+        kept.push((tag, offset, length));
+    }
+
+    let new_num = kept.len();
+    let mut out = Vec::new();
+    // Offset table header: keep the original sfnt version, fix up the table count
+    // and the binary-search hint fields for the new count.
+    out.extend_from_slice(&data[0..4]);
+    out.extend_from_slice(&(new_num as u16).to_be_bytes());
+    let max_pow2: u16 = 1 << (15 - (new_num.max(1) as u16).leading_zeros());
+    out.extend_from_slice(&(max_pow2 * 16).to_be_bytes());
+    out.extend_from_slice(&(15 - max_pow2.leading_zeros() as u16).to_be_bytes());
+    out.extend_from_slice(&((new_num as u16 * 16).wrapping_sub(max_pow2 * 16)).to_be_bytes());
+
+    let mut data_offset = 12 + new_num * 16;
+    let mut records = Vec::new();
+    let mut blobs = Vec::new();
+    for (tag, offset, length) in kept {
+        let padded = (length + 3) & !3;
+        let mut blob = data[offset..offset + length].to_vec();
+        blob.resize(padded, 0);
+        let mut rec = Vec::new();
+        rec.extend_from_slice(&tag);
+        rec.extend_from_slice(&0u32.to_be_bytes()); // checksum (ignored by ttf-parser)
+        rec.extend_from_slice(&(data_offset as u32).to_be_bytes());
+        rec.extend_from_slice(&(length as u32).to_be_bytes());
+        records.push(rec);
+        blobs.push(blob);
+        data_offset += padded;
+    }
+    for rec in records {
+        out.extend_from_slice(&rec);
+    }
+    for blob in blobs {
+        out.extend_from_slice(&blob);
+    }
+    out
+}
+
+/// A font without an OS/2 table (so no strikeout metric) and without a post
+/// table (so no underline metric) must still yield sensible, finite, positive
+/// decoration metrics via the ascender/descender-derived fallbacks — and never
+/// panic when drawing.
+#[cfg(feature = "textlayout")]
+#[test]
+fn decoration_metrics_fall_back_without_os2_and_post() {
+    let original = include_bytes!("../examples/assets/amiri-regular.ttf");
+
+    // Sanity: ttf-parser sees no strikeout/underline once the tables are gone.
+    let stripped = font_without_tables(original, &[b"OS/2", b"post"]);
+    let face = ttf_parser::Face::parse(&stripped, 0).expect("stripped font should still parse");
+    assert!(
+        face.strikeout_metrics().is_none(),
+        "OS/2 strikeout should be absent after stripping"
+    );
+    assert!(
+        face.underline_metrics().is_none(),
+        "post underline should be absent after stripping"
+    );
+
+    let text_context = TextContext::default();
+    let font_id = text_context.add_font_mem(&stripped).expect("stripped font should load");
+    let paint = Paint::default().with_font(&[font_id]).with_font_size(20.0);
+
+    let metrics = text_context.measure_font(&paint).expect("metrics");
+
+    assert!(
+        metrics.strikeout_thickness() > 0.0 && metrics.strikeout_thickness().is_finite(),
+        "fallback strikeout thickness must be positive and finite, got {}",
+        metrics.strikeout_thickness()
+    );
+    assert!(
+        metrics.strikeout_position() > 0.0 && metrics.strikeout_position().is_finite(),
+        "fallback strikeout should sit above the baseline, got {}",
+        metrics.strikeout_position()
+    );
+    assert!(
+        metrics.underline_thickness() > 0.0 && metrics.underline_thickness().is_finite(),
+        "fallback underline thickness must be positive and finite, got {}",
+        metrics.underline_thickness()
+    );
+    assert!(
+        metrics.underline_position() < 0.0 && metrics.underline_position().is_finite(),
+        "fallback underline should sit below the baseline, got {}",
+        metrics.underline_position()
+    );
+
+    // Drawing with the fallback font must not panic and must still emit the rects.
+    let renderer = RecordingRenderer::default();
+    let commands = renderer.last_commands.clone();
+    let verts = renderer.last_verts.clone();
+    let mut canvas = Canvas::new(renderer).unwrap();
+    canvas.set_size(1000, 1000, 1.0);
+    let font = canvas
+        .add_font_mem(&font_without_tables(original, &[b"OS/2", b"post"]))
+        .expect("stripped font should load into canvas");
+    let paint = Paint::color(Color::black())
+        .with_font(&[font])
+        .with_font_size(20.0)
+        .with_text_baseline(Baseline::Alphabetic)
+        .with_text_decoration_lines(true, true, false);
+    canvas.fill_text(20.0, 100.0, "fallback", &paint).unwrap();
+    canvas.flush_to_output(());
+    let spans = recorded_decoration_spans(&commands.borrow(), &verts.borrow());
+    assert_eq!(
+        spans.len(),
+        2,
+        "expected underline + strikethrough rects, got {spans:?}"
     );
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2096,40 +2096,41 @@ where
             return;
         };
 
-        // The decoration takes the text paint's color, matching SVG where the
-        // decoration uses the text fill. The full paint flavor (gradient/image)
-        // is reused as-is so a gradient-filled run gets a gradient-filled line.
-        let line_paint = paint.clone();
-
-        let emit = |this: &mut Self, center_y: f32, thickness: f32| {
+        // All enabled lines share one path (a single verbs/coords allocation) and
+        // one fill_path call, so a run costs one draw no matter how many lines
+        // are on. The rects are disjoint horizontal bands, and the paint below
+        // forces NonZero filling, so any degenerate overlap (e.g. thickness
+        // clamping on tiny fonts) still paints solid.
+        let mut path = Path::new();
+        let mut add_line = |center_y: f32, thickness: f32| {
             let thickness = thickness.max(1.0);
-            let mut path = Path::new();
             path.rect(x, center_y - thickness / 2.0, width, thickness);
-            this.fill_path(&path, &line_paint);
         };
 
         // OpenType position values measure from the baseline with +y pointing up,
         // while canvas y grows downward, so a line's center is `baseline - pos`.
         if decoration.underline {
-            emit(
-                self,
-                baseline - metrics.underline_position(),
-                metrics.underline_thickness(),
-            );
+            add_line(baseline - metrics.underline_position(), metrics.underline_thickness());
         }
         if decoration.strikethrough {
-            emit(
-                self,
-                baseline - metrics.strikeout_position(),
-                metrics.strikeout_thickness(),
-            );
+            add_line(baseline - metrics.strikeout_position(), metrics.strikeout_thickness());
         }
         if decoration.overline {
             // No dedicated metric; sit the line at the ascent with the underline
             // thickness, nudged up by half its thickness so it clears the glyphs.
             let thickness = metrics.underline_thickness().max(1.0);
-            emit(self, baseline - metrics.ascender() - thickness / 2.0, thickness);
+            add_line(baseline - metrics.ascender() - thickness / 2.0, thickness);
         }
+
+        if path.is_empty() {
+            return;
+        }
+
+        // The decoration takes the text paint's color, matching SVG where the
+        // decoration uses the text fill. The full paint flavor (gradient/image)
+        // is reused as-is so a gradient-filled run gets a gradient-filled line.
+        let line_paint = paint.clone().with_fill_rule(FillRule::NonZero);
+        self.fill_path(&path, &line_paint);
     }
 
     fn draw_glyph_run(
@@ -3253,52 +3254,61 @@ fn outline_text_shadow_pass_count_is_glyph_count_invariant() {
          their own shadow on top of the run-level one"
     );
 }
-/// Collects the screen-space filled rectangles that text decoration emits.
+/// Collects the screen-space filled rectangles that text decoration emits,
+/// grouped by fill command.
 ///
-/// A decoration line is a solid `ConvexFill` drawn to the screen with no glyph
-/// texture. (Atlas glyph rasterization also emits `ConvexFill`s, but those run
-/// while the render target is the atlas image, so tracking the active target
-/// discriminates them.) Returns the vertical `[min_y, max_y]` span of each such
-/// fill, in screen space.
+/// A run's decoration lines are batched into one solid path fill drawn to the
+/// screen with no glyph texture: a single enabled line arrives as a
+/// one-contour `ConvexFill`, several enabled lines as one multi-contour
+/// (concave) fill command. (Atlas glyph rasterization also emits
+/// `ConvexFill`s, but those run while the render target is the atlas image,
+/// so tracking the active target discriminates them.) Returns one entry per
+/// such fill command, listing the vertical `[min_y, max_y]` span of each
+/// contour in that command, in screen space.
 #[cfg(all(test, feature = "textlayout"))]
-fn recorded_decoration_spans(commands: &[renderer::Command], verts: &[renderer::Vertex]) -> Vec<(f32, f32)> {
+fn recorded_decoration_fills(commands: &[renderer::Command], verts: &[renderer::Vertex]) -> Vec<Vec<(f32, f32)>> {
     use crate::paint::GlyphTexture;
     use renderer::{CommandType, RenderTarget};
 
     let mut target = RenderTarget::Screen;
-    let mut spans = Vec::new();
+    let mut fills = Vec::new();
 
     for cmd in commands {
         match &cmd.cmd_type {
             CommandType::SetRenderTarget(new_target) => target = *new_target,
-            CommandType::ConvexFill { .. }
+            CommandType::ConvexFill { .. } | CommandType::ConcaveFill { .. }
                 if target == RenderTarget::Screen && matches!(cmd.glyph_texture, GlyphTexture::None) =>
             {
-                let mut min_y = f32::INFINITY;
-                let mut max_y = f32::NEG_INFINITY;
+                let mut spans = Vec::new();
                 for drawable in &cmd.drawables {
                     if let Some((offset, len)) = drawable.fill_verts {
+                        let mut min_y = f32::INFINITY;
+                        let mut max_y = f32::NEG_INFINITY;
                         for v in &verts[offset..offset + len] {
                             min_y = min_y.min(v.y);
                             max_y = max_y.max(v.y);
                         }
+                        if min_y.is_finite() {
+                            spans.push((min_y, max_y));
+                        }
                     }
                 }
-                if min_y.is_finite() {
-                    spans.push((min_y, max_y));
+                if !spans.is_empty() {
+                    fills.push(spans);
                 }
             }
             _ => {}
         }
     }
 
-    spans
+    fills
 }
 
-/// With a decoration enabled, `fill_text` emits exactly one extra solid rect per
-/// enabled line, positioned from the font's own metrics: underline below the
-/// baseline, strikethrough above it (through the text), overline near the ascent.
-/// With no decoration, no such rect is emitted.
+/// With any decoration enabled, `fill_text` emits exactly ONE extra solid fill
+/// command for the run, carrying one rect per enabled line positioned from the
+/// font's own metrics: underline below the baseline, strikethrough above it
+/// (through the text), overline near the ascent. With no decoration, no such
+/// fill is emitted.
 #[cfg(feature = "textlayout")]
 #[test]
 fn fill_text_emits_decoration_rects() {
@@ -3334,18 +3344,19 @@ fn fill_text_emits_decoration_rects() {
             .with_text_baseline(Baseline::Alphabetic)
     };
 
-    // No decoration: no screen-space solid rects at all.
+    // No decoration: no screen-space solid fills at all.
     {
         let (mut canvas, commands, verts, font) = make_canvas();
         canvas
             .fill_text(50.0, baseline_y, "Hello", &base_paint().with_font(&[font]))
             .unwrap();
         canvas.flush_to_output(());
-        let spans = recorded_decoration_spans(&commands.borrow(), &verts.borrow());
-        assert!(spans.is_empty(), "expected no decoration rect, got {spans:?}");
+        let fills = recorded_decoration_fills(&commands.borrow(), &verts.borrow());
+        assert!(fills.is_empty(), "expected no decoration fill, got {fills:?}");
     }
 
-    // Underline: one rect, centered below the baseline at -underline_position.
+    // Underline: one fill command with one rect, centered below the baseline at
+    // -underline_position.
     {
         let (mut canvas, commands, verts, font) = make_canvas();
         let paint = base_paint()
@@ -3353,9 +3364,10 @@ fn fill_text_emits_decoration_rects() {
             .with_text_decoration_lines(true, false, false);
         canvas.fill_text(50.0, baseline_y, "Hello", &paint).unwrap();
         canvas.flush_to_output(());
-        let spans = recorded_decoration_spans(&commands.borrow(), &verts.borrow());
-        assert_eq!(spans.len(), 1, "expected exactly one underline rect, got {spans:?}");
-        let (min_y, max_y) = spans[0];
+        let fills = recorded_decoration_fills(&commands.borrow(), &verts.borrow());
+        assert_eq!(fills.len(), 1, "expected exactly one decoration fill, got {fills:?}");
+        assert_eq!(fills[0].len(), 1, "expected exactly one underline rect, got {fills:?}");
+        let (min_y, max_y) = fills[0][0];
         let center = (min_y + max_y) / 2.0;
         let expected = baseline_y - metrics.underline_position();
         assert!(center > baseline_y, "underline should sit below the baseline");
@@ -3371,7 +3383,8 @@ fn fill_text_emits_decoration_rects() {
         );
     }
 
-    // Strikethrough: one rect, above the baseline at -strikeout_position.
+    // Strikethrough: one fill command with one rect, above the baseline at
+    // -strikeout_position.
     {
         let (mut canvas, commands, verts, font) = make_canvas();
         let paint = base_paint()
@@ -3379,9 +3392,14 @@ fn fill_text_emits_decoration_rects() {
             .with_text_decoration_lines(false, true, false);
         canvas.fill_text(50.0, baseline_y, "Hello", &paint).unwrap();
         canvas.flush_to_output(());
-        let spans = recorded_decoration_spans(&commands.borrow(), &verts.borrow());
-        assert_eq!(spans.len(), 1, "expected exactly one strikethrough rect, got {spans:?}");
-        let (min_y, max_y) = spans[0];
+        let fills = recorded_decoration_fills(&commands.borrow(), &verts.borrow());
+        assert_eq!(fills.len(), 1, "expected exactly one decoration fill, got {fills:?}");
+        assert_eq!(
+            fills[0].len(),
+            1,
+            "expected exactly one strikethrough rect, got {fills:?}"
+        );
+        let (min_y, max_y) = fills[0][0];
         let center = (min_y + max_y) / 2.0;
         let expected = baseline_y - metrics.strikeout_position();
         assert!(center < baseline_y, "strikethrough should sit above the baseline");
@@ -3391,7 +3409,7 @@ fn fill_text_emits_decoration_rects() {
         );
     }
 
-    // Overline: one rect, above the ascent.
+    // Overline: one fill command with one rect, above the ascent.
     {
         let (mut canvas, commands, verts, font) = make_canvas();
         let paint = base_paint()
@@ -3399,9 +3417,10 @@ fn fill_text_emits_decoration_rects() {
             .with_text_decoration_lines(false, false, true);
         canvas.fill_text(50.0, baseline_y, "Hello", &paint).unwrap();
         canvas.flush_to_output(());
-        let spans = recorded_decoration_spans(&commands.borrow(), &verts.borrow());
-        assert_eq!(spans.len(), 1, "expected exactly one overline rect, got {spans:?}");
-        let (_, max_y) = spans[0];
+        let fills = recorded_decoration_fills(&commands.borrow(), &verts.borrow());
+        assert_eq!(fills.len(), 1, "expected exactly one decoration fill, got {fills:?}");
+        assert_eq!(fills[0].len(), 1, "expected exactly one overline rect, got {fills:?}");
+        let (_, max_y) = fills[0][0];
         assert!(
             max_y <= baseline_y - metrics.ascender() + 1.0,
             "overline (bottom {max_y}) should sit at/above the ascent {}",
@@ -3409,7 +3428,9 @@ fn fill_text_emits_decoration_rects() {
         );
     }
 
-    // All three at once: three distinct rects.
+    // All three at once: still exactly ONE fill command — the lines are batched
+    // into a single path and draw — carrying three disjoint rects, one at each
+    // metric-derived position.
     {
         let (mut canvas, commands, verts, font) = make_canvas();
         let paint = base_paint()
@@ -3417,8 +3438,40 @@ fn fill_text_emits_decoration_rects() {
             .with_text_decoration_lines(true, true, true);
         canvas.fill_text(50.0, baseline_y, "Hello", &paint).unwrap();
         canvas.flush_to_output(());
-        let spans = recorded_decoration_spans(&commands.borrow(), &verts.borrow());
+        let fills = recorded_decoration_fills(&commands.borrow(), &verts.borrow());
+        assert_eq!(
+            fills.len(),
+            1,
+            "all lines must share one decoration fill, got {fills:?}"
+        );
+        let mut spans = fills[0].clone();
         assert_eq!(spans.len(), 3, "expected three decoration rects, got {spans:?}");
+
+        // Top to bottom: overline above the ascent, strikethrough above the
+        // baseline, underline below it — three non-overlapping bands.
+        spans.sort_by(|a, b| a.0.total_cmp(&b.0));
+        assert!(
+            spans[0].1 <= baseline_y - metrics.ascender() + 1.0,
+            "overline (bottom {}) should sit at/above the ascent {}",
+            spans[0].1,
+            baseline_y - metrics.ascender()
+        );
+        let strike_center = (spans[1].0 + spans[1].1) / 2.0;
+        let strike_expected = baseline_y - metrics.strikeout_position();
+        assert!(
+            (strike_center - strike_expected).abs() <= 1.0,
+            "strikethrough center {strike_center} should be near {strike_expected}"
+        );
+        let under_center = (spans[2].0 + spans[2].1) / 2.0;
+        let under_expected = baseline_y - metrics.underline_position();
+        assert!(
+            (under_center - under_expected).abs() <= 1.0,
+            "underline center {under_center} should be near {under_expected}"
+        );
+        assert!(
+            spans[0].1 <= spans[1].0 && spans[1].1 <= spans[2].0,
+            "decoration bands should not overlap: {spans:?}"
+        );
     }
 }
 
@@ -3455,9 +3508,10 @@ fn decoration_rect_tracks_scaled_atlas_transform() {
     canvas.fill_text(40.0, baseline_y, "Scaled", &paint).unwrap();
     canvas.flush_to_output(());
 
-    let spans = recorded_decoration_spans(&commands.borrow(), &verts.borrow());
-    assert_eq!(spans.len(), 1, "expected one underline rect, got {spans:?}");
-    let (min_y, max_y) = spans[0];
+    let fills = recorded_decoration_fills(&commands.borrow(), &verts.borrow());
+    assert_eq!(fills.len(), 1, "expected exactly one decoration fill, got {fills:?}");
+    assert_eq!(fills[0].len(), 1, "expected exactly one underline rect, got {fills:?}");
+    let (min_y, max_y) = fills[0][0];
     let center = (min_y + max_y) / 2.0;
     // User-space underline center is baseline - underline_position; on screen the
     // whole thing is multiplied by the canvas scale.
@@ -3652,7 +3706,8 @@ fn decoration_metrics_fall_back_without_os2_and_post() {
         metrics.underline_position()
     );
 
-    // Drawing with the fallback font must not panic and must still emit the rects.
+    // Drawing with the fallback font must not panic and must still emit both
+    // rects, batched into the run's single decoration fill.
     let renderer = RecordingRenderer::default();
     let commands = renderer.last_commands.clone();
     let verts = renderer.last_verts.clone();
@@ -3668,10 +3723,11 @@ fn decoration_metrics_fall_back_without_os2_and_post() {
         .with_text_decoration_lines(true, true, false);
     canvas.fill_text(20.0, 100.0, "fallback", &paint).unwrap();
     canvas.flush_to_output(());
-    let spans = recorded_decoration_spans(&commands.borrow(), &verts.borrow());
+    let fills = recorded_decoration_fills(&commands.borrow(), &verts.borrow());
+    assert_eq!(fills.len(), 1, "expected exactly one decoration fill, got {fills:?}");
     assert_eq!(
-        spans.len(),
+        fills[0].len(),
         2,
-        "expected underline + strikethrough rects, got {spans:?}"
+        "expected underline + strikethrough rects in one fill, got {fills:?}"
     );
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2083,6 +2083,14 @@ where
     /// run's left edge, and `width` its advance width.
     #[cfg(feature = "textlayout")]
     fn draw_text_decorations(&mut self, paint: &Paint, baseline: f32, x: f32, width: f32) {
+        // NOTE: this assumes a horizontal writing mode. The lines run along the
+        // advance direction (x) and are offset perpendicular to it (y), spanning
+        // `[x, x + width]` at a baseline-relative y. That is correct for both LTR
+        // and RTL runs, since a horizontal decoration is direction-independent.
+        // A vertical writing mode (top-to-bottom) would need the lines to run
+        // along y and offset along x, driven by vertical metrics; the geometry
+        // below would have to be generalized to the advance axis rather than
+        // hardcoding x as the run axis.
         let decoration = paint.text.text_decoration;
 
         // Metrics in user-space units (scaled for the unscaled font size) so the

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -329,6 +329,25 @@ pub struct Canvas<T: Renderer> {
     shadow_images: Vec<ImageId>,
 }
 
+/// Returns the shared baseline of a shaped horizontal run, in shaping space, or
+/// `None` if the run has no drawable glyph.
+///
+/// `layout` positions each glyph as
+/// `glyph.y = cursor_y + alignment_offset + glyph.offset_y`, so every glyph
+/// shares the same (possibly fractional) `cursor_y + alignment_offset` baseline
+/// and the per-glyph term is `glyph.offset_y` (the GPOS y-offset). Recovering the
+/// baseline as `glyph.y - glyph.offset_y` is what keeps text decorations anchored
+/// to the run baseline even when the first drawable glyph carries a non-zero
+/// offset (e.g. text starting with a combining mark), instead of riding that mark
+/// up or down.
+#[cfg(feature = "textlayout")]
+fn run_baseline(glyphs: &[text::ShapedGlyph]) -> Option<f32> {
+    glyphs
+        .iter()
+        .find(|shaped_glyph| !shaped_glyph.c.is_control())
+        .map(|shaped_glyph| shaped_glyph.y - shaped_glyph.offset_y)
+}
+
 impl<T> Canvas<T>
 where
     T: Renderer,
@@ -3447,6 +3466,83 @@ fn decoration_rect_tracks_scaled_atlas_transform() {
         (center - expected).abs() <= 2.0,
         "scaled underline center {center} should be near {expected}"
     );
+}
+
+/// The decoration baseline must be the shared run baseline, independent of the
+/// first drawable glyph's GPOS y-offset. `layout` bakes that offset into
+/// `glyph.y`, so a run beginning with a combining mark (non-zero `offset_y`)
+/// would otherwise drag every decoration line up or down with the mark.
+///
+/// This unit-tests `run_baseline` — the exact policy `draw_text` uses to anchor
+/// decorations — with a synthetic run whose first glyph carries an `offset_y`.
+/// The captured baseline must match the run baseline computed without the offset
+/// (i.e. the second, zero-offset glyph's `y`), not the first glyph's shifted `y`.
+#[cfg(feature = "textlayout")]
+#[test]
+fn run_baseline_ignores_leading_glyph_offset() {
+    // A real FontId is needed to populate the synthetic glyphs; `run_baseline`
+    // never reads it, but ShapedGlyph requires one.
+    let text_context = TextContext::default();
+    let font_id = text_context
+        .add_font_mem(include_bytes!("../examples/assets/RobotoFlex-VariableFont.ttf"))
+        .expect("failed to load test font");
+
+    // The shared run baseline both glyphs are positioned against.
+    let run_y = 200.0_f32;
+
+    let make_glyph = |c: char, offset_y: f32| text::ShapedGlyph {
+        // `layout` stores `glyph.y = run_baseline + glyph.offset_y`; mirror that.
+        x: 0.0,
+        y: run_y + offset_y,
+        c,
+        byte_index: 0,
+        font_id,
+        glyph_id: 0,
+        width: 0.0,
+        height: 0.0,
+        advance_x: 0.0,
+        advance_y: 0.0,
+        offset_x: 0.0,
+        offset_y,
+    };
+
+    // First drawable glyph carries a large positive y-offset (a combining mark
+    // pushed below the baseline); the second sits exactly on the baseline.
+    let offset = 15.0_f32;
+    let with_offset = [make_glyph('a', offset), make_glyph('b', 0.0)];
+    // Same run, but the leading glyph has no offset.
+    let without_offset = [make_glyph('a', 0.0), make_glyph('b', 0.0)];
+
+    let captured = run_baseline(&with_offset).expect("run has a drawable glyph");
+    let reference = run_baseline(&without_offset).expect("run has a drawable glyph");
+
+    // The capture must equal the true run baseline, not the shifted first glyph.
+    assert_eq!(
+        captured, run_y,
+        "captured baseline {captured} should equal the shared run baseline {run_y}"
+    );
+    assert_eq!(
+        captured, reference,
+        "leading glyph offset must not shift the captured baseline ({captured} vs {reference})"
+    );
+    assert!(
+        (captured - with_offset[0].y).abs() > offset - 1.0,
+        "captured baseline {captured} must not follow the offset glyph y {}",
+        with_offset[0].y
+    );
+
+    // A leading control glyph (skipped by the drawable filter) must not become
+    // the baseline source either.
+    let with_control = [make_glyph('\n', 99.0), make_glyph('b', 0.0)];
+    assert_eq!(
+        run_baseline(&with_control),
+        Some(run_y),
+        "control glyphs must be skipped when capturing the baseline"
+    );
+
+    // Empty / all-control runs have no baseline.
+    assert_eq!(run_baseline(&[]), None);
+    assert_eq!(run_baseline(&[make_glyph('\t', 0.0)]), None);
 }
 
 /// Rebuilds a sfnt/TrueType font byte buffer with the named 4-byte tables

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3588,9 +3588,11 @@ fn fill_text_emits_decoration_rects() {
     // -underline_position.
     {
         let (mut canvas, commands, verts, font) = make_canvas();
-        let paint = base_paint()
-            .with_font(&[font])
-            .with_text_decoration_lines(true, false, false);
+        let paint = base_paint().with_font(&[font]).with_text_decoration(TextDecoration {
+            underline: true,
+            strikethrough: false,
+            overline: false,
+        });
         canvas.fill_text(50.0, baseline_y, "Hello", &paint).unwrap();
         canvas.flush_to_output(());
         let fills = recorded_decoration_fills(&commands.borrow(), &verts.borrow());
@@ -3616,9 +3618,11 @@ fn fill_text_emits_decoration_rects() {
     // -strikeout_position.
     {
         let (mut canvas, commands, verts, font) = make_canvas();
-        let paint = base_paint()
-            .with_font(&[font])
-            .with_text_decoration_lines(false, true, false);
+        let paint = base_paint().with_font(&[font]).with_text_decoration(TextDecoration {
+            underline: false,
+            strikethrough: true,
+            overline: false,
+        });
         canvas.fill_text(50.0, baseline_y, "Hello", &paint).unwrap();
         canvas.flush_to_output(());
         let fills = recorded_decoration_fills(&commands.borrow(), &verts.borrow());
@@ -3641,9 +3645,11 @@ fn fill_text_emits_decoration_rects() {
     // Overline: one fill command with one rect, above the ascent.
     {
         let (mut canvas, commands, verts, font) = make_canvas();
-        let paint = base_paint()
-            .with_font(&[font])
-            .with_text_decoration_lines(false, false, true);
+        let paint = base_paint().with_font(&[font]).with_text_decoration(TextDecoration {
+            underline: false,
+            strikethrough: false,
+            overline: true,
+        });
         canvas.fill_text(50.0, baseline_y, "Hello", &paint).unwrap();
         canvas.flush_to_output(());
         let fills = recorded_decoration_fills(&commands.borrow(), &verts.borrow());
@@ -3662,9 +3668,11 @@ fn fill_text_emits_decoration_rects() {
     // metric-derived position.
     {
         let (mut canvas, commands, verts, font) = make_canvas();
-        let paint = base_paint()
-            .with_font(&[font])
-            .with_text_decoration_lines(true, true, true);
+        let paint = base_paint().with_font(&[font]).with_text_decoration(TextDecoration {
+            underline: true,
+            strikethrough: true,
+            overline: true,
+        });
         canvas.fill_text(50.0, baseline_y, "Hello", &paint).unwrap();
         canvas.flush_to_output(());
         let fills = recorded_decoration_fills(&commands.borrow(), &verts.borrow());
@@ -3731,7 +3739,11 @@ fn decoration_rect_tracks_scaled_atlas_transform() {
         .with_font(&[font])
         .with_font_size(24.0)
         .with_text_baseline(Baseline::Alphabetic)
-        .with_text_decoration_lines(true, false, false);
+        .with_text_decoration(TextDecoration {
+            underline: true,
+            strikethrough: false,
+            overline: false,
+        });
 
     canvas.scale(scale, scale);
     canvas.fill_text(40.0, baseline_y, "Scaled", &paint).unwrap();
@@ -3913,7 +3925,11 @@ fn decoration_metrics_fall_back_without_os2_and_post() {
         .with_font(&[font])
         .with_font_size(20.0)
         .with_text_baseline(Baseline::Alphabetic)
-        .with_text_decoration_lines(true, true, false);
+        .with_text_decoration(TextDecoration {
+            underline: true,
+            strikethrough: true,
+            overline: false,
+        });
     canvas.fill_text(20.0, 100.0, "fallback", &paint).unwrap();
     canvas.flush_to_output(());
     let fills = recorded_decoration_fills(&commands.borrow(), &verts.borrow());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3495,7 +3495,10 @@ fn arc_tessellation_is_deterministic_across_threads() {
 /// such fill command, listing the vertical `[min_y, max_y]` span of each
 /// contour in that command, in screen space.
 #[cfg(all(test, feature = "textlayout"))]
-fn recorded_decoration_fills(commands: &[renderer::Command], verts: &[renderer::Vertex]) -> Vec<Vec<(f32, f32)>> {
+fn recorded_decoration_fills(
+    commands: &[renderer::Command],
+    verts: &[renderer::Vertex],
+) -> Vec<Vec<(f32, f32, f32, f32)>> {
     use crate::paint::GlyphTexture;
     use renderer::{CommandType, RenderTarget};
 
@@ -3511,14 +3514,18 @@ fn recorded_decoration_fills(commands: &[renderer::Command], verts: &[renderer::
                 let mut spans = Vec::new();
                 for drawable in &cmd.drawables {
                     if let Some((offset, len)) = drawable.fill_verts {
+                        let mut min_x = f32::INFINITY;
+                        let mut max_x = f32::NEG_INFINITY;
                         let mut min_y = f32::INFINITY;
                         let mut max_y = f32::NEG_INFINITY;
                         for v in &verts[offset..offset + len] {
+                            min_x = min_x.min(v.x);
+                            max_x = max_x.max(v.x);
                             min_y = min_y.min(v.y);
                             max_y = max_y.max(v.y);
                         }
                         if min_y.is_finite() {
-                            spans.push((min_y, max_y));
+                            spans.push((min_x, min_y, max_x, max_y));
                         }
                     }
                 }
@@ -3598,7 +3605,7 @@ fn fill_text_emits_decoration_rects() {
         let fills = recorded_decoration_fills(&commands.borrow(), &verts.borrow());
         assert_eq!(fills.len(), 1, "expected exactly one decoration fill, got {fills:?}");
         assert_eq!(fills[0].len(), 1, "expected exactly one underline rect, got {fills:?}");
-        let (min_y, max_y) = fills[0][0];
+        let (_, min_y, _, max_y) = fills[0][0];
         let center = (min_y + max_y) / 2.0;
         let expected = baseline_y - metrics.underline_position();
         assert!(center > baseline_y, "underline should sit below the baseline");
@@ -3632,7 +3639,7 @@ fn fill_text_emits_decoration_rects() {
             1,
             "expected exactly one strikethrough rect, got {fills:?}"
         );
-        let (min_y, max_y) = fills[0][0];
+        let (_, min_y, _, max_y) = fills[0][0];
         let center = (min_y + max_y) / 2.0;
         let expected = baseline_y - metrics.strikeout_position();
         assert!(center < baseline_y, "strikethrough should sit above the baseline");
@@ -3655,7 +3662,7 @@ fn fill_text_emits_decoration_rects() {
         let fills = recorded_decoration_fills(&commands.borrow(), &verts.borrow());
         assert_eq!(fills.len(), 1, "expected exactly one decoration fill, got {fills:?}");
         assert_eq!(fills[0].len(), 1, "expected exactly one overline rect, got {fills:?}");
-        let (_, max_y) = fills[0][0];
+        let (_, _, _, max_y) = fills[0][0];
         assert!(
             max_y <= baseline_y - metrics.ascender() + 1.0,
             "overline (bottom {max_y}) should sit at/above the ascent {}",
@@ -3686,29 +3693,115 @@ fn fill_text_emits_decoration_rects() {
 
         // Top to bottom: overline above the ascent, strikethrough above the
         // baseline, underline below it — three non-overlapping bands.
-        spans.sort_by(|a, b| a.0.total_cmp(&b.0));
+        spans.sort_by(|a, b| a.1.total_cmp(&b.1));
         assert!(
-            spans[0].1 <= baseline_y - metrics.ascender() + 1.0,
+            spans[0].3 <= baseline_y - metrics.ascender() + 1.0,
             "overline (bottom {}) should sit at/above the ascent {}",
-            spans[0].1,
+            spans[0].3,
             baseline_y - metrics.ascender()
         );
-        let strike_center = (spans[1].0 + spans[1].1) / 2.0;
+        let strike_center = (spans[1].1 + spans[1].3) / 2.0;
         let strike_expected = baseline_y - metrics.strikeout_position();
         assert!(
             (strike_center - strike_expected).abs() <= 1.0,
             "strikethrough center {strike_center} should be near {strike_expected}"
         );
-        let under_center = (spans[2].0 + spans[2].1) / 2.0;
+        let under_center = (spans[2].1 + spans[2].3) / 2.0;
         let under_expected = baseline_y - metrics.underline_position();
         assert!(
             (under_center - under_expected).abs() <= 1.0,
             "underline center {under_center} should be near {under_expected}"
         );
         assert!(
-            spans[0].1 <= spans[1].0 && spans[1].1 <= spans[2].0,
+            spans[0].3 <= spans[1].1 && spans[1].3 <= spans[2].1,
             "decoration bands should not overlap: {spans:?}"
         );
+    }
+}
+
+/// A decoration line spans exactly the run's advance box `[layout.x, layout.x
+/// + width]`. Alignment moves `layout.x` (Center/Right shift the run left of
+/// the requested x), and an RTL run lays its glyphs out right-to-left — in
+/// every case the line must track the box the glyphs actually occupy, not the
+/// requested draw position.
+#[cfg(feature = "textlayout")]
+#[test]
+fn decoration_rect_spans_the_run_advance_box() {
+    let anchor_x = 300.0_f32;
+    for (case, text, align) in [
+        ("ltr left", "Deco", Align::Left),
+        ("ltr center", "Deco", Align::Center),
+        ("ltr right", "Deco", Align::Right),
+        // Arabic shapes right-to-left; Amiri provides the glyphs.
+        ("rtl left", "سلام", Align::Left),
+        ("rtl right", "سلام", Align::Right),
+    ] {
+        let renderer = RecordingRenderer::default();
+        let commands = renderer.last_commands.clone();
+        let verts = renderer.last_verts.clone();
+        let mut canvas = Canvas::new(renderer).unwrap();
+        canvas.set_size(1000, 1000, 1.0);
+        let latin = canvas
+            .add_font_mem(include_bytes!("../examples/assets/RobotoFlex-VariableFont.ttf"))
+            .expect("failed to load test font");
+        let arabic = canvas
+            .add_font_mem(include_bytes!("../examples/assets/amiri-regular.ttf"))
+            .expect("failed to load test font");
+
+        let paint = Paint::color(Color::black())
+            .with_font(&[latin, arabic])
+            .with_font_size(40.0)
+            .with_text_baseline(Baseline::Alphabetic)
+            .with_text_align(align)
+            .with_text_decoration(TextDecoration {
+                underline: true,
+                strikethrough: false,
+                overline: false,
+            });
+        let layout = canvas.fill_text(anchor_x, 200.0, text, &paint).unwrap();
+        canvas.flush_to_output(());
+
+        assert!(layout.width() > 0.0, "{case}: run should have advance width");
+        match align {
+            Align::Left => assert!((layout.x - anchor_x).abs() < 1e-3, "{case}: run starts at the anchor"),
+            Align::Center | Align::Right => {
+                assert!(layout.x < anchor_x, "{case}: aligned run starts left of the anchor")
+            }
+        }
+
+        let fills = recorded_decoration_fills(&commands.borrow(), &verts.borrow());
+        assert_eq!(
+            fills.len(),
+            1,
+            "{case}: expected exactly one decoration fill, got {fills:?}"
+        );
+        assert_eq!(
+            fills[0].len(),
+            1,
+            "{case}: expected exactly one underline rect, got {fills:?}"
+        );
+        let (min_x, _, max_x, _) = fills[0][0];
+        assert!(
+            (min_x - layout.x).abs() <= 0.5,
+            "{case}: underline left edge {min_x} should be the run's left edge {}",
+            layout.x
+        );
+        assert!(
+            (max_x - (layout.x + layout.width())).abs() <= 0.5,
+            "{case}: underline right edge {max_x} should be the run's right edge {}",
+            layout.x + layout.width()
+        );
+
+        // Independent of the advance-box arithmetic: the line must actually run
+        // under every glyph the shaper placed, wherever alignment or RTL
+        // ordering put them.
+        for glyph in layout.glyphs.iter().filter(|shaped_glyph| !shaped_glyph.c.is_control()) {
+            let glyph_center = glyph.x + glyph.width / 2.0;
+            assert!(
+                min_x <= glyph_center && glyph_center <= max_x,
+                "{case}: underline [{min_x}, {max_x}] must run under the glyph at {glyph_center}"
+            );
+        }
     }
 }
 
@@ -3752,7 +3845,7 @@ fn decoration_rect_tracks_scaled_atlas_transform() {
     let fills = recorded_decoration_fills(&commands.borrow(), &verts.borrow());
     assert_eq!(fills.len(), 1, "expected exactly one decoration fill, got {fills:?}");
     assert_eq!(fills[0].len(), 1, "expected exactly one underline rect, got {fills:?}");
-    let (min_y, max_y) = fills[0][0];
+    let (_, min_y, _, max_y) = fills[0][0];
     let center = (min_y + max_y) / 2.0;
     // User-space underline center is baseline - underline_position; on screen the
     // whole thing is multiplied by the canvas scale.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -341,13 +341,6 @@ pub struct Canvas<T: Renderer> {
 /// offset (e.g. text starting with a combining mark), instead of riding that mark
 /// up or down.
 #[cfg(feature = "textlayout")]
-fn run_baseline(glyphs: &[text::ShapedGlyph]) -> Option<f32> {
-    glyphs
-        .iter()
-        .find(|shaped_glyph| !shaped_glyph.c.is_control())
-        .map(|shaped_glyph| shaped_glyph.y - shaped_glyph.offset_y)
-}
-
 impl<T> Canvas<T>
 where
     T: Renderer,
@@ -1943,8 +1936,9 @@ where
             text::normalize_variations(&text_context, &paint.text.font_ids, &paint.text.font_variations)
         };
 
-        // Captured in scaled shaping space; decorations hang off it below.
-        let baseline_scaled = run_baseline(&layout.glyphs);
+        // Whether anything will actually be painted; decorations and shadows
+        // hang off the run only when it has at least one drawable glyph.
+        let has_drawable_glyphs = layout.glyphs.iter().any(|shaped_glyph| !shaped_glyph.c.is_control());
 
         // Draw the drop shadow (if any) under the text. The shaped layout gives a
         // user-space box; transform its corners by the CTM to obtain device-space
@@ -1977,7 +1971,7 @@ where
                 // extent clips the decoration shadows of short (x-height-only)
                 // runs like "www". Deriving it from the metrics covers glyphs,
                 // decorations, ascenders, descenders and diacritics alike.
-                let baseline = baseline_scaled.map_or(layout.y * invscale, |b| b * invscale);
+                let baseline = layout.baseline() * invscale;
                 let (ascent, descent) = {
                     let text_context = self.text_context.borrow();
                     text_context
@@ -2065,10 +2059,8 @@ where
         // pass above already rendered the decorations into its coverage (it
         // re-enters draw_text, which draws them), so glyphs and decorations share
         // a single shadow and the lines must not cast a second one.
-        if glyph_run_result.is_ok() && !paint.text.text_decoration.is_none() {
-            if let Some(baseline_scaled) = baseline_scaled {
-                self.draw_text_decorations(paint, baseline_scaled * invscale, layout.x, layout.width());
-            }
+        if glyph_run_result.is_ok() && !paint.text.text_decoration.is_none() && has_drawable_glyphs {
+            self.draw_text_decorations(paint, layout.baseline(), layout.x, layout.width());
         }
 
         // Restore the shadow state on the success and error paths alike.
@@ -3759,76 +3751,40 @@ fn decoration_rect_tracks_scaled_atlas_transform() {
 /// `glyph.y`, so a run beginning with a combining mark (non-zero `offset_y`)
 /// would otherwise drag every decoration line up or down with the mark.
 ///
-/// This unit-tests `run_baseline` — the exact policy `draw_text` uses to anchor
-/// decorations — with a synthetic run whose first glyph carries an `offset_y`.
-/// The captured baseline must match the run baseline computed without the offset
-/// (i.e. the second, zero-offset glyph's `y`), not the first glyph's shifted `y`.
+/// The baseline `layout()` stores in `TextMetrics` is the anchor decorations
+/// hang from. It must be the run baseline the `Baseline` setting places, not
+/// something re-derived from glyph positions, which per-glyph y-offsets
+/// (combining marks) would skew.
 #[cfg(feature = "textlayout")]
 #[test]
-fn run_baseline_ignores_leading_glyph_offset() {
-    // A real FontId is needed to populate the synthetic glyphs; `run_baseline`
-    // never reads it, but ShapedGlyph requires one.
-    let text_context = TextContext::default();
-    let font_id = text_context
+fn layout_stores_the_run_baseline() {
+    let renderer = RecordingRenderer::default();
+    let mut canvas = Canvas::new(renderer).unwrap();
+    canvas.set_size(400, 200, 1.0);
+    let font_id = canvas
         .add_font_mem(include_bytes!("../examples/assets/RobotoFlex-VariableFont.ttf"))
         .expect("failed to load test font");
 
-    // The shared run baseline both glyphs are positioned against.
-    let run_y = 200.0_f32;
+    let y = 80.0;
+    let base_paint = Paint::color(Color::black()).with_font(&[font_id]).with_font_size(24.0);
+    let metrics = canvas.measure_font(&base_paint).expect("font metrics");
 
-    let make_glyph = |c: char, offset_y: f32| text::ShapedGlyph {
-        // `layout` stores `glyph.y = run_baseline + glyph.offset_y`; mirror that.
-        x: 0.0,
-        y: run_y + offset_y,
-        c,
-        byte_index: 0,
-        font_id,
-        glyph_id: 0,
-        width: 0.0,
-        height: 0.0,
-        advance_x: 0.0,
-        advance_y: 0.0,
-        offset_x: 0.0,
-        offset_y,
-    };
-
-    // First drawable glyph carries a large positive y-offset (a combining mark
-    // pushed below the baseline); the second sits exactly on the baseline.
-    let offset = 15.0_f32;
-    let with_offset = [make_glyph('a', offset), make_glyph('b', 0.0)];
-    // Same run, but the leading glyph has no offset.
-    let without_offset = [make_glyph('a', 0.0), make_glyph('b', 0.0)];
-
-    let captured = run_baseline(&with_offset).expect("run has a drawable glyph");
-    let reference = run_baseline(&without_offset).expect("run has a drawable glyph");
-
-    // The capture must equal the true run baseline, not the shifted first glyph.
-    assert_eq!(
-        captured, run_y,
-        "captured baseline {captured} should equal the shared run baseline {run_y}"
-    );
-    assert_eq!(
-        captured, reference,
-        "leading glyph offset must not shift the captured baseline ({captured} vs {reference})"
-    );
-    assert!(
-        (captured - with_offset[0].y).abs() > offset - 1.0,
-        "captured baseline {captured} must not follow the offset glyph y {}",
-        with_offset[0].y
-    );
-
-    // A leading control glyph (skipped by the drawable filter) must not become
-    // the baseline source either.
-    let with_control = [make_glyph('\n', 99.0), make_glyph('b', 0.0)];
-    assert_eq!(
-        run_baseline(&with_control),
-        Some(run_y),
-        "control glyphs must be skipped when capturing the baseline"
-    );
-
-    // Empty / all-control runs have no baseline.
-    assert_eq!(run_baseline(&[]), None);
-    assert_eq!(run_baseline(&[make_glyph('\t', 0.0)]), None);
+    // The alphabetic baseline is the requested y itself; the other settings
+    // shift it by the run's ascent/descent exactly as layout() aligns glyphs.
+    for (setting, expected) in [
+        (Baseline::Alphabetic, y),
+        (Baseline::Top, y + metrics.ascender()),
+        (Baseline::Middle, y + (metrics.ascender() + metrics.descender()) / 2.0),
+        (Baseline::Bottom, y + metrics.descender()),
+    ] {
+        let paint = base_paint.clone().with_text_baseline(setting);
+        let layout = canvas.measure_text(15.0, y, "Ay", &paint).expect("shaping succeeds");
+        assert!(
+            (layout.baseline() - expected).abs() < 1e-3,
+            "{setting:?}: baseline {} should be {expected}",
+            layout.baseline()
+        );
+    }
 }
 
 /// Rebuilds a sfnt/TrueType font byte buffer with the named 4-byte tables

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2096,40 +2096,41 @@ where
             return;
         };
 
-        // The decoration takes the text paint's color, matching SVG where the
-        // decoration uses the text fill. The full paint flavor (gradient/image)
-        // is reused as-is so a gradient-filled run gets a gradient-filled line.
-        let line_paint = paint.clone();
-
-        let emit = |this: &mut Self, center_y: f32, thickness: f32| {
+        // All enabled lines share one path (a single verbs/coords allocation) and
+        // one fill_path call, so a run costs one draw no matter how many lines
+        // are on. The rects are disjoint horizontal bands, and the paint below
+        // forces NonZero filling, so any degenerate overlap (e.g. thickness
+        // clamping on tiny fonts) still paints solid.
+        let mut path = Path::new();
+        let mut add_line = |center_y: f32, thickness: f32| {
             let thickness = thickness.max(1.0);
-            let mut path = Path::new();
             path.rect(x, center_y - thickness / 2.0, width, thickness);
-            this.fill_path(&path, &line_paint);
         };
 
         // OpenType position values measure from the baseline with +y pointing up,
         // while canvas y grows downward, so a line's center is `baseline - pos`.
         if decoration.underline {
-            emit(
-                self,
-                baseline - metrics.underline_position(),
-                metrics.underline_thickness(),
-            );
+            add_line(baseline - metrics.underline_position(), metrics.underline_thickness());
         }
         if decoration.strikethrough {
-            emit(
-                self,
-                baseline - metrics.strikeout_position(),
-                metrics.strikeout_thickness(),
-            );
+            add_line(baseline - metrics.strikeout_position(), metrics.strikeout_thickness());
         }
         if decoration.overline {
             // No dedicated metric; sit the line at the ascent with the underline
             // thickness, nudged up by half its thickness so it clears the glyphs.
             let thickness = metrics.underline_thickness().max(1.0);
-            emit(self, baseline - metrics.ascender() - thickness / 2.0, thickness);
+            add_line(baseline - metrics.ascender() - thickness / 2.0, thickness);
         }
+
+        if path.is_empty() {
+            return;
+        }
+
+        // The decoration takes the text paint's color, matching SVG where the
+        // decoration uses the text fill. The full paint flavor (gradient/image)
+        // is reused as-is so a gradient-filled run gets a gradient-filled line.
+        let line_paint = paint.clone().with_fill_rule(FillRule::NonZero);
+        self.fill_path(&path, &line_paint);
     }
 
     fn draw_glyph_run(
@@ -3476,52 +3477,62 @@ fn arc_tessellation_is_deterministic_across_threads() {
         worker.join().unwrap();
     }
 }
-/// Collects the screen-space filled rectangles that text decoration emits.
+
+/// Collects the screen-space filled rectangles that text decoration emits,
+/// grouped by fill command.
 ///
-/// A decoration line is a solid `ConvexFill` drawn to the screen with no glyph
-/// texture. (Atlas glyph rasterization also emits `ConvexFill`s, but those run
-/// while the render target is the atlas image, so tracking the active target
-/// discriminates them.) Returns the vertical `[min_y, max_y]` span of each such
-/// fill, in screen space.
+/// A run's decoration lines are batched into one solid path fill drawn to the
+/// screen with no glyph texture: a single enabled line arrives as a
+/// one-contour `ConvexFill`, several enabled lines as one multi-contour
+/// (concave) fill command. (Atlas glyph rasterization also emits
+/// `ConvexFill`s, but those run while the render target is the atlas image,
+/// so tracking the active target discriminates them.) Returns one entry per
+/// such fill command, listing the vertical `[min_y, max_y]` span of each
+/// contour in that command, in screen space.
 #[cfg(all(test, feature = "textlayout"))]
-fn recorded_decoration_spans(commands: &[renderer::Command], verts: &[renderer::Vertex]) -> Vec<(f32, f32)> {
+fn recorded_decoration_fills(commands: &[renderer::Command], verts: &[renderer::Vertex]) -> Vec<Vec<(f32, f32)>> {
     use crate::paint::GlyphTexture;
     use renderer::{CommandType, RenderTarget};
 
     let mut target = RenderTarget::Screen;
-    let mut spans = Vec::new();
+    let mut fills = Vec::new();
 
     for cmd in commands {
         match &cmd.cmd_type {
             CommandType::SetRenderTarget(new_target) => target = *new_target,
-            CommandType::ConvexFill { .. }
+            CommandType::ConvexFill { .. } | CommandType::ConcaveFill { .. }
                 if target == RenderTarget::Screen && matches!(cmd.glyph_texture, GlyphTexture::None) =>
             {
-                let mut min_y = f32::INFINITY;
-                let mut max_y = f32::NEG_INFINITY;
+                let mut spans = Vec::new();
                 for drawable in &cmd.drawables {
                     if let Some((offset, len)) = drawable.fill_verts {
+                        let mut min_y = f32::INFINITY;
+                        let mut max_y = f32::NEG_INFINITY;
                         for v in &verts[offset..offset + len] {
                             min_y = min_y.min(v.y);
                             max_y = max_y.max(v.y);
                         }
+                        if min_y.is_finite() {
+                            spans.push((min_y, max_y));
+                        }
                     }
                 }
-                if min_y.is_finite() {
-                    spans.push((min_y, max_y));
+                if !spans.is_empty() {
+                    fills.push(spans);
                 }
             }
             _ => {}
         }
     }
 
-    spans
+    fills
 }
 
-/// With a decoration enabled, `fill_text` emits exactly one extra solid rect per
-/// enabled line, positioned from the font's own metrics: underline below the
-/// baseline, strikethrough above it (through the text), overline near the ascent.
-/// With no decoration, no such rect is emitted.
+/// With any decoration enabled, `fill_text` emits exactly ONE extra solid fill
+/// command for the run, carrying one rect per enabled line positioned from the
+/// font's own metrics: underline below the baseline, strikethrough above it
+/// (through the text), overline near the ascent. With no decoration, no such
+/// fill is emitted.
 #[cfg(feature = "textlayout")]
 #[test]
 fn fill_text_emits_decoration_rects() {
@@ -3557,18 +3568,19 @@ fn fill_text_emits_decoration_rects() {
             .with_text_baseline(Baseline::Alphabetic)
     };
 
-    // No decoration: no screen-space solid rects at all.
+    // No decoration: no screen-space solid fills at all.
     {
         let (mut canvas, commands, verts, font) = make_canvas();
         canvas
             .fill_text(50.0, baseline_y, "Hello", &base_paint().with_font(&[font]))
             .unwrap();
         canvas.flush_to_output(());
-        let spans = recorded_decoration_spans(&commands.borrow(), &verts.borrow());
-        assert!(spans.is_empty(), "expected no decoration rect, got {spans:?}");
+        let fills = recorded_decoration_fills(&commands.borrow(), &verts.borrow());
+        assert!(fills.is_empty(), "expected no decoration fill, got {fills:?}");
     }
 
-    // Underline: one rect, centered below the baseline at -underline_position.
+    // Underline: one fill command with one rect, centered below the baseline at
+    // -underline_position.
     {
         let (mut canvas, commands, verts, font) = make_canvas();
         let paint = base_paint()
@@ -3576,9 +3588,10 @@ fn fill_text_emits_decoration_rects() {
             .with_text_decoration_lines(true, false, false);
         canvas.fill_text(50.0, baseline_y, "Hello", &paint).unwrap();
         canvas.flush_to_output(());
-        let spans = recorded_decoration_spans(&commands.borrow(), &verts.borrow());
-        assert_eq!(spans.len(), 1, "expected exactly one underline rect, got {spans:?}");
-        let (min_y, max_y) = spans[0];
+        let fills = recorded_decoration_fills(&commands.borrow(), &verts.borrow());
+        assert_eq!(fills.len(), 1, "expected exactly one decoration fill, got {fills:?}");
+        assert_eq!(fills[0].len(), 1, "expected exactly one underline rect, got {fills:?}");
+        let (min_y, max_y) = fills[0][0];
         let center = (min_y + max_y) / 2.0;
         let expected = baseline_y - metrics.underline_position();
         assert!(center > baseline_y, "underline should sit below the baseline");
@@ -3594,7 +3607,8 @@ fn fill_text_emits_decoration_rects() {
         );
     }
 
-    // Strikethrough: one rect, above the baseline at -strikeout_position.
+    // Strikethrough: one fill command with one rect, above the baseline at
+    // -strikeout_position.
     {
         let (mut canvas, commands, verts, font) = make_canvas();
         let paint = base_paint()
@@ -3602,9 +3616,14 @@ fn fill_text_emits_decoration_rects() {
             .with_text_decoration_lines(false, true, false);
         canvas.fill_text(50.0, baseline_y, "Hello", &paint).unwrap();
         canvas.flush_to_output(());
-        let spans = recorded_decoration_spans(&commands.borrow(), &verts.borrow());
-        assert_eq!(spans.len(), 1, "expected exactly one strikethrough rect, got {spans:?}");
-        let (min_y, max_y) = spans[0];
+        let fills = recorded_decoration_fills(&commands.borrow(), &verts.borrow());
+        assert_eq!(fills.len(), 1, "expected exactly one decoration fill, got {fills:?}");
+        assert_eq!(
+            fills[0].len(),
+            1,
+            "expected exactly one strikethrough rect, got {fills:?}"
+        );
+        let (min_y, max_y) = fills[0][0];
         let center = (min_y + max_y) / 2.0;
         let expected = baseline_y - metrics.strikeout_position();
         assert!(center < baseline_y, "strikethrough should sit above the baseline");
@@ -3614,7 +3633,7 @@ fn fill_text_emits_decoration_rects() {
         );
     }
 
-    // Overline: one rect, above the ascent.
+    // Overline: one fill command with one rect, above the ascent.
     {
         let (mut canvas, commands, verts, font) = make_canvas();
         let paint = base_paint()
@@ -3622,9 +3641,10 @@ fn fill_text_emits_decoration_rects() {
             .with_text_decoration_lines(false, false, true);
         canvas.fill_text(50.0, baseline_y, "Hello", &paint).unwrap();
         canvas.flush_to_output(());
-        let spans = recorded_decoration_spans(&commands.borrow(), &verts.borrow());
-        assert_eq!(spans.len(), 1, "expected exactly one overline rect, got {spans:?}");
-        let (_, max_y) = spans[0];
+        let fills = recorded_decoration_fills(&commands.borrow(), &verts.borrow());
+        assert_eq!(fills.len(), 1, "expected exactly one decoration fill, got {fills:?}");
+        assert_eq!(fills[0].len(), 1, "expected exactly one overline rect, got {fills:?}");
+        let (_, max_y) = fills[0][0];
         assert!(
             max_y <= baseline_y - metrics.ascender() + 1.0,
             "overline (bottom {max_y}) should sit at/above the ascent {}",
@@ -3632,7 +3652,9 @@ fn fill_text_emits_decoration_rects() {
         );
     }
 
-    // All three at once: three distinct rects.
+    // All three at once: still exactly ONE fill command — the lines are batched
+    // into a single path and draw — carrying three disjoint rects, one at each
+    // metric-derived position.
     {
         let (mut canvas, commands, verts, font) = make_canvas();
         let paint = base_paint()
@@ -3640,8 +3662,40 @@ fn fill_text_emits_decoration_rects() {
             .with_text_decoration_lines(true, true, true);
         canvas.fill_text(50.0, baseline_y, "Hello", &paint).unwrap();
         canvas.flush_to_output(());
-        let spans = recorded_decoration_spans(&commands.borrow(), &verts.borrow());
+        let fills = recorded_decoration_fills(&commands.borrow(), &verts.borrow());
+        assert_eq!(
+            fills.len(),
+            1,
+            "all lines must share one decoration fill, got {fills:?}"
+        );
+        let mut spans = fills[0].clone();
         assert_eq!(spans.len(), 3, "expected three decoration rects, got {spans:?}");
+
+        // Top to bottom: overline above the ascent, strikethrough above the
+        // baseline, underline below it — three non-overlapping bands.
+        spans.sort_by(|a, b| a.0.total_cmp(&b.0));
+        assert!(
+            spans[0].1 <= baseline_y - metrics.ascender() + 1.0,
+            "overline (bottom {}) should sit at/above the ascent {}",
+            spans[0].1,
+            baseline_y - metrics.ascender()
+        );
+        let strike_center = (spans[1].0 + spans[1].1) / 2.0;
+        let strike_expected = baseline_y - metrics.strikeout_position();
+        assert!(
+            (strike_center - strike_expected).abs() <= 1.0,
+            "strikethrough center {strike_center} should be near {strike_expected}"
+        );
+        let under_center = (spans[2].0 + spans[2].1) / 2.0;
+        let under_expected = baseline_y - metrics.underline_position();
+        assert!(
+            (under_center - under_expected).abs() <= 1.0,
+            "underline center {under_center} should be near {under_expected}"
+        );
+        assert!(
+            spans[0].1 <= spans[1].0 && spans[1].1 <= spans[2].0,
+            "decoration bands should not overlap: {spans:?}"
+        );
     }
 }
 
@@ -3678,9 +3732,10 @@ fn decoration_rect_tracks_scaled_atlas_transform() {
     canvas.fill_text(40.0, baseline_y, "Scaled", &paint).unwrap();
     canvas.flush_to_output(());
 
-    let spans = recorded_decoration_spans(&commands.borrow(), &verts.borrow());
-    assert_eq!(spans.len(), 1, "expected one underline rect, got {spans:?}");
-    let (min_y, max_y) = spans[0];
+    let fills = recorded_decoration_fills(&commands.borrow(), &verts.borrow());
+    assert_eq!(fills.len(), 1, "expected exactly one decoration fill, got {fills:?}");
+    assert_eq!(fills[0].len(), 1, "expected exactly one underline rect, got {fills:?}");
+    let (min_y, max_y) = fills[0][0];
     let center = (min_y + max_y) / 2.0;
     // User-space underline center is baseline - underline_position; on screen the
     // whole thing is multiplied by the canvas scale.
@@ -3875,7 +3930,8 @@ fn decoration_metrics_fall_back_without_os2_and_post() {
         metrics.underline_position()
     );
 
-    // Drawing with the fallback font must not panic and must still emit the rects.
+    // Drawing with the fallback font must not panic and must still emit both
+    // rects, batched into the run's single decoration fill.
     let renderer = RecordingRenderer::default();
     let commands = renderer.last_commands.clone();
     let verts = renderer.last_verts.clone();
@@ -3891,10 +3947,11 @@ fn decoration_metrics_fall_back_without_os2_and_post() {
         .with_text_decoration_lines(true, true, false);
     canvas.fill_text(20.0, 100.0, "fallback", &paint).unwrap();
     canvas.flush_to_output(());
-    let spans = recorded_decoration_spans(&commands.borrow(), &verts.borrow());
+    let fills = recorded_decoration_fills(&commands.borrow(), &verts.borrow());
+    assert_eq!(fills.len(), 1, "expected exactly one decoration fill, got {fills:?}");
     assert_eq!(
-        spans.len(),
+        fills[0].len(),
         2,
-        "expected underline + strikethrough rects, got {spans:?}"
+        "expected underline + strikethrough rects in one fill, got {fills:?}"
     );
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,6 +60,7 @@ use geometry::*;
 
 mod paint;
 pub use paint::Paint;
+pub use paint::TextDecoration;
 use paint::{GlyphTexture, PaintFlavor, StrokeSettings};
 
 mod path;
@@ -1923,27 +1924,55 @@ where
             text::normalize_variations(&text_context, &paint.text.font_ids, &paint.text.font_variations)
         };
 
+        // Captured in scaled shaping space; decorations hang off it below.
+        let baseline_scaled = run_baseline(&layout.glyphs);
+
         // Draw the drop shadow (if any) under the text. The shaped layout gives a
         // user-space box; transform its corners by the CTM to obtain device-space
         // bounds and let render_shadow re-enter draw_text with the shadow tint.
-        // (render_shadow disables shadows in the state so this does not recurse.)
+        // The re-entered draw_text draws glyphs *and* decoration lines (with
+        // shadows suppressed), so a single shadow covers the whole painting
+        // operation, matching the drawing model — decorations are not shadowed
+        // separately. (render_shadow disables shadows in the state so this does
+        // not recurse.)
         if self.shadow_enabled() {
             // Layout metrics are in the scaled shaping space; bring them back to
-            // user space. The horizontal extent is derived from the union of the
-            // glyph boxes rather than the advance-summed layout width: negative
-            // letter spacing can collapse the summed width to zero while ink is
-            // still painted, and the shadow must cover everything that is drawn.
-            // Expand by the line height on all sides so bearings, overhang,
-            // ascenders, descenders and diacritics are fully covered.
+            // user space. The horizontal extent unions the glyph ink boxes with
+            // the run's advance box (layout.x .. layout.x + width): negative letter
+            // spacing can collapse the advance width while ink is still painted,
+            // yet the decoration lines are drawn across that advance box, so the
+            // shadow must cover both.
             let (mut gx0, mut gx1) = (f32::INFINITY, f32::NEG_INFINITY);
             for glyph in &layout.glyphs {
                 gx0 = gx0.min(glyph.x);
                 gx1 = gx1.max(glyph.x + glyph.width);
             }
-            let ly = layout.y * invscale;
-            let lh = layout.height() * invscale;
             let (ux0, uy0, ux1, uy1) = if gx0 <= gx1 {
-                (gx0 * invscale - lh, ly - lh, gx1 * invscale + lh, ly + lh + lh)
+                let rx0 = layout.x.min(layout.x + layout.width());
+                let rx1 = layout.x.max(layout.x + layout.width());
+                let x0 = (gx0 * invscale).min(rx0 * invscale);
+                let x1 = (gx1 * invscale).max(rx1 * invscale);
+                // The vertical extent is the font's line box (baseline - ascent ..
+                // baseline - descent), not the glyph ink box: the overline sits at
+                // the ascent and the underline below the baseline, so an ink-box
+                // extent clips the decoration shadows of short (x-height-only)
+                // runs like "www". Deriving it from the metrics covers glyphs,
+                // decorations, ascenders, descenders and diacritics alike.
+                let baseline = baseline_scaled.map_or(layout.y * invscale, |b| b * invscale);
+                let (ascent, descent) = {
+                    let text_context = self.text_context.borrow();
+                    text_context
+                        .measure_font(paint.text.font_size, &paint.text.font_ids, &paint.text.font_variations)
+                        .map_or((0.0, 0.0), |m| (m.ascender(), m.descender()))
+                };
+                // A little slack for the overline nudge and antialiased edges.
+                let margin = paint.text.font_size * 0.2;
+                (
+                    x0 - margin,
+                    baseline - ascent - margin,
+                    x1 + margin,
+                    baseline - descent + margin,
+                )
             } else {
                 // No drawable glyphs: nothing painted, nothing to shadow.
                 (0.0, 0.0, 0.0, 0.0)
@@ -2004,12 +2033,84 @@ where
             }
         }
 
+        layout.scale(invscale);
+
+        // Text decorations are an SVG/CSS extension (Canvas 2D has none). They are
+        // emitted as plain filled rectangles in user space — the same coordinate
+        // space as the `* invscale` glyph positions handed to `draw_glyph_run` —
+        // so `fill_path` runs them through the identical canvas transform the
+        // glyph runs use. That keeps the lines aligned with the glyphs across the
+        // direct-outline, atlas, and scale-baked-atlas paths alike.
+        //
+        // They are drawn while shadows are still suppressed: the run-level shadow
+        // pass above already rendered the decorations into its coverage (it
+        // re-enters draw_text, which draws them), so glyphs and decorations share
+        // a single shadow and the lines must not cast a second one.
+        if glyph_run_result.is_ok() && !paint.text.text_decoration.is_none() {
+            if let Some(baseline_scaled) = baseline_scaled {
+                self.draw_text_decorations(paint, baseline_scaled * invscale, layout.x, layout.width());
+            }
+        }
+
+        // Restore the shadow state on the success and error paths alike.
         self.state_mut().shadow_color = saved_shadow_color;
         glyph_run_result?;
 
-        layout.scale(invscale);
-
         Ok(layout)
+    }
+
+    /// Emits the enabled text-decoration lines for a run as filled rectangles in
+    /// user space. `baseline` is the run baseline (user space, +y down), `x` the
+    /// run's left edge, and `width` its advance width.
+    #[cfg(feature = "textlayout")]
+    fn draw_text_decorations(&mut self, paint: &Paint, baseline: f32, x: f32, width: f32) {
+        let decoration = paint.text.text_decoration;
+
+        // Metrics in user-space units (scaled for the unscaled font size) so the
+        // offsets match the user-space baseline. `measure_font` reads the primary
+        // font with the same variations the run was shaped with.
+        let metrics = {
+            let text_context = self.text_context.borrow();
+            text_context.measure_font(paint.text.font_size, &paint.text.font_ids, &paint.text.font_variations)
+        };
+        let Ok(metrics) = metrics else {
+            return;
+        };
+
+        // The decoration takes the text paint's color, matching SVG where the
+        // decoration uses the text fill. The full paint flavor (gradient/image)
+        // is reused as-is so a gradient-filled run gets a gradient-filled line.
+        let line_paint = paint.clone();
+
+        let emit = |this: &mut Self, center_y: f32, thickness: f32| {
+            let thickness = thickness.max(1.0);
+            let mut path = Path::new();
+            path.rect(x, center_y - thickness / 2.0, width, thickness);
+            this.fill_path(&path, &line_paint);
+        };
+
+        // OpenType position values measure from the baseline with +y pointing up,
+        // while canvas y grows downward, so a line's center is `baseline - pos`.
+        if decoration.underline {
+            emit(
+                self,
+                baseline - metrics.underline_position(),
+                metrics.underline_thickness(),
+            );
+        }
+        if decoration.strikethrough {
+            emit(
+                self,
+                baseline - metrics.strikeout_position(),
+                metrics.strikeout_thickness(),
+            );
+        }
+        if decoration.overline {
+            // No dedicated metric; sit the line at the ascent with the underline
+            // thickness, nudged up by half its thickness so it clears the glyphs.
+            let thickness = metrics.underline_thickness().max(1.0);
+            emit(self, baseline - metrics.ascender() - thickness / 2.0, thickness);
+        }
     }
 
     fn draw_glyph_run(
@@ -3355,4 +3456,349 @@ fn arc_tessellation_is_deterministic_across_threads() {
     for worker in workers {
         worker.join().unwrap();
     }
+}
+/// Collects the screen-space filled rectangles that text decoration emits.
+///
+/// A decoration line is a solid `ConvexFill` drawn to the screen with no glyph
+/// texture. (Atlas glyph rasterization also emits `ConvexFill`s, but those run
+/// while the render target is the atlas image, so tracking the active target
+/// discriminates them.) Returns the vertical `[min_y, max_y]` span of each such
+/// fill, in screen space.
+#[cfg(all(test, feature = "textlayout"))]
+fn recorded_decoration_spans(commands: &[renderer::Command], verts: &[renderer::Vertex]) -> Vec<(f32, f32)> {
+    use crate::paint::GlyphTexture;
+    use renderer::{CommandType, RenderTarget};
+
+    let mut target = RenderTarget::Screen;
+    let mut spans = Vec::new();
+
+    for cmd in commands {
+        match &cmd.cmd_type {
+            CommandType::SetRenderTarget(new_target) => target = *new_target,
+            CommandType::ConvexFill { .. }
+                if target == RenderTarget::Screen && matches!(cmd.glyph_texture, GlyphTexture::None) =>
+            {
+                let mut min_y = f32::INFINITY;
+                let mut max_y = f32::NEG_INFINITY;
+                for drawable in &cmd.drawables {
+                    if let Some((offset, len)) = drawable.fill_verts {
+                        for v in &verts[offset..offset + len] {
+                            min_y = min_y.min(v.y);
+                            max_y = max_y.max(v.y);
+                        }
+                    }
+                }
+                if min_y.is_finite() {
+                    spans.push((min_y, max_y));
+                }
+            }
+            _ => {}
+        }
+    }
+
+    spans
+}
+
+/// With a decoration enabled, `fill_text` emits exactly one extra solid rect per
+/// enabled line, positioned from the font's own metrics: underline below the
+/// baseline, strikethrough above it (through the text), overline near the ascent.
+/// With no decoration, no such rect is emitted.
+#[cfg(feature = "textlayout")]
+#[test]
+fn fill_text_emits_decoration_rects() {
+    let make_canvas = || {
+        let renderer = RecordingRenderer::default();
+        let commands = renderer.last_commands.clone();
+        let verts = renderer.last_verts.clone();
+        let mut canvas = Canvas::new(renderer).unwrap();
+        canvas.set_size(1000, 1000, 1.0);
+        let font = canvas
+            .add_font_mem(include_bytes!("../examples/assets/RobotoFlex-VariableFont.ttf"))
+            .expect("failed to load test font");
+        (canvas, commands, verts, font)
+    };
+
+    // Baseline::Alphabetic places the baseline exactly at the draw y, so the
+    // metric offsets are easy to reason about. A pure-translation transform keeps
+    // text on the cached-atlas path.
+    let baseline_y = 200.0_f32;
+
+    // Reference metrics for this font/size, in user space.
+    let metrics = {
+        let (canvas, _, _, font) = make_canvas();
+        let paint = Paint::color(Color::black()).with_font(&[font]).with_font_size(40.0);
+        canvas.measure_font(&paint).expect("metrics")
+    };
+    assert!(metrics.underline_thickness() > 0.0);
+    assert!(metrics.strikeout_thickness() > 0.0);
+
+    let base_paint = || {
+        Paint::color(Color::black())
+            .with_font_size(40.0)
+            .with_text_baseline(Baseline::Alphabetic)
+    };
+
+    // No decoration: no screen-space solid rects at all.
+    {
+        let (mut canvas, commands, verts, font) = make_canvas();
+        canvas
+            .fill_text(50.0, baseline_y, "Hello", &base_paint().with_font(&[font]))
+            .unwrap();
+        canvas.flush_to_output(());
+        let spans = recorded_decoration_spans(&commands.borrow(), &verts.borrow());
+        assert!(spans.is_empty(), "expected no decoration rect, got {spans:?}");
+    }
+
+    // Underline: one rect, centered below the baseline at -underline_position.
+    {
+        let (mut canvas, commands, verts, font) = make_canvas();
+        let paint = base_paint()
+            .with_font(&[font])
+            .with_text_decoration_lines(true, false, false);
+        canvas.fill_text(50.0, baseline_y, "Hello", &paint).unwrap();
+        canvas.flush_to_output(());
+        let spans = recorded_decoration_spans(&commands.borrow(), &verts.borrow());
+        assert_eq!(spans.len(), 1, "expected exactly one underline rect, got {spans:?}");
+        let (min_y, max_y) = spans[0];
+        let center = (min_y + max_y) / 2.0;
+        let expected = baseline_y - metrics.underline_position();
+        assert!(center > baseline_y, "underline should sit below the baseline");
+        assert!(
+            (center - expected).abs() <= 1.0,
+            "underline center {center} should be near {expected}"
+        );
+        assert!(
+            (max_y - min_y - metrics.underline_thickness()).abs() <= 1.0,
+            "underline thickness {} should be near {}",
+            max_y - min_y,
+            metrics.underline_thickness()
+        );
+    }
+
+    // Strikethrough: one rect, above the baseline at -strikeout_position.
+    {
+        let (mut canvas, commands, verts, font) = make_canvas();
+        let paint = base_paint()
+            .with_font(&[font])
+            .with_text_decoration_lines(false, true, false);
+        canvas.fill_text(50.0, baseline_y, "Hello", &paint).unwrap();
+        canvas.flush_to_output(());
+        let spans = recorded_decoration_spans(&commands.borrow(), &verts.borrow());
+        assert_eq!(spans.len(), 1, "expected exactly one strikethrough rect, got {spans:?}");
+        let (min_y, max_y) = spans[0];
+        let center = (min_y + max_y) / 2.0;
+        let expected = baseline_y - metrics.strikeout_position();
+        assert!(center < baseline_y, "strikethrough should sit above the baseline");
+        assert!(
+            (center - expected).abs() <= 1.0,
+            "strikethrough center {center} should be near {expected}"
+        );
+    }
+
+    // Overline: one rect, above the ascent.
+    {
+        let (mut canvas, commands, verts, font) = make_canvas();
+        let paint = base_paint()
+            .with_font(&[font])
+            .with_text_decoration_lines(false, false, true);
+        canvas.fill_text(50.0, baseline_y, "Hello", &paint).unwrap();
+        canvas.flush_to_output(());
+        let spans = recorded_decoration_spans(&commands.borrow(), &verts.borrow());
+        assert_eq!(spans.len(), 1, "expected exactly one overline rect, got {spans:?}");
+        let (_, max_y) = spans[0];
+        assert!(
+            max_y <= baseline_y - metrics.ascender() + 1.0,
+            "overline (bottom {max_y}) should sit at/above the ascent {}",
+            baseline_y - metrics.ascender()
+        );
+    }
+
+    // All three at once: three distinct rects.
+    {
+        let (mut canvas, commands, verts, font) = make_canvas();
+        let paint = base_paint()
+            .with_font(&[font])
+            .with_text_decoration_lines(true, true, true);
+        canvas.fill_text(50.0, baseline_y, "Hello", &paint).unwrap();
+        canvas.flush_to_output(());
+        let spans = recorded_decoration_spans(&commands.borrow(), &verts.borrow());
+        assert_eq!(spans.len(), 3, "expected three decoration rects, got {spans:?}");
+    }
+}
+
+/// Under a uniform-scale (scale-baked atlas) transform, the decoration rect must
+/// still line up with the glyphs: it is emitted in user space and run through the
+/// same canvas transform, so its screen-space center scales with the baseline.
+#[cfg(feature = "textlayout")]
+#[test]
+fn decoration_rect_tracks_scaled_atlas_transform() {
+    let renderer = RecordingRenderer::default();
+    let commands = renderer.last_commands.clone();
+    let verts = renderer.last_verts.clone();
+    let mut canvas = Canvas::new(renderer).unwrap();
+    canvas.set_size(2000, 2000, 1.0);
+    let font = canvas
+        .add_font_mem(include_bytes!("../examples/assets/RobotoFlex-VariableFont.ttf"))
+        .expect("failed to load test font");
+
+    let baseline_y = 150.0_f32;
+    let scale = 2.0_f32;
+
+    let metrics = {
+        let paint = Paint::color(Color::black()).with_font(&[font]).with_font_size(24.0);
+        canvas.measure_font(&paint).expect("metrics")
+    };
+
+    let paint = Paint::color(Color::black())
+        .with_font(&[font])
+        .with_font_size(24.0)
+        .with_text_baseline(Baseline::Alphabetic)
+        .with_text_decoration_lines(true, false, false);
+
+    canvas.scale(scale, scale);
+    canvas.fill_text(40.0, baseline_y, "Scaled", &paint).unwrap();
+    canvas.flush_to_output(());
+
+    let spans = recorded_decoration_spans(&commands.borrow(), &verts.borrow());
+    assert_eq!(spans.len(), 1, "expected one underline rect, got {spans:?}");
+    let (min_y, max_y) = spans[0];
+    let center = (min_y + max_y) / 2.0;
+    // User-space underline center is baseline - underline_position; on screen the
+    // whole thing is multiplied by the canvas scale.
+    let expected = (baseline_y - metrics.underline_position()) * scale;
+    assert!(
+        (center - expected).abs() <= 2.0,
+        "scaled underline center {center} should be near {expected}"
+    );
+}
+
+/// Rebuilds a sfnt/TrueType font byte buffer with the named 4-byte tables
+/// removed, so the fallback metric paths can be exercised on real assets.
+#[cfg(all(test, feature = "textlayout"))]
+fn font_without_tables(data: &[u8], drop_tags: &[&[u8; 4]]) -> Vec<u8> {
+    let read_u16 = |buf: &[u8], at: usize| u16::from_be_bytes([buf[at], buf[at + 1]]);
+    let read_u32 =
+        |buf: &[u8], at: usize| u32::from_be_bytes([buf[at], buf[at + 1], buf[at + 2], buf[at + 3]]) as usize;
+
+    let num_tables = read_u16(data, 4) as usize;
+
+    // Collect (tag, offset, length) for the tables we keep, in directory order.
+    let mut kept: Vec<([u8; 4], usize, usize)> = Vec::new();
+    for i in 0..num_tables {
+        let rec = 12 + i * 16;
+        let tag = [data[rec], data[rec + 1], data[rec + 2], data[rec + 3]];
+        if drop_tags.iter().any(|d| **d == tag) {
+            continue;
+        }
+        let offset = read_u32(data, rec + 8);
+        let length = read_u32(data, rec + 12);
+        kept.push((tag, offset, length));
+    }
+
+    let new_num = kept.len();
+    let mut out = Vec::new();
+    // Offset table header: keep the original sfnt version, fix up the table count
+    // and the binary-search hint fields for the new count.
+    out.extend_from_slice(&data[0..4]);
+    out.extend_from_slice(&(new_num as u16).to_be_bytes());
+    let max_pow2: u16 = 1 << (15 - (new_num.max(1) as u16).leading_zeros());
+    out.extend_from_slice(&(max_pow2 * 16).to_be_bytes());
+    out.extend_from_slice(&(15 - max_pow2.leading_zeros() as u16).to_be_bytes());
+    out.extend_from_slice(&((new_num as u16 * 16).wrapping_sub(max_pow2 * 16)).to_be_bytes());
+
+    let mut data_offset = 12 + new_num * 16;
+    let mut records = Vec::new();
+    let mut blobs = Vec::new();
+    for (tag, offset, length) in kept {
+        let padded = (length + 3) & !3;
+        let mut blob = data[offset..offset + length].to_vec();
+        blob.resize(padded, 0);
+        let mut rec = Vec::new();
+        rec.extend_from_slice(&tag);
+        rec.extend_from_slice(&0u32.to_be_bytes()); // checksum (ignored by ttf-parser)
+        rec.extend_from_slice(&(data_offset as u32).to_be_bytes());
+        rec.extend_from_slice(&(length as u32).to_be_bytes());
+        records.push(rec);
+        blobs.push(blob);
+        data_offset += padded;
+    }
+    for rec in records {
+        out.extend_from_slice(&rec);
+    }
+    for blob in blobs {
+        out.extend_from_slice(&blob);
+    }
+    out
+}
+
+/// A font without an OS/2 table (so no strikeout metric) and without a post
+/// table (so no underline metric) must still yield sensible, finite, positive
+/// decoration metrics via the ascender/descender-derived fallbacks — and never
+/// panic when drawing.
+#[cfg(feature = "textlayout")]
+#[test]
+fn decoration_metrics_fall_back_without_os2_and_post() {
+    let original = include_bytes!("../examples/assets/amiri-regular.ttf");
+
+    // Sanity: ttf-parser sees no strikeout/underline once the tables are gone.
+    let stripped = font_without_tables(original, &[b"OS/2", b"post"]);
+    let face = ttf_parser::Face::parse(&stripped, 0).expect("stripped font should still parse");
+    assert!(
+        face.strikeout_metrics().is_none(),
+        "OS/2 strikeout should be absent after stripping"
+    );
+    assert!(
+        face.underline_metrics().is_none(),
+        "post underline should be absent after stripping"
+    );
+
+    let text_context = TextContext::default();
+    let font_id = text_context.add_font_mem(&stripped).expect("stripped font should load");
+    let paint = Paint::default().with_font(&[font_id]).with_font_size(20.0);
+
+    let metrics = text_context.measure_font(&paint).expect("metrics");
+
+    assert!(
+        metrics.strikeout_thickness() > 0.0 && metrics.strikeout_thickness().is_finite(),
+        "fallback strikeout thickness must be positive and finite, got {}",
+        metrics.strikeout_thickness()
+    );
+    assert!(
+        metrics.strikeout_position() > 0.0 && metrics.strikeout_position().is_finite(),
+        "fallback strikeout should sit above the baseline, got {}",
+        metrics.strikeout_position()
+    );
+    assert!(
+        metrics.underline_thickness() > 0.0 && metrics.underline_thickness().is_finite(),
+        "fallback underline thickness must be positive and finite, got {}",
+        metrics.underline_thickness()
+    );
+    assert!(
+        metrics.underline_position() < 0.0 && metrics.underline_position().is_finite(),
+        "fallback underline should sit below the baseline, got {}",
+        metrics.underline_position()
+    );
+
+    // Drawing with the fallback font must not panic and must still emit the rects.
+    let renderer = RecordingRenderer::default();
+    let commands = renderer.last_commands.clone();
+    let verts = renderer.last_verts.clone();
+    let mut canvas = Canvas::new(renderer).unwrap();
+    canvas.set_size(1000, 1000, 1.0);
+    let font = canvas
+        .add_font_mem(&font_without_tables(original, &[b"OS/2", b"post"]))
+        .expect("stripped font should load into canvas");
+    let paint = Paint::color(Color::black())
+        .with_font(&[font])
+        .with_font_size(20.0)
+        .with_text_baseline(Baseline::Alphabetic)
+        .with_text_decoration_lines(true, true, false);
+    canvas.fill_text(20.0, 100.0, "fallback", &paint).unwrap();
+    canvas.flush_to_output(());
+    let spans = recorded_decoration_spans(&commands.borrow(), &verts.borrow());
+    assert_eq!(
+        spans.len(),
+        2,
+        "expected underline + strikethrough rects, got {spans:?}"
+    );
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -329,18 +329,36 @@ pub struct Canvas<T: Renderer> {
     shadow_images: Vec<ImageId>,
 }
 
-/// Returns the shared baseline of a shaped horizontal run, in shaping space, or
-/// `None` if the run has no drawable glyph.
+/// Returns the enabled text-decoration lines as `(offset, thickness)` pairs,
+/// where `offset` is the line center relative to the run baseline in +y-down
+/// user space. This is the single source of decoration geometry: the painter
+/// builds its rects from it and the shadow pass sizes its coverage box with it,
+/// so the two can never disagree.
 ///
-/// `layout` positions each glyph as
-/// `glyph.y = cursor_y + alignment_offset + glyph.offset_y`, so every glyph
-/// shares the same (possibly fractional) `cursor_y + alignment_offset` baseline
-/// and the per-glyph term is `glyph.offset_y` (the GPOS y-offset). Recovering the
-/// baseline as `glyph.y - glyph.offset_y` is what keeps text decorations anchored
-/// to the run baseline even when the first drawable glyph carries a non-zero
-/// offset (e.g. text starting with a combining mark), instead of riding that mark
-/// up or down.
+/// OpenType position values measure from the baseline with +y pointing up,
+/// while canvas y grows downward, so a line's center is the negated position.
+/// The overline has no dedicated metric; it sits at the ascent with the
+/// underline's thickness, nudged up by half that thickness so it clears the
+/// glyphs. Thicknesses are clamped to one user-space unit so lines stay
+/// visible for tiny fonts.
 #[cfg(feature = "textlayout")]
+fn decoration_lines(decoration: TextDecoration, metrics: &FontMetrics) -> impl Iterator<Item = (f32, f32)> {
+    let underline_thickness = metrics.underline_thickness().max(1.0);
+    [
+        decoration
+            .underline
+            .then(|| (-metrics.underline_position(), underline_thickness)),
+        decoration
+            .strikethrough
+            .then(|| (-metrics.strikeout_position(), metrics.strikeout_thickness().max(1.0))),
+        decoration
+            .overline
+            .then(|| (-metrics.ascender() - underline_thickness / 2.0, underline_thickness)),
+    ]
+    .into_iter()
+    .flatten()
+}
+
 impl<T> Canvas<T>
 where
     T: Renderer,
@@ -1940,6 +1958,17 @@ where
         // hang off the run only when it has at least one drawable glyph.
         let has_drawable_glyphs = layout.glyphs.iter().any(|shaped_glyph| !shaped_glyph.c.is_control());
 
+        // Font metrics for the run in user-space units, matching the user-space
+        // baseline. Fetched once (with the same variations the run was shaped
+        // with) and shared by the shadow-extent computation and the decoration
+        // painter below.
+        let run_font_metrics = {
+            let text_context = self.text_context.borrow();
+            text_context
+                .measure_font(paint.text.font_size, &paint.text.font_ids, &paint.text.font_variations)
+                .ok()
+        };
+
         // Draw the drop shadow (if any) under the text. The shaped layout gives a
         // user-space box; transform its corners by the CTM to obtain device-space
         // bounds and let render_shadow re-enter draw_text with the shadow tint.
@@ -1965,27 +1994,28 @@ where
                 let rx1 = layout.x.max(layout.x + layout.width());
                 let x0 = (gx0 * invscale).min(rx0 * invscale);
                 let x1 = (gx1 * invscale).max(rx1 * invscale);
-                // The vertical extent is the font's line box (baseline - ascent ..
-                // baseline - descent), not the glyph ink box: the overline sits at
-                // the ascent and the underline below the baseline, so an ink-box
-                // extent clips the decoration shadows of short (x-height-only)
-                // runs like "www". Deriving it from the metrics covers glyphs,
-                // decorations, ascenders, descenders and diacritics alike.
+                // The vertical extent starts from the font's line box (baseline -
+                // ascent .. baseline - descent), not the glyph ink box: an ink-box
+                // extent would clip the shadows of ascenders, descenders and
+                // diacritics on short (x-height-only) runs like "www". Any enabled
+                // decoration lines are unioned in through the same geometry the
+                // painter uses, so a line outside the line box (the nudged
+                // overline, a font with an unusual underline position) grows the
+                // box with it.
                 let baseline = layout.baseline() * invscale;
-                let (ascent, descent) = {
-                    let text_context = self.text_context.borrow();
-                    text_context
-                        .measure_font(paint.text.font_size, &paint.text.font_ids, &paint.text.font_variations)
-                        .map_or((0.0, 0.0), |m| (m.ascender(), m.descender()))
-                };
-                // A little slack for the overline nudge and antialiased edges.
+                let (ascent, descent) = run_font_metrics
+                    .as_ref()
+                    .map_or((0.0, 0.0), |m| (m.ascender(), m.descender()));
+                let (mut top, mut bottom) = (baseline - ascent, baseline - descent);
+                if let Some(metrics) = &run_font_metrics {
+                    for (offset, thickness) in decoration_lines(paint.text.text_decoration, metrics) {
+                        top = top.min(baseline + offset - thickness / 2.0);
+                        bottom = bottom.max(baseline + offset + thickness / 2.0);
+                    }
+                }
+                // A little slack for antialiased edges and blur reach.
                 let margin = paint.text.font_size * 0.2;
-                (
-                    x0 - margin,
-                    baseline - ascent - margin,
-                    x1 + margin,
-                    baseline - descent + margin,
-                )
+                (x0 - margin, top - margin, x1 + margin, bottom + margin)
             } else {
                 // No drawable glyphs: nothing painted, nothing to shadow.
                 (0.0, 0.0, 0.0, 0.0)
@@ -2060,7 +2090,9 @@ where
         // re-enters draw_text, which draws them), so glyphs and decorations share
         // a single shadow and the lines must not cast a second one.
         if glyph_run_result.is_ok() && !paint.text.text_decoration.is_none() && has_drawable_glyphs {
-            self.draw_text_decorations(paint, layout.baseline(), layout.x, layout.width());
+            if let Some(metrics) = &run_font_metrics {
+                self.draw_text_decorations(paint, metrics, layout.baseline(), layout.x, layout.width());
+            }
         }
 
         // Restore the shadow state on the success and error paths alike.
@@ -2072,9 +2104,10 @@ where
 
     /// Emits the enabled text-decoration lines for a run as filled rectangles in
     /// user space. `baseline` is the run baseline (user space, +y down), `x` the
-    /// run's left edge, and `width` its advance width.
+    /// run's left edge, and `width` its advance width. `metrics` is the run's
+    /// font metrics in the same user-space units as `baseline`.
     #[cfg(feature = "textlayout")]
-    fn draw_text_decorations(&mut self, paint: &Paint, baseline: f32, x: f32, width: f32) {
+    fn draw_text_decorations(&mut self, paint: &Paint, metrics: &FontMetrics, baseline: f32, x: f32, width: f32) {
         // NOTE: this assumes a horizontal writing mode. The lines run along the
         // advance direction (x) and are offset perpendicular to it (y), spanning
         // `[x, x + width]` at a baseline-relative y. That is correct for both LTR
@@ -2083,43 +2116,15 @@ where
         // along y and offset along x, driven by vertical metrics; the geometry
         // below would have to be generalized to the advance axis rather than
         // hardcoding x as the run axis.
-        let decoration = paint.text.text_decoration;
-
-        // Metrics in user-space units (scaled for the unscaled font size) so the
-        // offsets match the user-space baseline. `measure_font` reads the primary
-        // font with the same variations the run was shaped with.
-        let metrics = {
-            let text_context = self.text_context.borrow();
-            text_context.measure_font(paint.text.font_size, &paint.text.font_ids, &paint.text.font_variations)
-        };
-        let Ok(metrics) = metrics else {
-            return;
-        };
-
+        //
         // All enabled lines share one path (a single verbs/coords allocation) and
         // one fill_path call, so a run costs one draw no matter how many lines
         // are on. The rects are disjoint horizontal bands, and the paint below
         // forces NonZero filling, so any degenerate overlap (e.g. thickness
         // clamping on tiny fonts) still paints solid.
         let mut path = Path::new();
-        let mut add_line = |center_y: f32, thickness: f32| {
-            let thickness = thickness.max(1.0);
-            path.rect(x, center_y - thickness / 2.0, width, thickness);
-        };
-
-        // OpenType position values measure from the baseline with +y pointing up,
-        // while canvas y grows downward, so a line's center is `baseline - pos`.
-        if decoration.underline {
-            add_line(baseline - metrics.underline_position(), metrics.underline_thickness());
-        }
-        if decoration.strikethrough {
-            add_line(baseline - metrics.strikeout_position(), metrics.strikeout_thickness());
-        }
-        if decoration.overline {
-            // No dedicated metric; sit the line at the ascent with the underline
-            // thickness, nudged up by half its thickness so it clears the glyphs.
-            let thickness = metrics.underline_thickness().max(1.0);
-            add_line(baseline - metrics.ascender() - thickness / 2.0, thickness);
+        for (offset, thickness) in decoration_lines(paint.text.text_decoration, metrics) {
+            path.rect(x, baseline + offset - thickness / 2.0, width, thickness);
         }
 
         if path.is_empty() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -329,6 +329,25 @@ pub struct Canvas<T: Renderer> {
     shadow_images: Vec<ImageId>,
 }
 
+/// Returns the shared baseline of a shaped horizontal run, in shaping space, or
+/// `None` if the run has no drawable glyph.
+///
+/// `layout` positions each glyph as
+/// `glyph.y = cursor_y + alignment_offset + glyph.offset_y`, so every glyph
+/// shares the same (possibly fractional) `cursor_y + alignment_offset` baseline
+/// and the per-glyph term is `glyph.offset_y` (the GPOS y-offset). Recovering the
+/// baseline as `glyph.y - glyph.offset_y` is what keeps text decorations anchored
+/// to the run baseline even when the first drawable glyph carries a non-zero
+/// offset (e.g. text starting with a combining mark), instead of riding that mark
+/// up or down.
+#[cfg(feature = "textlayout")]
+fn run_baseline(glyphs: &[text::ShapedGlyph]) -> Option<f32> {
+    glyphs
+        .iter()
+        .find(|shaped_glyph| !shaped_glyph.c.is_control())
+        .map(|shaped_glyph| shaped_glyph.y - shaped_glyph.offset_y)
+}
+
 impl<T> Canvas<T>
 where
     T: Renderer,
@@ -3670,6 +3689,83 @@ fn decoration_rect_tracks_scaled_atlas_transform() {
         (center - expected).abs() <= 2.0,
         "scaled underline center {center} should be near {expected}"
     );
+}
+
+/// The decoration baseline must be the shared run baseline, independent of the
+/// first drawable glyph's GPOS y-offset. `layout` bakes that offset into
+/// `glyph.y`, so a run beginning with a combining mark (non-zero `offset_y`)
+/// would otherwise drag every decoration line up or down with the mark.
+///
+/// This unit-tests `run_baseline` — the exact policy `draw_text` uses to anchor
+/// decorations — with a synthetic run whose first glyph carries an `offset_y`.
+/// The captured baseline must match the run baseline computed without the offset
+/// (i.e. the second, zero-offset glyph's `y`), not the first glyph's shifted `y`.
+#[cfg(feature = "textlayout")]
+#[test]
+fn run_baseline_ignores_leading_glyph_offset() {
+    // A real FontId is needed to populate the synthetic glyphs; `run_baseline`
+    // never reads it, but ShapedGlyph requires one.
+    let text_context = TextContext::default();
+    let font_id = text_context
+        .add_font_mem(include_bytes!("../examples/assets/RobotoFlex-VariableFont.ttf"))
+        .expect("failed to load test font");
+
+    // The shared run baseline both glyphs are positioned against.
+    let run_y = 200.0_f32;
+
+    let make_glyph = |c: char, offset_y: f32| text::ShapedGlyph {
+        // `layout` stores `glyph.y = run_baseline + glyph.offset_y`; mirror that.
+        x: 0.0,
+        y: run_y + offset_y,
+        c,
+        byte_index: 0,
+        font_id,
+        glyph_id: 0,
+        width: 0.0,
+        height: 0.0,
+        advance_x: 0.0,
+        advance_y: 0.0,
+        offset_x: 0.0,
+        offset_y,
+    };
+
+    // First drawable glyph carries a large positive y-offset (a combining mark
+    // pushed below the baseline); the second sits exactly on the baseline.
+    let offset = 15.0_f32;
+    let with_offset = [make_glyph('a', offset), make_glyph('b', 0.0)];
+    // Same run, but the leading glyph has no offset.
+    let without_offset = [make_glyph('a', 0.0), make_glyph('b', 0.0)];
+
+    let captured = run_baseline(&with_offset).expect("run has a drawable glyph");
+    let reference = run_baseline(&without_offset).expect("run has a drawable glyph");
+
+    // The capture must equal the true run baseline, not the shifted first glyph.
+    assert_eq!(
+        captured, run_y,
+        "captured baseline {captured} should equal the shared run baseline {run_y}"
+    );
+    assert_eq!(
+        captured, reference,
+        "leading glyph offset must not shift the captured baseline ({captured} vs {reference})"
+    );
+    assert!(
+        (captured - with_offset[0].y).abs() > offset - 1.0,
+        "captured baseline {captured} must not follow the offset glyph y {}",
+        with_offset[0].y
+    );
+
+    // A leading control glyph (skipped by the drawable filter) must not become
+    // the baseline source either.
+    let with_control = [make_glyph('\n', 99.0), make_glyph('b', 0.0)];
+    assert_eq!(
+        run_baseline(&with_control),
+        Some(run_y),
+        "control glyphs must be skipped when capturing the baseline"
+    );
+
+    // Empty / all-control runs have no baseline.
+    assert_eq!(run_baseline(&[]), None);
+    assert_eq!(run_baseline(&[make_glyph('\t', 0.0)]), None);
 }
 
 /// Rebuilds a sfnt/TrueType font byte buffer with the named 4-byte tables

--- a/src/paint.rs
+++ b/src/paint.rs
@@ -380,6 +380,31 @@ impl Default for StrokeSettings {
     }
 }
 
+/// Set of text decoration lines (underline, strikethrough, overline) to draw
+/// along a text run.
+///
+/// This is an extension toward SVG/CSS `text-decoration` parity; the HTML
+/// Canvas 2D API has no equivalent. Lines combine additively, so any subset can
+/// be enabled at once. The decoration is drawn in the text paint's color.
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct TextDecoration {
+    /// Draw an underline below the baseline (from the font's `post` metrics).
+    pub underline: bool,
+    /// Draw a line through the middle of the text (from the font's OS/2 metrics).
+    pub strikethrough: bool,
+    /// Draw a line above the text, near the ascent.
+    pub overline: bool,
+}
+
+impl TextDecoration {
+    /// Returns `true` if no decoration line is enabled.
+    #[inline]
+    pub fn is_none(&self) -> bool {
+        !self.underline && !self.strikethrough && !self.overline
+    }
+}
+
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct TextSettings {
@@ -391,6 +416,7 @@ pub struct TextSettings {
     pub(crate) text_align: Align,
     #[cfg_attr(feature = "serde", serde(skip))]
     pub(crate) font_variations: FontVariations,
+    pub(crate) text_decoration: TextDecoration,
 }
 
 impl Default for TextSettings {
@@ -402,6 +428,7 @@ impl Default for TextSettings {
             text_baseline: Baseline::default(),
             text_align: Align::default(),
             font_variations: FontVariations::default(),
+            text_decoration: TextDecoration::default(),
         }
     }
 }
@@ -1055,6 +1082,45 @@ impl Paint {
     #[inline]
     pub fn with_text_align(mut self, align: Align) -> Self {
         self.set_text_align(align);
+        self
+    }
+
+    // --- Text decoration (underline / strikethrough / overline) ---
+
+    /// Returns the current set of text decoration lines for text operations.
+    #[inline]
+    pub fn text_decoration(&self) -> TextDecoration {
+        self.text.text_decoration
+    }
+
+    /// Sets the text decoration lines drawn along text runs.
+    ///
+    /// Decoration lines are drawn in the paint's color using the font's own
+    /// underline/strikeout metrics (overline is derived from the ascent). This
+    /// extends femtovg toward SVG/CSS `text-decoration`; Canvas 2D has no
+    /// equivalent.
+    #[inline]
+    pub fn set_text_decoration(&mut self, decoration: TextDecoration) {
+        self.text.text_decoration = decoration;
+    }
+
+    /// Returns the paint with the text decoration set to the specified value.
+    #[inline]
+    pub fn with_text_decoration(mut self, decoration: TextDecoration) -> Self {
+        self.set_text_decoration(decoration);
+        self
+    }
+
+    /// Returns the paint with underline/strikethrough/overline toggled.
+    ///
+    /// A convenience wrapper over [`with_text_decoration`](Self::with_text_decoration).
+    #[inline]
+    pub fn with_text_decoration_lines(mut self, underline: bool, strikethrough: bool, overline: bool) -> Self {
+        self.set_text_decoration(TextDecoration {
+            underline,
+            strikethrough,
+            overline,
+        });
         self
     }
 

--- a/src/paint.rs
+++ b/src/paint.rs
@@ -416,6 +416,9 @@ pub struct TextSettings {
     pub(crate) text_align: Align,
     #[cfg_attr(feature = "serde", serde(skip))]
     pub(crate) font_variations: FontVariations,
+    // Older serialized paints predate this field; default it so they keep
+    // deserializing. `TextDecoration::default()` is all-false, i.e. no decoration.
+    #[cfg_attr(feature = "serde", serde(default))]
     pub(crate) text_decoration: TextDecoration,
 }
 
@@ -1352,5 +1355,90 @@ mod tests {
         let paint = Paint::default().with_line_dash(&[0.0, 0.0]);
 
         assert_eq!(paint.line_dash(), &[0.0, 0.0]);
+    }
+}
+
+#[cfg(all(test, feature = "serde"))]
+mod serde_tests {
+    use super::*;
+
+    /// A paint serialized before `text_decoration` existed omits that field. With
+    /// `#[serde(default)]` the field must fall back to `TextDecoration::default()`
+    /// (no decoration) instead of failing to deserialize. This guards back-compat
+    /// with older serialized paints / configs.
+    #[test]
+    fn text_settings_deserializes_without_text_decoration() {
+        // Representation of a pre-`text_decoration` TextSettings: every serialized
+        // field except `text_decoration`. (`font_ids` / `font_variations` are
+        // `serde(skip)`, so they never appear.)
+        let json = r#"{
+            "font_size": 16.0,
+            "letter_spacing": 0.0,
+            "text_baseline": "Alphabetic",
+            "text_align": "Left"
+        }"#;
+
+        let settings: TextSettings = serde_json::from_str(json).expect("must deserialize without text_decoration");
+        assert_eq!(
+            settings.text_decoration,
+            TextDecoration::default(),
+            "missing text_decoration must default to TextDecoration::default()"
+        );
+        assert!(
+            settings.text_decoration.is_none(),
+            "the default decoration must enable no lines"
+        );
+    }
+
+    /// Same guarantee through the full `Paint`: a paint whose `text` block omits
+    /// `text_decoration` round-trips to the default (no) decoration.
+    #[test]
+    fn paint_deserializes_without_text_decoration() {
+        let json = r#"{
+            "flavor": { "Color": { "r": 1.0, "g": 1.0, "b": 1.0, "a": 1.0 } },
+            "shape_anti_alias": true,
+            "stroke": {
+                "stencil_strokes": true,
+                "miter_limit": 10.0,
+                "line_width": 1.0,
+                "line_cap_start": "Butt",
+                "line_cap_end": "Butt",
+                "line_join": "Miter",
+                "line_dash": [],
+                "line_dash_offset": 0.0
+            },
+            "text": {
+                "font_size": 16.0,
+                "letter_spacing": 0.0,
+                "text_baseline": "Alphabetic",
+                "text_align": "Left"
+            },
+            "fill_rule": "NonZero"
+        }"#;
+
+        let paint: Paint = serde_json::from_str(json).expect("Paint must deserialize without text_decoration");
+        assert_eq!(
+            paint.text.text_decoration,
+            TextDecoration::default(),
+            "missing text_decoration must default to TextDecoration::default()"
+        );
+    }
+
+    /// A present `text_decoration` still deserializes normally (the default does
+    /// not mask explicit values).
+    #[test]
+    fn text_settings_deserializes_with_text_decoration() {
+        let settings = TextSettings {
+            text_decoration: TextDecoration {
+                underline: true,
+                strikethrough: false,
+                overline: true,
+            },
+            ..TextSettings::default()
+        };
+
+        let json = serde_json::to_string(&settings).expect("serialize");
+        let restored: TextSettings = serde_json::from_str(&json).expect("round-trip");
+        assert_eq!(restored.text_decoration, settings.text_decoration);
     }
 }

--- a/src/paint.rs
+++ b/src/paint.rs
@@ -386,6 +386,31 @@ impl Default for StrokeSettings {
     }
 }
 
+/// Set of text decoration lines (underline, strikethrough, overline) to draw
+/// along a text run.
+///
+/// This is an extension toward SVG/CSS `text-decoration` parity; the HTML
+/// Canvas 2D API has no equivalent. Lines combine additively, so any subset can
+/// be enabled at once. The decoration is drawn in the text paint's color.
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct TextDecoration {
+    /// Draw an underline below the baseline (from the font's `post` metrics).
+    pub underline: bool,
+    /// Draw a line through the middle of the text (from the font's OS/2 metrics).
+    pub strikethrough: bool,
+    /// Draw a line above the text, near the ascent.
+    pub overline: bool,
+}
+
+impl TextDecoration {
+    /// Returns `true` if no decoration line is enabled.
+    #[inline]
+    pub fn is_none(&self) -> bool {
+        !self.underline && !self.strikethrough && !self.overline
+    }
+}
+
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct TextSettings {
@@ -397,6 +422,7 @@ pub struct TextSettings {
     pub(crate) text_align: Align,
     #[cfg_attr(feature = "serde", serde(skip))]
     pub(crate) font_variations: FontVariations,
+    pub(crate) text_decoration: TextDecoration,
 }
 
 impl Default for TextSettings {
@@ -408,6 +434,7 @@ impl Default for TextSettings {
             text_baseline: Baseline::default(),
             text_align: Align::default(),
             font_variations: FontVariations::default(),
+            text_decoration: TextDecoration::default(),
         }
     }
 }
@@ -1119,6 +1146,45 @@ impl Paint {
     #[inline]
     pub fn with_text_align(mut self, align: Align) -> Self {
         self.set_text_align(align);
+        self
+    }
+
+    // --- Text decoration (underline / strikethrough / overline) ---
+
+    /// Returns the current set of text decoration lines for text operations.
+    #[inline]
+    pub fn text_decoration(&self) -> TextDecoration {
+        self.text.text_decoration
+    }
+
+    /// Sets the text decoration lines drawn along text runs.
+    ///
+    /// Decoration lines are drawn in the paint's color using the font's own
+    /// underline/strikeout metrics (overline is derived from the ascent). This
+    /// extends femtovg toward SVG/CSS `text-decoration`; Canvas 2D has no
+    /// equivalent.
+    #[inline]
+    pub fn set_text_decoration(&mut self, decoration: TextDecoration) {
+        self.text.text_decoration = decoration;
+    }
+
+    /// Returns the paint with the text decoration set to the specified value.
+    #[inline]
+    pub fn with_text_decoration(mut self, decoration: TextDecoration) -> Self {
+        self.set_text_decoration(decoration);
+        self
+    }
+
+    /// Returns the paint with underline/strikethrough/overline toggled.
+    ///
+    /// A convenience wrapper over [`with_text_decoration`](Self::with_text_decoration).
+    #[inline]
+    pub fn with_text_decoration_lines(mut self, underline: bool, strikethrough: bool, overline: bool) -> Self {
+        self.set_text_decoration(TextDecoration {
+            underline,
+            strikethrough,
+            overline,
+        });
         self
     }
 

--- a/src/paint.rs
+++ b/src/paint.rs
@@ -1178,19 +1178,6 @@ impl Paint {
         self
     }
 
-    /// Returns the paint with underline/strikethrough/overline toggled.
-    ///
-    /// A convenience wrapper over [`with_text_decoration`](Self::with_text_decoration).
-    #[inline]
-    pub fn with_text_decoration_lines(mut self, underline: bool, strikethrough: bool, overline: bool) -> Self {
-        self.set_text_decoration(TextDecoration {
-            underline,
-            strikethrough,
-            overline,
-        });
-        self
-    }
-
     // --- Font weight (wght axis) ---
 
     /// Returns the current font weight override for variable fonts, in design space.

--- a/src/paint.rs
+++ b/src/paint.rs
@@ -422,6 +422,9 @@ pub struct TextSettings {
     pub(crate) text_align: Align,
     #[cfg_attr(feature = "serde", serde(skip))]
     pub(crate) font_variations: FontVariations,
+    // Older serialized paints predate this field; default it so they keep
+    // deserializing. `TextDecoration::default()` is all-false, i.e. no decoration.
+    #[cfg_attr(feature = "serde", serde(default))]
     pub(crate) text_decoration: TextDecoration,
 }
 
@@ -1500,5 +1503,90 @@ mod tests {
         // Finite angles must pass through untouched.
         let finite = Paint::conic_gradient_with_angle(10.0, 20.0, -1.25, Color::black(), Color::white());
         assert_eq!(start_angle_of(finite), -1.25);
+    }
+}
+
+#[cfg(all(test, feature = "serde"))]
+mod serde_tests {
+    use super::*;
+
+    /// A paint serialized before `text_decoration` existed omits that field. With
+    /// `#[serde(default)]` the field must fall back to `TextDecoration::default()`
+    /// (no decoration) instead of failing to deserialize. This guards back-compat
+    /// with older serialized paints / configs.
+    #[test]
+    fn text_settings_deserializes_without_text_decoration() {
+        // Representation of a pre-`text_decoration` TextSettings: every serialized
+        // field except `text_decoration`. (`font_ids` / `font_variations` are
+        // `serde(skip)`, so they never appear.)
+        let json = r#"{
+            "font_size": 16.0,
+            "letter_spacing": 0.0,
+            "text_baseline": "Alphabetic",
+            "text_align": "Left"
+        }"#;
+
+        let settings: TextSettings = serde_json::from_str(json).expect("must deserialize without text_decoration");
+        assert_eq!(
+            settings.text_decoration,
+            TextDecoration::default(),
+            "missing text_decoration must default to TextDecoration::default()"
+        );
+        assert!(
+            settings.text_decoration.is_none(),
+            "the default decoration must enable no lines"
+        );
+    }
+
+    /// Same guarantee through the full `Paint`: a paint whose `text` block omits
+    /// `text_decoration` round-trips to the default (no) decoration.
+    #[test]
+    fn paint_deserializes_without_text_decoration() {
+        let json = r#"{
+            "flavor": { "Color": { "r": 1.0, "g": 1.0, "b": 1.0, "a": 1.0 } },
+            "shape_anti_alias": true,
+            "stroke": {
+                "stencil_strokes": true,
+                "miter_limit": 10.0,
+                "line_width": 1.0,
+                "line_cap_start": "Butt",
+                "line_cap_end": "Butt",
+                "line_join": "Miter",
+                "line_dash": [],
+                "line_dash_offset": 0.0
+            },
+            "text": {
+                "font_size": 16.0,
+                "letter_spacing": 0.0,
+                "text_baseline": "Alphabetic",
+                "text_align": "Left"
+            },
+            "fill_rule": "NonZero"
+        }"#;
+
+        let paint: Paint = serde_json::from_str(json).expect("Paint must deserialize without text_decoration");
+        assert_eq!(
+            paint.text.text_decoration,
+            TextDecoration::default(),
+            "missing text_decoration must default to TextDecoration::default()"
+        );
+    }
+
+    /// A present `text_decoration` still deserializes normally (the default does
+    /// not mask explicit values).
+    #[test]
+    fn text_settings_deserializes_with_text_decoration() {
+        let settings = TextSettings {
+            text_decoration: TextDecoration {
+                underline: true,
+                strikethrough: false,
+                overline: true,
+            },
+            ..TextSettings::default()
+        };
+
+        let json = serde_json::to_string(&settings).expect("serialize");
+        let restored: TextSettings = serde_json::from_str(&json).expect("round-trip");
+        assert_eq!(restored.text_decoration, settings.text_decoration);
     }
 }

--- a/src/text/font.rs
+++ b/src/text/font.rs
@@ -65,7 +65,7 @@ pub enum GlyphRendering<'a> {
 #[derive(Copy, Clone, Default, Debug)]
 struct FontFlags(u8);
 
-// TODO: underline, strikeout, subscript, superscript metrics
+// TODO: subscript, superscript metrics
 impl FontFlags {
     fn new(regular: bool, italic: bool, bold: bool, oblique: bool, variable: bool) -> Self {
         let mut flags = 0;
@@ -119,6 +119,10 @@ pub struct FontMetrics {
     ascender: f32,
     descender: f32,
     height: f32,
+    underline_position: f32,
+    underline_thickness: f32,
+    strikeout_position: f32,
+    strikeout_thickness: f32,
     flags: FontFlags,
     weight: u16,
     width: u16,
@@ -129,6 +133,10 @@ impl FontMetrics {
         self.ascender *= scale;
         self.descender *= scale;
         self.height *= scale;
+        self.underline_position *= scale;
+        self.underline_thickness *= scale;
+        self.strikeout_position *= scale;
+        self.strikeout_thickness *= scale;
     }
 
     /// Returns the distance from the baseline to the top of the highest glyph.
@@ -144,6 +152,43 @@ impl FontMetrics {
     /// Returns the height of the font.
     pub fn height(&self) -> f32 {
         self.height.round()
+    }
+
+    /// Returns the position of the underline relative to the baseline.
+    ///
+    /// Follows the OpenType `post` table convention: the value is measured from
+    /// the baseline with the positive y-axis pointing up, so it is typically
+    /// negative (the underline sits below the baseline). Sourced from the font's
+    /// `post` table when present, otherwise derived from the descender.
+    pub fn underline_position(&self) -> f32 {
+        self.underline_position
+    }
+
+    /// Returns the thickness of the underline.
+    ///
+    /// Sourced from the font's `post` table when present, otherwise derived from
+    /// the font height.
+    pub fn underline_thickness(&self) -> f32 {
+        self.underline_thickness
+    }
+
+    /// Returns the position of the strikeout line relative to the baseline.
+    ///
+    /// Follows the OpenType OS/2 table convention: the value is measured from the
+    /// baseline with the positive y-axis pointing up, so it is typically positive
+    /// (the strikeout sits above the baseline, through the middle of the text).
+    /// Sourced from the font's OS/2 table when present, otherwise derived from the
+    /// ascender.
+    pub fn strikeout_position(&self) -> f32 {
+        self.strikeout_position
+    }
+
+    /// Returns the thickness of the strikeout line.
+    ///
+    /// Sourced from the font's OS/2 table when present, otherwise derived from the
+    /// font height.
+    pub fn strikeout_thickness(&self) -> f32 {
+        self.strikeout_thickness
     }
 
     /// Returns if the font is regular.
@@ -219,10 +264,26 @@ impl Font {
 
         let units_per_em = ttf_font.units_per_em();
 
+        let ascender = ttf_font.ascender() as f32;
+        let descender = ttf_font.descender() as f32;
+        // The `post`/OS-2 tables are optional. When absent, fall back to values
+        // derived from the ascender/descender so decorations still land sensibly:
+        //   * underline a little below the baseline (descender follows +y up, so
+        //     it is negative), at roughly 1/14 of the em as thickness.
+        //   * strikeout through the middle of the lowercase x-height region,
+        //     approximated as ~40% of the ascender above the baseline.
+        let default_thickness = units_per_em as f32 / 14.0;
+        let underline = ttf_font.underline_metrics();
+        let strikeout = ttf_font.strikeout_metrics();
+
         let metrics = FontMetrics {
-            ascender: ttf_font.ascender() as f32,
-            descender: ttf_font.descender() as f32,
+            ascender,
+            descender,
             height: ttf_font.height() as f32,
+            underline_position: underline.map_or(descender * 0.5, |m| m.position as f32),
+            underline_thickness: underline.map_or(default_thickness, |m| m.thickness as f32),
+            strikeout_position: strikeout.map_or(ascender * 0.4, |m| m.position as f32),
+            strikeout_thickness: strikeout.map_or(default_thickness, |m| m.thickness as f32),
             flags: FontFlags::new(
                 ttf_font.is_regular(),
                 ttf_font.is_italic(),
@@ -283,12 +344,35 @@ impl Font {
             _ => 5,
         };
 
+        // swash reports underline/strikeout offsets from the baseline with +y up
+        // (so underline_offset is typically negative), matching ttf-parser's
+        // post/OS-2 convention; stroke_size is shared by both decorations. Fall
+        // back to ascender/descender-derived values when the font omits them.
+        let default_thickness = units_per_em as f32 / 14.0;
+        let stroke_size = if swash_metrics.stroke_size > 0.0 {
+            swash_metrics.stroke_size
+        } else {
+            default_thickness
+        };
+
         let metrics = FontMetrics {
             ascender: swash_metrics.ascent,
             descender: -swash_metrics.descent,
             // swash ascent and descent are both positive (distance from baseline),
             // unlike ttf-parser where descent is negative, so this is a sum not a difference.
             height: swash_metrics.ascent + swash_metrics.descent + swash_metrics.leading,
+            underline_position: if swash_metrics.underline_offset != 0.0 {
+                swash_metrics.underline_offset
+            } else {
+                -swash_metrics.descent * 0.5
+            },
+            underline_thickness: stroke_size,
+            strikeout_position: if swash_metrics.strikeout_offset != 0.0 {
+                swash_metrics.strikeout_offset
+            } else {
+                swash_metrics.ascent * 0.4
+            },
+            strikeout_thickness: stroke_size,
             flags: FontFlags::new(is_regular, is_italic, is_bold, is_oblique, is_variable),
             weight,
             width,

--- a/src/text/font.rs
+++ b/src/text/font.rs
@@ -65,7 +65,6 @@ pub enum GlyphRendering<'a> {
 #[derive(Copy, Clone, Default, Debug)]
 struct FontFlags(u8);
 
-// TODO: subscript, superscript metrics
 impl FontFlags {
     fn new(regular: bool, italic: bool, bold: bool, oblique: bool, variable: bool) -> Self {
         let mut flags = 0;
@@ -113,6 +112,23 @@ impl FontFlags {
     }
 }
 
+/// Conventional typographic approximations used when a font does not provide
+/// the corresponding OS/2 value. Expressed as fractions of the em size and
+/// shared by both font-parsing backends so they agree on fallbacks.
+#[cfg(any(feature = "textlayout", feature = "swash"))]
+mod fallback {
+    /// Recommended sub/superscript glyph size: 65% of the em.
+    pub const SCRIPT_SIZE: f32 = 0.65;
+    /// Subscript baseline drop below the text baseline: 14% of the em.
+    pub const SUBSCRIPT_DROP: f32 = 0.14;
+    /// Superscript baseline rise above the text baseline: 48% of the em.
+    pub const SUPERSCRIPT_RISE: f32 = 0.48;
+    /// Height of a lowercase "x" above the baseline: half the em.
+    pub const X_HEIGHT: f32 = 0.5;
+    /// Height of an uppercase letter above the baseline: 70% of the em.
+    pub const CAP_HEIGHT: f32 = 0.7;
+}
+
 /// Information about a font.
 #[derive(Copy, Clone, Default, Debug)]
 pub struct FontMetrics {
@@ -123,6 +139,13 @@ pub struct FontMetrics {
     underline_thickness: f32,
     strikeout_position: f32,
     strikeout_thickness: f32,
+    subscript_size: (f32, f32),
+    subscript_offset: (f32, f32),
+    superscript_size: (f32, f32),
+    superscript_offset: (f32, f32),
+    x_height: f32,
+    cap_height: f32,
+    line_gap: f32,
     flags: FontFlags,
     weight: u16,
     width: u16,
@@ -137,6 +160,17 @@ impl FontMetrics {
         self.underline_thickness *= scale;
         self.strikeout_position *= scale;
         self.strikeout_thickness *= scale;
+        self.subscript_size.0 *= scale;
+        self.subscript_size.1 *= scale;
+        self.subscript_offset.0 *= scale;
+        self.subscript_offset.1 *= scale;
+        self.superscript_size.0 *= scale;
+        self.superscript_size.1 *= scale;
+        self.superscript_offset.0 *= scale;
+        self.superscript_offset.1 *= scale;
+        self.x_height *= scale;
+        self.cap_height *= scale;
+        self.line_gap *= scale;
     }
 
     /// Returns the distance from the baseline to the top of the highest glyph.
@@ -189,6 +223,88 @@ impl FontMetrics {
     /// font height.
     pub fn strikeout_thickness(&self) -> f32 {
         self.strikeout_thickness
+    }
+
+    /// Returns the recommended horizontal and vertical size for subscript text,
+    /// as an `(x, y)` pair.
+    ///
+    /// Sourced from the font's OS/2 table (`ySubscriptXSize`/`ySubscriptYSize`)
+    /// when present, otherwise both components fall back to 0.65 × the em size,
+    /// a conventional typographic approximation. Text layout engines can use
+    /// this as the font size for `vertical-align: sub` runs.
+    pub fn subscript_size(&self) -> (f32, f32) {
+        self.subscript_size
+    }
+
+    /// Returns the recommended offset from the text origin to the subscript
+    /// origin, as an `(x, y)` pair.
+    ///
+    /// Sourced from the font's OS/2 table (`ySubscriptXOffset`/`ySubscriptYOffset`)
+    /// when present, otherwise falls back to `(0, 0.14 × em)`, a conventional
+    /// typographic approximation. The y component follows the canvas convention
+    /// (+y points down): it is typically positive, dropping the subscript
+    /// baseline below the text baseline. This matches the raw OS/2 value, which
+    /// is also expressed positive-down, but note it differs from
+    /// [`Self::underline_position`], which keeps the +y-up `post` table
+    /// convention.
+    pub fn subscript_offset(&self) -> (f32, f32) {
+        self.subscript_offset
+    }
+
+    /// Returns the recommended horizontal and vertical size for superscript
+    /// text, as an `(x, y)` pair.
+    ///
+    /// Sourced from the font's OS/2 table (`ySuperscriptXSize`/`ySuperscriptYSize`)
+    /// when present, otherwise both components fall back to 0.65 × the em size,
+    /// a conventional typographic approximation. Text layout engines can use
+    /// this as the font size for `vertical-align: super` runs.
+    pub fn superscript_size(&self) -> (f32, f32) {
+        self.superscript_size
+    }
+
+    /// Returns the recommended offset from the text origin to the superscript
+    /// origin, as an `(x, y)` pair.
+    ///
+    /// Sourced from the font's OS/2 table (`ySuperscriptXOffset`/`ySuperscriptYOffset`)
+    /// when present, otherwise falls back to `(0, -0.48 × em)`, a conventional
+    /// typographic approximation. The y component follows the canvas convention
+    /// (+y points down): it is typically negative, raising the superscript
+    /// baseline above the text baseline. The raw OS/2 `ySuperscriptYOffset` is
+    /// expressed positive-up; it is negated here so both script offsets share
+    /// the same +y-down convention.
+    pub fn superscript_offset(&self) -> (f32, f32) {
+        self.superscript_offset
+    }
+
+    /// Returns the height of lowercase letters without ascenders or descenders
+    /// (the height of a lowercase "x") above the baseline.
+    ///
+    /// Sourced from the font's OS/2 table (`sxHeight`, version 2 and up) when
+    /// present, otherwise falls back to 0.5 × the em size, a conventional
+    /// typographic approximation. Useful for implementing the CSS `ex` unit.
+    pub fn x_height(&self) -> f32 {
+        self.x_height
+    }
+
+    /// Returns the height of uppercase letters (the height of a capital "H")
+    /// above the baseline.
+    ///
+    /// Sourced from the font's OS/2 table (`sCapHeight`, version 2 and up) when
+    /// present, otherwise falls back to 0.7 × the em size, a conventional
+    /// typographic approximation. Useful for implementing the CSS `cap` unit
+    /// and for small-caps synthesis.
+    pub fn cap_height(&self) -> f32 {
+        self.cap_height
+    }
+
+    /// Returns the recommended additional space between lines of text, beyond
+    /// ascender + descender.
+    ///
+    /// Sourced from the font's `hhea` table (or the OS/2 typographic line gap
+    /// when the font opts into typographic metrics via `USE_TYPO_METRICS`).
+    /// Many fonts legitimately report 0 here.
+    pub fn line_gap(&self) -> f32 {
+        self.line_gap
     }
 
     /// Returns if the font is regular.
@@ -272,9 +388,15 @@ impl Font {
         //     it is negative), at roughly 1/14 of the em as thickness.
         //   * strikeout through the middle of the lowercase x-height region,
         //     approximated as ~40% of the ascender above the baseline.
-        let default_thickness = units_per_em as f32 / 14.0;
+        // The typesetting metrics below fall back to the conventional fractions
+        // of the em size documented in the `fallback` module.
+        let em = units_per_em as f32;
+        let default_thickness = em / 14.0;
         let underline = ttf_font.underline_metrics();
         let strikeout = ttf_font.strikeout_metrics();
+        let subscript = ttf_font.subscript_metrics();
+        let superscript = ttf_font.superscript_metrics();
+        let fallback_script_size = (em * fallback::SCRIPT_SIZE, em * fallback::SCRIPT_SIZE);
 
         let metrics = FontMetrics {
             ascender,
@@ -284,6 +406,23 @@ impl Font {
             underline_thickness: underline.map_or(default_thickness, |m| m.thickness as f32),
             strikeout_position: strikeout.map_or(ascender * 0.4, |m| m.position as f32),
             strikeout_thickness: strikeout.map_or(default_thickness, |m| m.thickness as f32),
+            // The OS/2 script offsets are normalized to canvas +y-down
+            // semantics: `ySubscriptYOffset` is defined positive-down and
+            // passes through unchanged, while `ySuperscriptYOffset` is defined
+            // positive-up and is negated.
+            subscript_size: subscript.map_or(fallback_script_size, |m| (m.x_size as f32, m.y_size as f32)),
+            subscript_offset: subscript.map_or((0.0, em * fallback::SUBSCRIPT_DROP), |m| {
+                (m.x_offset as f32, m.y_offset as f32)
+            }),
+            superscript_size: superscript.map_or(fallback_script_size, |m| (m.x_size as f32, m.y_size as f32)),
+            superscript_offset: superscript.map_or((0.0, -(em * fallback::SUPERSCRIPT_RISE)), |m| {
+                (m.x_offset as f32, -(m.y_offset as f32))
+            }),
+            x_height: ttf_font.x_height().map_or(em * fallback::X_HEIGHT, |v| v as f32),
+            cap_height: ttf_font
+                .capital_height()
+                .map_or(em * fallback::CAP_HEIGHT, |v| v as f32),
+            line_gap: ttf_font.line_gap() as f32,
             flags: FontFlags::new(
                 ttf_font.is_regular(),
                 ttf_font.is_italic(),
@@ -348,12 +487,21 @@ impl Font {
         // (so underline_offset is typically negative), matching ttf-parser's
         // post/OS-2 convention; stroke_size is shared by both decorations. Fall
         // back to ascender/descender-derived values when the font omits them.
-        let default_thickness = units_per_em as f32 / 14.0;
+        let em = units_per_em as f32;
+        let default_thickness = em / 14.0;
         let stroke_size = if swash_metrics.stroke_size > 0.0 {
             swash_metrics.stroke_size
         } else {
             default_thickness
         };
+
+        // swash's `Metrics` does not surface the OS/2 sub/superscript metrics,
+        // so this backend always uses the conventional em-fraction fallbacks
+        // that the ttf-parser backend applies when a font omits them. x-height
+        // and cap-height are reported as 0 when the font lacks them, in which
+        // case the same fallbacks kick in, keeping both backends in agreement
+        // on availability.
+        let fallback_script_size = (em * fallback::SCRIPT_SIZE, em * fallback::SCRIPT_SIZE);
 
         let metrics = FontMetrics {
             ascender: swash_metrics.ascent,
@@ -373,6 +521,23 @@ impl Font {
                 swash_metrics.ascent * 0.4
             },
             strikeout_thickness: stroke_size,
+            subscript_size: fallback_script_size,
+            subscript_offset: (0.0, em * fallback::SUBSCRIPT_DROP),
+            superscript_size: fallback_script_size,
+            superscript_offset: (0.0, -(em * fallback::SUPERSCRIPT_RISE)),
+            x_height: if swash_metrics.x_height != 0.0 {
+                swash_metrics.x_height
+            } else {
+                em * fallback::X_HEIGHT
+            },
+            cap_height: if swash_metrics.cap_height != 0.0 {
+                swash_metrics.cap_height
+            } else {
+                em * fallback::CAP_HEIGHT
+            },
+            // swash's leading is the hhea line gap (or the OS/2 typographic
+            // line gap when the font opts into typographic metrics).
+            line_gap: swash_metrics.leading,
             flags: FontFlags::new(is_regular, is_italic, is_bold, is_oblique, is_variable),
             weight,
             width,
@@ -745,5 +910,167 @@ impl Font {
                 .ok()
                 .map(GlyphRendering::RenderAsPath)
         })
+    }
+}
+
+// These tests exercise whichever font-parsing backend the enabled features
+// select, so running them with `--features textlayout` and with
+// `--no-default-features --features swash` checks that both backends report
+// the same metrics availability.
+#[cfg(all(test, any(feature = "textlayout", feature = "swash")))]
+mod tests {
+    use super::Font;
+
+    fn parse_font(data: Vec<u8>) -> Font {
+        Font::new_with_data(data, 0, &super::super::TextContextImpl::default()).expect("font should parse")
+    }
+
+    /// Builds a minimal TrueType font containing only the tables required for
+    /// parsing (`head`, `hhea` and `maxp`), so every optional metric has to
+    /// take its documented fallback. Units per em is 1024 and the
+    /// ascender/descender are 800/-200 font units.
+    fn minimal_font_without_optional_tables() -> Vec<u8> {
+        fn push_u16(data: &mut Vec<u8>, value: u16) {
+            data.extend_from_slice(&value.to_be_bytes());
+        }
+        fn push_i16(data: &mut Vec<u8>, value: i16) {
+            data.extend_from_slice(&value.to_be_bytes());
+        }
+        fn push_u32(data: &mut Vec<u8>, value: u32) {
+            data.extend_from_slice(&value.to_be_bytes());
+        }
+
+        let mut head = Vec::new();
+        push_u16(&mut head, 1); // majorVersion
+        push_u16(&mut head, 0); // minorVersion
+        push_u32(&mut head, 0); // fontRevision
+        push_u32(&mut head, 0); // checkSumAdjustment
+        push_u32(&mut head, 0x5F0F_3CF5); // magicNumber
+        push_u16(&mut head, 0); // flags
+        push_u16(&mut head, 1024); // unitsPerEm
+        push_u32(&mut head, 0); // created (upper half)
+        push_u32(&mut head, 0); // created (lower half)
+        push_u32(&mut head, 0); // modified (upper half)
+        push_u32(&mut head, 0); // modified (lower half)
+        push_i16(&mut head, 0); // xMin
+        push_i16(&mut head, -200); // yMin
+        push_i16(&mut head, 500); // xMax
+        push_i16(&mut head, 800); // yMax
+        push_u16(&mut head, 0); // macStyle
+        push_u16(&mut head, 8); // lowestRecPPEM
+        push_i16(&mut head, 2); // fontDirectionHint
+        push_i16(&mut head, 0); // indexToLocFormat
+        push_i16(&mut head, 0); // glyphDataFormat
+
+        let mut hhea = Vec::new();
+        push_u16(&mut hhea, 1); // majorVersion
+        push_u16(&mut hhea, 0); // minorVersion
+        push_i16(&mut hhea, 800); // ascender
+        push_i16(&mut hhea, -200); // descender
+        push_i16(&mut hhea, 0); // lineGap
+        push_u16(&mut hhea, 500); // advanceWidthMax
+        push_i16(&mut hhea, 0); // minLeftSideBearing
+        push_i16(&mut hhea, 0); // minRightSideBearing
+        push_i16(&mut hhea, 500); // xMaxExtent
+        push_i16(&mut hhea, 1); // caretSlopeRise
+        push_i16(&mut hhea, 0); // caretSlopeRun
+        push_i16(&mut hhea, 0); // caretOffset
+        for _ in 0..4 {
+            push_i16(&mut hhea, 0); // reserved
+        }
+        push_i16(&mut hhea, 0); // metricDataFormat
+        push_u16(&mut hhea, 0); // numberOfHMetrics
+
+        let mut maxp = Vec::new();
+        push_u32(&mut maxp, 0x0000_5000); // version 0.5
+        push_u16(&mut maxp, 1); // numGlyphs
+
+        // Table records must be sorted by tag.
+        let tables: [(&[u8; 4], &Vec<u8>); 3] = [(b"head", &head), (b"hhea", &hhea), (b"maxp", &maxp)];
+
+        let mut font = Vec::new();
+        push_u32(&mut font, 0x0001_0000); // sfntVersion
+        push_u16(&mut font, tables.len() as u16); // numTables
+        push_u16(&mut font, 32); // searchRange
+        push_u16(&mut font, 1); // entrySelector
+        push_u16(&mut font, 16); // rangeShift
+
+        let header_len = 12 + 16 * tables.len();
+        let mut records = Vec::new();
+        let mut body: Vec<u8> = Vec::new();
+        for (tag, table) in tables {
+            records.extend_from_slice(&tag[..]);
+            push_u32(&mut records, 0); // checksum, not verified by the parsers
+            push_u32(&mut records, (header_len + body.len()) as u32);
+            push_u32(&mut records, table.len() as u32);
+            body.extend_from_slice(table);
+            while !body.len().is_multiple_of(4) {
+                body.push(0); // tables start on 4-byte boundaries
+            }
+        }
+        font.extend_from_slice(&records);
+        font.extend_from_slice(&body);
+        font
+    }
+
+    #[test]
+    fn missing_optional_tables_fall_back_to_documented_ratios() {
+        let font = parse_font(minimal_font_without_optional_tables());
+
+        // Half the 1024 units per em, so raw font units scale by exactly 0.5.
+        let em = 512.;
+        let metrics = font.metrics(em);
+
+        // Without an OS/2 table, every typesetting metric takes its documented
+        // fallback, expressed as a conventional fraction of the em size.
+        assert_eq!(metrics.x_height(), em * 0.5);
+        assert_eq!(metrics.cap_height(), em * 0.7);
+        assert_eq!(metrics.subscript_size(), (em * 0.65, em * 0.65));
+        assert_eq!(metrics.subscript_offset(), (0.0, em * 0.14));
+        assert_eq!(metrics.superscript_size(), (em * 0.65, em * 0.65));
+        assert_eq!(metrics.superscript_offset(), (0.0, -(em * 0.48)));
+        assert_eq!(metrics.line_gap(), 0.0);
+
+        // The underline/strikeout fallbacks engage as well, derived from the
+        // hhea ascender/descender of 800/-200 font units.
+        assert_eq!(metrics.underline_position(), -50.0); // half the descender
+        assert_eq!(metrics.strikeout_position(), 160.0); // 40% of the ascender
+        assert!(metrics.underline_thickness() > 0.0);
+        assert!(metrics.strikeout_thickness() > 0.0);
+    }
+
+    #[test]
+    fn real_font_typographic_metrics_are_plausible() {
+        let data = std::fs::read(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/examples/assets/RobotoFlex-VariableFont.ttf"
+        ))
+        .expect("Font not found");
+        let font = parse_font(data);
+
+        let em = 32.;
+        let metrics = font.metrics(em);
+
+        // The vertical extents are ordered: 0 < x-height < cap-height <= ascender.
+        assert!(metrics.x_height() > 0.0);
+        assert!(metrics.x_height() < metrics.cap_height());
+        assert!(metrics.cap_height() <= metrics.ascender());
+
+        // Sub/superscript glyphs are recommended at a readable fraction of the
+        // em, dropped below the baseline and raised above it respectively
+        // (canvas convention: +y points down).
+        for (size, offset) in [
+            (metrics.subscript_size(), metrics.subscript_offset()),
+            (metrics.superscript_size(), metrics.superscript_offset()),
+        ] {
+            assert!(size.0 > 0.0 && size.0 < em);
+            assert!(size.1 > 0.0 && size.1 < em);
+            assert!(offset.1 != 0.0);
+        }
+        assert!(metrics.subscript_offset().1 > 0.0);
+        assert!(metrics.superscript_offset().1 < 0.0);
+
+        // The hhea line gap is commonly zero, but never negative for this font.
+        assert!(metrics.line_gap() >= 0.0);
     }
 }

--- a/src/text/font.rs
+++ b/src/text/font.rs
@@ -272,6 +272,10 @@ impl Font {
         //     it is negative), at roughly 1/14 of the em as thickness.
         //   * strikeout through the middle of the lowercase x-height region,
         //     approximated as ~40% of the ascender above the baseline.
+        // A table that is present but holds a zero is treated like a missing
+        // table, matching the swash backend's `!= 0` checks: a zero position
+        // would draw the line on the baseline and a zero thickness would make
+        // it invisible, neither of which a font can mean.
         let default_thickness = units_per_em as f32 / 14.0;
         let underline = ttf_font.underline_metrics();
         let strikeout = ttf_font.strikeout_metrics();
@@ -280,10 +284,22 @@ impl Font {
             ascender,
             descender,
             height: ttf_font.height() as f32,
-            underline_position: underline.map_or(descender * 0.5, |m| m.position as f32),
-            underline_thickness: underline.map_or(default_thickness, |m| m.thickness as f32),
-            strikeout_position: strikeout.map_or(ascender * 0.4, |m| m.position as f32),
-            strikeout_thickness: strikeout.map_or(default_thickness, |m| m.thickness as f32),
+            underline_position: underline
+                .map(|m| m.position)
+                .filter(|&v| v != 0)
+                .map_or(descender * 0.5, |v| v as f32),
+            underline_thickness: underline
+                .map(|m| m.thickness)
+                .filter(|&v| v != 0)
+                .map_or(default_thickness, |v| v as f32),
+            strikeout_position: strikeout
+                .map(|m| m.position)
+                .filter(|&v| v != 0)
+                .map_or(ascender * 0.4, |v| v as f32),
+            strikeout_thickness: strikeout
+                .map(|m| m.thickness)
+                .filter(|&v| v != 0)
+                .map_or(default_thickness, |v| v as f32),
             flags: FontFlags::new(
                 ttf_font.is_regular(),
                 ttf_font.is_italic(),

--- a/src/text/font.rs
+++ b/src/text/font.rs
@@ -65,7 +65,6 @@ pub enum GlyphRendering<'a> {
 #[derive(Copy, Clone, Default, Debug)]
 struct FontFlags(u8);
 
-// TODO: subscript, superscript metrics
 impl FontFlags {
     fn new(regular: bool, italic: bool, bold: bool, oblique: bool, variable: bool) -> Self {
         let mut flags = 0;
@@ -113,6 +112,23 @@ impl FontFlags {
     }
 }
 
+/// Conventional typographic approximations used when a font does not provide
+/// the corresponding OS/2 value. Expressed as fractions of the em size and
+/// shared by both font-parsing backends so they agree on fallbacks.
+#[cfg(any(feature = "textlayout", feature = "swash"))]
+mod fallback {
+    /// Recommended sub/superscript glyph size: 65% of the em.
+    pub const SCRIPT_SIZE: f32 = 0.65;
+    /// Subscript baseline drop below the text baseline: 14% of the em.
+    pub const SUBSCRIPT_DROP: f32 = 0.14;
+    /// Superscript baseline rise above the text baseline: 48% of the em.
+    pub const SUPERSCRIPT_RISE: f32 = 0.48;
+    /// Height of a lowercase "x" above the baseline: half the em.
+    pub const X_HEIGHT: f32 = 0.5;
+    /// Height of an uppercase letter above the baseline: 70% of the em.
+    pub const CAP_HEIGHT: f32 = 0.7;
+}
+
 /// Information about a font.
 #[derive(Copy, Clone, Default, Debug)]
 pub struct FontMetrics {
@@ -123,6 +139,13 @@ pub struct FontMetrics {
     underline_thickness: f32,
     strikeout_position: f32,
     strikeout_thickness: f32,
+    subscript_size: (f32, f32),
+    subscript_offset: (f32, f32),
+    superscript_size: (f32, f32),
+    superscript_offset: (f32, f32),
+    x_height: f32,
+    cap_height: f32,
+    line_gap: f32,
     flags: FontFlags,
     weight: u16,
     width: u16,
@@ -137,6 +160,17 @@ impl FontMetrics {
         self.underline_thickness *= scale;
         self.strikeout_position *= scale;
         self.strikeout_thickness *= scale;
+        self.subscript_size.0 *= scale;
+        self.subscript_size.1 *= scale;
+        self.subscript_offset.0 *= scale;
+        self.subscript_offset.1 *= scale;
+        self.superscript_size.0 *= scale;
+        self.superscript_size.1 *= scale;
+        self.superscript_offset.0 *= scale;
+        self.superscript_offset.1 *= scale;
+        self.x_height *= scale;
+        self.cap_height *= scale;
+        self.line_gap *= scale;
     }
 
     /// Returns the distance from the baseline to the top of the highest glyph.
@@ -189,6 +223,88 @@ impl FontMetrics {
     /// font height.
     pub fn strikeout_thickness(&self) -> f32 {
         self.strikeout_thickness
+    }
+
+    /// Returns the recommended horizontal and vertical size for subscript text,
+    /// as an `(x, y)` pair.
+    ///
+    /// Sourced from the font's OS/2 table (`ySubscriptXSize`/`ySubscriptYSize`)
+    /// when present, otherwise both components fall back to 0.65 × the em size,
+    /// a conventional typographic approximation. Text layout engines can use
+    /// this as the font size for `vertical-align: sub` runs.
+    pub fn subscript_size(&self) -> (f32, f32) {
+        self.subscript_size
+    }
+
+    /// Returns the recommended offset from the text origin to the subscript
+    /// origin, as an `(x, y)` pair.
+    ///
+    /// Sourced from the font's OS/2 table (`ySubscriptXOffset`/`ySubscriptYOffset`)
+    /// when present, otherwise falls back to `(0, 0.14 × em)`, a conventional
+    /// typographic approximation. The y component follows the canvas convention
+    /// (+y points down): it is typically positive, dropping the subscript
+    /// baseline below the text baseline. This matches the raw OS/2 value, which
+    /// is also expressed positive-down, but note it differs from
+    /// [`Self::underline_position`], which keeps the +y-up `post` table
+    /// convention.
+    pub fn subscript_offset(&self) -> (f32, f32) {
+        self.subscript_offset
+    }
+
+    /// Returns the recommended horizontal and vertical size for superscript
+    /// text, as an `(x, y)` pair.
+    ///
+    /// Sourced from the font's OS/2 table (`ySuperscriptXSize`/`ySuperscriptYSize`)
+    /// when present, otherwise both components fall back to 0.65 × the em size,
+    /// a conventional typographic approximation. Text layout engines can use
+    /// this as the font size for `vertical-align: super` runs.
+    pub fn superscript_size(&self) -> (f32, f32) {
+        self.superscript_size
+    }
+
+    /// Returns the recommended offset from the text origin to the superscript
+    /// origin, as an `(x, y)` pair.
+    ///
+    /// Sourced from the font's OS/2 table (`ySuperscriptXOffset`/`ySuperscriptYOffset`)
+    /// when present, otherwise falls back to `(0, -0.48 × em)`, a conventional
+    /// typographic approximation. The y component follows the canvas convention
+    /// (+y points down): it is typically negative, raising the superscript
+    /// baseline above the text baseline. The raw OS/2 `ySuperscriptYOffset` is
+    /// expressed positive-up; it is negated here so both script offsets share
+    /// the same +y-down convention.
+    pub fn superscript_offset(&self) -> (f32, f32) {
+        self.superscript_offset
+    }
+
+    /// Returns the height of lowercase letters without ascenders or descenders
+    /// (the height of a lowercase "x") above the baseline.
+    ///
+    /// Sourced from the font's OS/2 table (`sxHeight`, version 2 and up) when
+    /// present, otherwise falls back to 0.5 × the em size, a conventional
+    /// typographic approximation. Useful for implementing the CSS `ex` unit.
+    pub fn x_height(&self) -> f32 {
+        self.x_height
+    }
+
+    /// Returns the height of uppercase letters (the height of a capital "H")
+    /// above the baseline.
+    ///
+    /// Sourced from the font's OS/2 table (`sCapHeight`, version 2 and up) when
+    /// present, otherwise falls back to 0.7 × the em size, a conventional
+    /// typographic approximation. Useful for implementing the CSS `cap` unit
+    /// and for small-caps synthesis.
+    pub fn cap_height(&self) -> f32 {
+        self.cap_height
+    }
+
+    /// Returns the recommended additional space between lines of text, beyond
+    /// ascender + descender.
+    ///
+    /// Sourced from the font's `hhea` table (or the OS/2 typographic line gap
+    /// when the font opts into typographic metrics via `USE_TYPO_METRICS`).
+    /// Many fonts legitimately report 0 here.
+    pub fn line_gap(&self) -> f32 {
+        self.line_gap
     }
 
     /// Returns if the font is regular.
@@ -272,13 +388,20 @@ impl Font {
         //     it is negative), at roughly 1/14 of the em as thickness.
         //   * strikeout through the middle of the lowercase x-height region,
         //     approximated as ~40% of the ascender above the baseline.
+        // The typesetting metrics below fall back to the conventional fractions
+        // of the em size documented in the `fallback` module.
         // A table that is present but holds a zero is treated like a missing
         // table, matching the swash backend's `!= 0` checks: a zero position
-        // would draw the line on the baseline and a zero thickness would make
-        // it invisible, neither of which a font can mean.
-        let default_thickness = units_per_em as f32 / 14.0;
+        // would draw the line on the baseline, a zero thickness would make it
+        // invisible, and a zero script size would typeset invisible sub- or
+        // superscript text, none of which a font can mean.
+        let em = units_per_em as f32;
+        let default_thickness = em / 14.0;
         let underline = ttf_font.underline_metrics();
         let strikeout = ttf_font.strikeout_metrics();
+        let subscript = ttf_font.subscript_metrics().filter(|m| m.x_size != 0 && m.y_size != 0);
+        let superscript = ttf_font.superscript_metrics().filter(|m| m.x_size != 0 && m.y_size != 0);
+        let fallback_script_size = (em * fallback::SCRIPT_SIZE, em * fallback::SCRIPT_SIZE);
 
         let metrics = FontMetrics {
             ascender,
@@ -300,6 +423,27 @@ impl Font {
                 .map(|m| m.thickness)
                 .filter(|&v| v != 0)
                 .map_or(default_thickness, |v| v as f32),
+            // The OS/2 script offsets are normalized to canvas +y-down
+            // semantics: `ySubscriptYOffset` is defined positive-down and
+            // passes through unchanged, while `ySuperscriptYOffset` is defined
+            // positive-up and is negated.
+            subscript_size: subscript.map_or(fallback_script_size, |m| (m.x_size as f32, m.y_size as f32)),
+            subscript_offset: subscript.map_or((0.0, em * fallback::SUBSCRIPT_DROP), |m| {
+                (m.x_offset as f32, m.y_offset as f32)
+            }),
+            superscript_size: superscript.map_or(fallback_script_size, |m| (m.x_size as f32, m.y_size as f32)),
+            superscript_offset: superscript.map_or((0.0, -(em * fallback::SUPERSCRIPT_RISE)), |m| {
+                (m.x_offset as f32, -(m.y_offset as f32))
+            }),
+            x_height: ttf_font
+                .x_height()
+                .filter(|&v| v != 0)
+                .map_or(em * fallback::X_HEIGHT, |v| v as f32),
+            cap_height: ttf_font
+                .capital_height()
+                .filter(|&v| v != 0)
+                .map_or(em * fallback::CAP_HEIGHT, |v| v as f32),
+            line_gap: ttf_font.line_gap() as f32,
             flags: FontFlags::new(
                 ttf_font.is_regular(),
                 ttf_font.is_italic(),
@@ -364,12 +508,21 @@ impl Font {
         // (so underline_offset is typically negative), matching ttf-parser's
         // post/OS-2 convention; stroke_size is shared by both decorations. Fall
         // back to ascender/descender-derived values when the font omits them.
-        let default_thickness = units_per_em as f32 / 14.0;
+        let em = units_per_em as f32;
+        let default_thickness = em / 14.0;
         let stroke_size = if swash_metrics.stroke_size > 0.0 {
             swash_metrics.stroke_size
         } else {
             default_thickness
         };
+
+        // swash's `Metrics` does not surface the OS/2 sub/superscript metrics,
+        // so this backend always uses the conventional em-fraction fallbacks
+        // that the ttf-parser backend applies when a font omits them. x-height
+        // and cap-height are reported as 0 when the font lacks them, in which
+        // case the same fallbacks kick in, keeping both backends in agreement
+        // on availability.
+        let fallback_script_size = (em * fallback::SCRIPT_SIZE, em * fallback::SCRIPT_SIZE);
 
         let metrics = FontMetrics {
             ascender: swash_metrics.ascent,
@@ -389,6 +542,23 @@ impl Font {
                 swash_metrics.ascent * 0.4
             },
             strikeout_thickness: stroke_size,
+            subscript_size: fallback_script_size,
+            subscript_offset: (0.0, em * fallback::SUBSCRIPT_DROP),
+            superscript_size: fallback_script_size,
+            superscript_offset: (0.0, -(em * fallback::SUPERSCRIPT_RISE)),
+            x_height: if swash_metrics.x_height != 0.0 {
+                swash_metrics.x_height
+            } else {
+                em * fallback::X_HEIGHT
+            },
+            cap_height: if swash_metrics.cap_height != 0.0 {
+                swash_metrics.cap_height
+            } else {
+                em * fallback::CAP_HEIGHT
+            },
+            // swash's leading is the hhea line gap (or the OS/2 typographic
+            // line gap when the font opts into typographic metrics).
+            line_gap: swash_metrics.leading,
             flags: FontFlags::new(is_regular, is_italic, is_bold, is_oblique, is_variable),
             weight,
             width,
@@ -761,5 +931,167 @@ impl Font {
                 .ok()
                 .map(GlyphRendering::RenderAsPath)
         })
+    }
+}
+
+// These tests exercise whichever font-parsing backend the enabled features
+// select, so running them with `--features textlayout` and with
+// `--no-default-features --features swash` checks that both backends report
+// the same metrics availability.
+#[cfg(all(test, any(feature = "textlayout", feature = "swash")))]
+mod tests {
+    use super::Font;
+
+    fn parse_font(data: Vec<u8>) -> Font {
+        Font::new_with_data(data, 0, &super::super::TextContextImpl::default()).expect("font should parse")
+    }
+
+    /// Builds a minimal TrueType font containing only the tables required for
+    /// parsing (`head`, `hhea` and `maxp`), so every optional metric has to
+    /// take its documented fallback. Units per em is 1024 and the
+    /// ascender/descender are 800/-200 font units.
+    fn minimal_font_without_optional_tables() -> Vec<u8> {
+        fn push_u16(data: &mut Vec<u8>, value: u16) {
+            data.extend_from_slice(&value.to_be_bytes());
+        }
+        fn push_i16(data: &mut Vec<u8>, value: i16) {
+            data.extend_from_slice(&value.to_be_bytes());
+        }
+        fn push_u32(data: &mut Vec<u8>, value: u32) {
+            data.extend_from_slice(&value.to_be_bytes());
+        }
+
+        let mut head = Vec::new();
+        push_u16(&mut head, 1); // majorVersion
+        push_u16(&mut head, 0); // minorVersion
+        push_u32(&mut head, 0); // fontRevision
+        push_u32(&mut head, 0); // checkSumAdjustment
+        push_u32(&mut head, 0x5F0F_3CF5); // magicNumber
+        push_u16(&mut head, 0); // flags
+        push_u16(&mut head, 1024); // unitsPerEm
+        push_u32(&mut head, 0); // created (upper half)
+        push_u32(&mut head, 0); // created (lower half)
+        push_u32(&mut head, 0); // modified (upper half)
+        push_u32(&mut head, 0); // modified (lower half)
+        push_i16(&mut head, 0); // xMin
+        push_i16(&mut head, -200); // yMin
+        push_i16(&mut head, 500); // xMax
+        push_i16(&mut head, 800); // yMax
+        push_u16(&mut head, 0); // macStyle
+        push_u16(&mut head, 8); // lowestRecPPEM
+        push_i16(&mut head, 2); // fontDirectionHint
+        push_i16(&mut head, 0); // indexToLocFormat
+        push_i16(&mut head, 0); // glyphDataFormat
+
+        let mut hhea = Vec::new();
+        push_u16(&mut hhea, 1); // majorVersion
+        push_u16(&mut hhea, 0); // minorVersion
+        push_i16(&mut hhea, 800); // ascender
+        push_i16(&mut hhea, -200); // descender
+        push_i16(&mut hhea, 0); // lineGap
+        push_u16(&mut hhea, 500); // advanceWidthMax
+        push_i16(&mut hhea, 0); // minLeftSideBearing
+        push_i16(&mut hhea, 0); // minRightSideBearing
+        push_i16(&mut hhea, 500); // xMaxExtent
+        push_i16(&mut hhea, 1); // caretSlopeRise
+        push_i16(&mut hhea, 0); // caretSlopeRun
+        push_i16(&mut hhea, 0); // caretOffset
+        for _ in 0..4 {
+            push_i16(&mut hhea, 0); // reserved
+        }
+        push_i16(&mut hhea, 0); // metricDataFormat
+        push_u16(&mut hhea, 0); // numberOfHMetrics
+
+        let mut maxp = Vec::new();
+        push_u32(&mut maxp, 0x0000_5000); // version 0.5
+        push_u16(&mut maxp, 1); // numGlyphs
+
+        // Table records must be sorted by tag.
+        let tables: [(&[u8; 4], &Vec<u8>); 3] = [(b"head", &head), (b"hhea", &hhea), (b"maxp", &maxp)];
+
+        let mut font = Vec::new();
+        push_u32(&mut font, 0x0001_0000); // sfntVersion
+        push_u16(&mut font, tables.len() as u16); // numTables
+        push_u16(&mut font, 32); // searchRange
+        push_u16(&mut font, 1); // entrySelector
+        push_u16(&mut font, 16); // rangeShift
+
+        let header_len = 12 + 16 * tables.len();
+        let mut records = Vec::new();
+        let mut body: Vec<u8> = Vec::new();
+        for (tag, table) in tables {
+            records.extend_from_slice(&tag[..]);
+            push_u32(&mut records, 0); // checksum, not verified by the parsers
+            push_u32(&mut records, (header_len + body.len()) as u32);
+            push_u32(&mut records, table.len() as u32);
+            body.extend_from_slice(table);
+            while !body.len().is_multiple_of(4) {
+                body.push(0); // tables start on 4-byte boundaries
+            }
+        }
+        font.extend_from_slice(&records);
+        font.extend_from_slice(&body);
+        font
+    }
+
+    #[test]
+    fn missing_optional_tables_fall_back_to_documented_ratios() {
+        let font = parse_font(minimal_font_without_optional_tables());
+
+        // Half the 1024 units per em, so raw font units scale by exactly 0.5.
+        let em = 512.;
+        let metrics = font.metrics(em);
+
+        // Without an OS/2 table, every typesetting metric takes its documented
+        // fallback, expressed as a conventional fraction of the em size.
+        assert_eq!(metrics.x_height(), em * 0.5);
+        assert_eq!(metrics.cap_height(), em * 0.7);
+        assert_eq!(metrics.subscript_size(), (em * 0.65, em * 0.65));
+        assert_eq!(metrics.subscript_offset(), (0.0, em * 0.14));
+        assert_eq!(metrics.superscript_size(), (em * 0.65, em * 0.65));
+        assert_eq!(metrics.superscript_offset(), (0.0, -(em * 0.48)));
+        assert_eq!(metrics.line_gap(), 0.0);
+
+        // The underline/strikeout fallbacks engage as well, derived from the
+        // hhea ascender/descender of 800/-200 font units.
+        assert_eq!(metrics.underline_position(), -50.0); // half the descender
+        assert_eq!(metrics.strikeout_position(), 160.0); // 40% of the ascender
+        assert!(metrics.underline_thickness() > 0.0);
+        assert!(metrics.strikeout_thickness() > 0.0);
+    }
+
+    #[test]
+    fn real_font_typographic_metrics_are_plausible() {
+        let data = std::fs::read(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/examples/assets/RobotoFlex-VariableFont.ttf"
+        ))
+        .expect("Font not found");
+        let font = parse_font(data);
+
+        let em = 32.;
+        let metrics = font.metrics(em);
+
+        // The vertical extents are ordered: 0 < x-height < cap-height <= ascender.
+        assert!(metrics.x_height() > 0.0);
+        assert!(metrics.x_height() < metrics.cap_height());
+        assert!(metrics.cap_height() <= metrics.ascender());
+
+        // Sub/superscript glyphs are recommended at a readable fraction of the
+        // em, dropped below the baseline and raised above it respectively
+        // (canvas convention: +y points down).
+        for (size, offset) in [
+            (metrics.subscript_size(), metrics.subscript_offset()),
+            (metrics.superscript_size(), metrics.superscript_offset()),
+        ] {
+            assert!(size.0 > 0.0 && size.0 < em);
+            assert!(size.1 > 0.0 && size.1 < em);
+            assert!(offset.1 != 0.0);
+        }
+        assert!(metrics.subscript_offset().1 > 0.0);
+        assert!(metrics.superscript_offset().1 < 0.0);
+
+        // The hhea line gap is commonly zero, but never negative for this font.
+        assert!(metrics.line_gap() >= 0.0);
     }
 }

--- a/src/text/font.rs
+++ b/src/text/font.rs
@@ -400,7 +400,9 @@ impl Font {
         let underline = ttf_font.underline_metrics();
         let strikeout = ttf_font.strikeout_metrics();
         let subscript = ttf_font.subscript_metrics().filter(|m| m.x_size != 0 && m.y_size != 0);
-        let superscript = ttf_font.superscript_metrics().filter(|m| m.x_size != 0 && m.y_size != 0);
+        let superscript = ttf_font
+            .superscript_metrics()
+            .filter(|m| m.x_size != 0 && m.y_size != 0);
         let fallback_script_size = (em * fallback::SCRIPT_SIZE, em * fallback::SCRIPT_SIZE);
 
         let metrics = FontMetrics {

--- a/src/text/textlayout.rs
+++ b/src/text/textlayout.rs
@@ -181,6 +181,7 @@ pub struct TextMetrics {
     pub y: f32,
     width: f32,
     height: f32,
+    baseline: f32,
     /// Vector of shaped glyphs resulting from the text shaping run.
     pub glyphs: Vec<ShapedGlyph>,
     pub(crate) final_byte_index: usize,
@@ -192,6 +193,7 @@ impl TextMetrics {
         self.y *= scale;
         self.width *= scale;
         self.height *= scale;
+        self.baseline *= scale;
 
         for glyph in &mut self.glyphs {
             glyph.x *= scale;
@@ -204,6 +206,14 @@ impl TextMetrics {
     /// width of the glyphs as drawn
     pub fn width(&self) -> f32 {
         self.width
+    }
+
+    /// Y-coordinate of the run's alphabetic baseline, in the same space as the
+    /// glyph positions: the requested `y` adjusted for the paint's
+    /// [`Baseline`](crate::Baseline) setting. Glyphs and text decorations are
+    /// positioned relative to this line.
+    pub fn baseline(&self) -> f32 {
+        self.baseline
     }
 
     /// height of the glyphs as drawn
@@ -267,6 +277,7 @@ fn shape_run(
         y: 0.0,
         width: 0.0,
         height: 0.0,
+        baseline: 0.0,
         glyphs: Vec::with_capacity(text.len()),
         final_byte_index: 0,
     };
@@ -539,6 +550,11 @@ fn layout(
         Baseline::Alphabetic => 0.0,
         Baseline::Bottom => descender,
     };
+
+    // Record where the alphabetic baseline lands so consumers (glyph drawing,
+    // text decorations) need not re-derive it from glyph positions, which
+    // would be skewed by per-glyph y-offsets such as combining marks.
+    res.baseline = cursor_y + alignment_offset_y;
 
     for glyph in &mut res.glyphs {
         glyph.x = cursor_x + glyph.offset_x;

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -295,16 +295,35 @@ fn font_metrics_report_typographic_metrics() {
     }
 
     // Canvas convention: +y points down, so subscripts drop below the baseline
-    // (positive) and superscripts rise above it (negative).
+    // (positive) and superscripts rise above it (negative). Beyond the sign, the
+    // recommended offset places the raised/lowered glyph within the font's own
+    // vertical envelope: a superscript typeset at its recommended size lifts its
+    // cap above the base x-height (so it reads as raised) yet stays within the
+    // ascent, and a subscript drops within the descent depth. This guards the
+    // sign normalization (the superscript y is negated from the raw OS/2 value)
+    // against a regression that swapped or mis-scaled the offsets.
+    let ascent = metrics.ascender();
+    let descent = metrics.descender().abs();
+
+    let sup_rise = -metrics.superscript_offset().1;
+    // Cap-height scaled down to the recommended superscript size, matching the
+    // space the rendered superscript glyph occupies.
+    let sup_cap = metrics.cap_height() * metrics.superscript_size().1 / font_size;
     assert!(
-        metrics.subscript_offset().1 > 0.0,
-        "subscript offset should point down, got {}",
-        metrics.subscript_offset().1
+        sup_rise > 0.0 && sup_rise < ascent,
+        "superscript rise ({sup_rise}) should lift within the ascent (0, {ascent})"
     );
     assert!(
-        metrics.superscript_offset().1 < 0.0,
-        "superscript offset should point up, got {}",
-        metrics.superscript_offset().1
+        sup_rise + sup_cap > metrics.x_height(),
+        "superscript cap top ({}) should clear the base x-height ({})",
+        sup_rise + sup_cap,
+        metrics.x_height()
+    );
+
+    let sub_drop = metrics.subscript_offset().1;
+    assert!(
+        sub_drop > 0.0 && sub_drop <= descent,
+        "subscript drop ({sub_drop}) should fall within the descent (0, {descent}]"
     );
 
     // The hhea line gap is commonly zero, but never negative for this font.

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -204,6 +204,46 @@ fn text_layout_preserves_fractional_baseline_y() {
 }
 
 #[test]
+fn font_metrics_report_underline_and_strikeout() {
+    let text_context = femtovg::TextContext::default();
+
+    let font_id = text_context
+        .add_font_file("examples/assets/RobotoFlex-VariableFont.ttf")
+        .expect("Font not found");
+
+    let test_paint = femtovg::Paint::default().with_font(&[font_id]).with_font_size(32.);
+
+    let metrics = text_context
+        .measure_font(&test_paint)
+        .expect("font measuring failed unexpectedly");
+
+    // Roboto Flex ships post + OS/2 tables, so these are read straight from the
+    // font rather than from a fallback.
+    assert!(
+        metrics.underline_thickness() > 0.0,
+        "underline thickness should be positive, got {}",
+        metrics.underline_thickness()
+    );
+    assert!(
+        metrics.strikeout_thickness() > 0.0,
+        "strikeout thickness should be positive, got {}",
+        metrics.strikeout_thickness()
+    );
+    // OpenType convention: +y up from the baseline. The underline sits below the
+    // baseline (negative) and the strikeout above it (positive, through the text).
+    assert!(
+        metrics.underline_position() < 0.0,
+        "underline should sit below the baseline, got {}",
+        metrics.underline_position()
+    );
+    assert!(
+        metrics.strikeout_position() > 0.0,
+        "strikeout should sit above the baseline, got {}",
+        metrics.strikeout_position()
+    );
+}
+
+#[test]
 fn font_measure_without_canvas() {
     let text_context = femtovg::TextContext::default();
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -244,6 +244,140 @@ fn font_metrics_report_underline_and_strikeout() {
 }
 
 #[test]
+fn font_metrics_report_typographic_metrics() {
+    let text_context = femtovg::TextContext::default();
+
+    let font_id = text_context
+        .add_font_file("examples/assets/RobotoFlex-VariableFont.ttf")
+        .expect("Font not found");
+
+    let font_size = 32.;
+    let test_paint = femtovg::Paint::default()
+        .with_font(&[font_id])
+        .with_font_size(font_size);
+
+    let metrics = text_context
+        .measure_font(&test_paint)
+        .expect("font measuring failed unexpectedly");
+
+    // The vertical extents are ordered: 0 < x-height < cap-height <= ascender.
+    assert!(
+        metrics.x_height() > 0.0,
+        "x-height should be positive, got {}",
+        metrics.x_height()
+    );
+    assert!(
+        metrics.x_height() < metrics.cap_height(),
+        "x-height ({}) should be below the cap-height ({})",
+        metrics.x_height(),
+        metrics.cap_height()
+    );
+    assert!(
+        metrics.cap_height() <= metrics.ascender(),
+        "cap-height ({}) should not exceed the ascender ({})",
+        metrics.cap_height(),
+        metrics.ascender()
+    );
+
+    // Sub/superscript glyphs are recommended at a readable fraction of the em.
+    for (label, (x_size, y_size)) in [
+        ("subscript", metrics.subscript_size()),
+        ("superscript", metrics.superscript_size()),
+    ] {
+        assert!(
+            x_size > 0.0 && x_size < font_size,
+            "{label} x size should be within (0, em), got {x_size}"
+        );
+        assert!(
+            y_size > 0.0 && y_size < font_size,
+            "{label} y size should be within (0, em), got {y_size}"
+        );
+    }
+
+    // Canvas convention: +y points down, so subscripts drop below the baseline
+    // (positive) and superscripts rise above it (negative).
+    assert!(
+        metrics.subscript_offset().1 > 0.0,
+        "subscript offset should point down, got {}",
+        metrics.subscript_offset().1
+    );
+    assert!(
+        metrics.superscript_offset().1 < 0.0,
+        "superscript offset should point up, got {}",
+        metrics.superscript_offset().1
+    );
+
+    // The hhea line gap is commonly zero, but never negative for this font.
+    assert!(
+        metrics.line_gap() >= 0.0,
+        "line gap should not be negative, got {}",
+        metrics.line_gap()
+    );
+}
+
+#[test]
+fn font_metrics_scale_linearly_with_font_size() {
+    let text_context = femtovg::TextContext::default();
+
+    let font_id = text_context
+        .add_font_file("examples/assets/RobotoFlex-VariableFont.ttf")
+        .expect("Font not found");
+
+    let paint = femtovg::Paint::default().with_font(&[font_id]);
+    let small = text_context
+        .measure_font(&paint.clone().with_font_size(20.))
+        .expect("font measuring failed unexpectedly");
+    let large = text_context
+        .measure_font(&paint.with_font_size(40.))
+        .expect("font measuring failed unexpectedly");
+
+    let halves = [
+        ("x-height", small.x_height(), large.x_height()),
+        ("cap-height", small.cap_height(), large.cap_height()),
+        ("line gap", small.line_gap(), large.line_gap()),
+        ("subscript x size", small.subscript_size().0, large.subscript_size().0),
+        ("subscript y size", small.subscript_size().1, large.subscript_size().1),
+        (
+            "subscript x offset",
+            small.subscript_offset().0,
+            large.subscript_offset().0,
+        ),
+        (
+            "subscript y offset",
+            small.subscript_offset().1,
+            large.subscript_offset().1,
+        ),
+        (
+            "superscript x size",
+            small.superscript_size().0,
+            large.superscript_size().0,
+        ),
+        (
+            "superscript y size",
+            small.superscript_size().1,
+            large.superscript_size().1,
+        ),
+        (
+            "superscript x offset",
+            small.superscript_offset().0,
+            large.superscript_offset().0,
+        ),
+        (
+            "superscript y offset",
+            small.superscript_offset().1,
+            large.superscript_offset().1,
+        ),
+    ];
+    for (label, at_20, at_40) in halves {
+        assert_eq!(
+            at_20 * 2.0,
+            at_40,
+            "{label} at font size 20 should be exactly half of its value at 40"
+        );
+    }
+}
+
+#[test]
 fn font_measure_without_canvas() {
     let text_context = femtovg::TextContext::default();
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -869,3 +869,49 @@ fn conic_gradient_start_angle_matches_canvas_convention() {
         "with start_angle=PI/2, offset-0.875 must be blue; got {down_right:?}"
     );
 }
+
+#[test]
+fn zeroed_os2_script_metrics_fall_back() {
+    // A present OS/2 table whose sub/superscript sizes are zero cannot mean
+    // "typeset script text at zero size"; it gets the same conventional
+    // fallbacks as a missing table. Patch the font bytes so the table is
+    // present but zeroed, which is what some minimal or broken fonts ship.
+    let mut data = std::fs::read("examples/assets/RobotoFlex-VariableFont.ttf").expect("Font not found");
+
+    // sfnt: numTables at 4, table records from 12, each 16 bytes of
+    // tag/checksum/offset/length. ttf-parser does not re-verify checksums.
+    let num_tables = u16::from_be_bytes([data[4], data[5]]) as usize;
+    let os2_offset = (0..num_tables)
+        .map(|i| 12 + i * 16)
+        .find(|&rec| &data[rec..rec + 4] == b"OS/2")
+        .map(|rec| u32::from_be_bytes(data[rec + 8..rec + 12].try_into().unwrap()) as usize)
+        .expect("font has an OS/2 table");
+    // ySubscriptXSize/YSize at 10/12, ySuperscriptXSize/YSize at 18/20.
+    for field in [10, 12, 18, 20] {
+        data[os2_offset + field] = 0;
+        data[os2_offset + field + 1] = 0;
+    }
+
+    let text_context = femtovg::TextContext::default();
+    let font_id = text_context.add_font_mem(&data).expect("patched font parses");
+
+    let font_size = 32.;
+    let test_paint = femtovg::Paint::default()
+        .with_font(&[font_id])
+        .with_font_size(font_size);
+    let metrics = text_context
+        .measure_font(&test_paint)
+        .expect("font measuring failed unexpectedly");
+
+    // The conventional recommendation: 65% of the em, on both axes.
+    let expected = font_size * 0.65;
+    for (label, (x_size, y_size)) in [
+        ("subscript", metrics.subscript_size()),
+        ("superscript", metrics.superscript_size()),
+    ] {
+        assert!(
+            (x_size - expected).abs() < 1e-3 && (y_size - expected).abs() < 1e-3,
+            "zeroed {label} size should fall back to ({expected}, {expected}), got ({x_size}, {y_size})"
+        );
+    }
+}

--- a/tests/shadow_wgpu.rs
+++ b/tests/shadow_wgpu.rs
@@ -606,3 +606,86 @@ fn shadow_blur_falloff_width_matches_spec_sigma() {
          expected ~17px band: a value near 12px means the kernel reach regressed to ~1.5*sigma"
     );
 }
+
+/// Text decoration + drop shadow interaction. A decorated text run is a single
+/// painting operation, so its decoration lines are part of the same shadow as
+/// the glyphs: the run-level shadow pass renders glyphs *and* decorations into
+/// its coverage, and the decoration lines must NOT cast a second shadow of their
+/// own. This verifies both halves — that the underline contributes to the shadow
+/// (it is not missing) and that its shadow alpha never exceeds the shadow color's
+/// alpha (it is not doubled by a per-decoration shadow pass).
+#[cfg(feature = "textlayout")]
+#[test]
+fn decoration_shares_the_single_text_shadow() {
+    let Some((device, queue)) = headless_device() else {
+        eprintln!("skipping: no wgpu adapter available");
+        return;
+    };
+
+    // (shadow, decoration lines u/s/o) -> rendered pixels. A far vertical offset
+    // keeps the shadow band clear of the ink so shadow-only pixels are isolable.
+    let render = |shadow: bool, lines: (bool, bool, bool)| -> Vec<u8> {
+        render_to_pixels(&device, &queue, |canvas| {
+            let font = canvas
+                .add_font("examples/assets/RobotoFlex-VariableFont.ttf")
+                .expect("Font not found");
+            let paint = Paint::color(Color::white())
+                .with_font(&[font])
+                .with_font_size(40.0)
+                .with_text_decoration_lines(lines.0, lines.1, lines.2);
+            if shadow {
+                canvas.set_shadow_color(Color::rgba(0, 0, 0, 128));
+                canvas.set_shadow_offset(0.0, 40.0); // straight down, well clear of the ink
+            }
+            canvas.fill_text(6.0, 50.0, "www", &paint).unwrap();
+        })
+    };
+
+    let plain_shadow_cover = {
+        let ink = render(false, (false, false, false));
+        let sh = render(true, (false, false, false));
+        (0..H * W)
+            .filter(|i| {
+                let (x, y) = (i % W, i / W);
+                pixel(&ink, x, y)[3] == 0 && pixel(&sh, x, y)[3] > 32
+            })
+            .count()
+    };
+
+    // Each decoration kind, on its own, must be covered by one shared shadow.
+    for (name, lines) in [
+        ("underline", (true, false, false)),
+        ("strikethrough", (false, true, false)),
+        ("overline", (false, false, true)),
+    ] {
+        let ink = render(false, lines); // decorated ink, no shadow (mask)
+        let shadowed = render(true, lines);
+
+        let mut max_shadow = 0u8;
+        let mut cover = 0usize;
+        for y in 0..H {
+            for x in 0..W {
+                if pixel(&ink, x, y)[3] == 0 {
+                    let a = pixel(&shadowed, x, y)[3];
+                    max_shadow = max_shadow.max(a);
+                    if a > 32 {
+                        cover += 1;
+                    }
+                }
+            }
+        }
+
+        // Not doubled: a per-decoration shadow would compound to ~1-(1-0.5)^2 ~= 191.
+        assert!(
+            max_shadow <= 140,
+            "{name}: decorated text shadow alpha {max_shadow} exceeds the shadow color's \
+             alpha; the line must not cast its own shadow on top of the run shadow"
+        );
+        // Not missing: the decoration adds a shadow band the plain run does not have.
+        assert!(
+            cover > plain_shadow_cover + 40,
+            "{name}: the decoration line must cast a shadow (coverage {cover} \
+             vs plain {plain_shadow_cover})"
+        );
+    }
+}

--- a/tests/shadow_wgpu.rs
+++ b/tests/shadow_wgpu.rs
@@ -632,7 +632,11 @@ fn decoration_shares_the_single_text_shadow() {
             let paint = Paint::color(Color::white())
                 .with_font(&[font])
                 .with_font_size(40.0)
-                .with_text_decoration_lines(lines.0, lines.1, lines.2);
+                .with_text_decoration(femtovg::TextDecoration {
+                    underline: lines.0,
+                    strikethrough: lines.1,
+                    overline: lines.2,
+                });
             if shadow {
                 canvas.set_shadow_color(Color::rgba(0, 0, 0, 128));
                 canvas.set_shadow_offset(0.0, 40.0); // straight down, well clear of the ink


### PR DESCRIPTION
Completes the `FontMetrics` TODO (`underline, strikeout, subscript, superscript metrics`) begun in #291: exposes the remaining OpenType typographic metrics so text-layout layers (parley, cosmic-text, applications) can implement `vertical-align: super/sub`, CSS `ex`/`cap` units, small-caps synthesis, and line-box layout. **Metrics only — no rendering changes**; super/subscript *rendering* is typesetting (baseline shift + size) and stays the layout layer's job.

**Stacked on #291** (text decoration) — rebased onto current master; the diff shows #291's commits beneath the two typographic-metrics commits at the top, so merge #291 first. Metrics-only, independent of the decoration rendering.

### API (all on `FontMetrics`, scaled to the requested font size like the existing accessors)

| Accessor | OpenType source |
| --- | --- |
| `subscript_size()` / `superscript_size()` → `(f32, f32)` | OS/2 `ySub/SuperscriptXSize/YSize` (MVAR-adjusted for variable fonts) |
| `subscript_offset()` / `superscript_offset()` → `(f32, f32)` | OS/2 `ySub/SuperscriptX/YOffset` |
| `x_height()` | OS/2 `sxHeight` |
| `cap_height()` | OS/2 `sCapHeight` |
| `line_gap()` | hhea (OS/2 typo gap under `USE_TYPO_METRICS`) |

PS: lolz at seeing OS/2 as a sequence of characters post-1997 XD

Script offsets are normalized to the canvas **+y-down** convention (subscript offset typically positive/down, superscript negative/up); each doc comment states the convention and the contrast with `underline_position()`'s post-table +y-up convention established in #291.

Fonts lacking the tables fall back to documented conventional ratios (script size 0.65 em, subscript drop 0.14 em, superscript rise 0.48 em, x-height 0.5 em, cap-height 0.7 em, line gap 0) shared by both metric backends. The ratios are empirically grounded: RobotoFlex's real OS/2 values are these same conventions (e.g. `ySubscriptYOffset` 287/2048 = 0.14). The swash backend exposes x-height/cap-height/leading natively and takes the shared fallbacks for the OS/2 script metrics it does not surface, so both backends agree on availability.

### Footprint

Zero rendering-path changes; zero heap allocations — `FontMetrics` remains a plain `Copy` stack struct (36 → 80 bytes, still under two cache lines on iPhone XS and Meta Quest 2), populated during the `Face::parse` table read that already runs; no new dependencies; nothing added to any per-frame path.

### Comparison vs Chromium Canary

femtovg exposes no script *rendering* (that is the layout layer's job), so these panels typeset `E=mc²` / `H₂O` **from the metrics this PR exposes**, then compose them with decorations and drop shadow. Chrome renders the same content driven with the **identical OS/2 numbers** (SVG `<text>` baseline + `baseline-shift`, `feDropShadow`), so a match confirms the metrics are correct and consumable end to end:

![typographic metrics vs Chromium](https://raw.githubusercontent.com/rebeckerspecialties/femtovg/pixel-comparisons/comparisons/typographic_metrics.png)

Rows: superscript, subscript, then both combined with underline / strikethrough / overline, and finally with a sharp and a blurred drop shadow. Per-row difference from Chrome (max-channel > 40, the antialiasing floor):

| Row | Δ area |
| --- | --- |
| superscript | 1.2% |
| subscript | 0.5% |
| + underline | 2.1% |
| + strikethrough | 2.0% |
| + overline | 2.1% |
| + underline + sharp shadow | 3.3% |
| + underline + blur shadow | 2.1% |

Every row sits at the plain-glyph-edge antialiasing floor — script placement, decoration composition, and shadow all track Chrome with no structural difference. (The shadow rows are within the same floor because the composite's runs are spaced apart; femtovg's per-operation shadow model only diverges from a browser's whole-element `filter` when translucent shadows of *overlapping* operations superimpose, which is the offscreen-compositing/layers item on the roadmap, not a metrics concern.)

**Intentional difference — OS/2 metrics vs browser UA defaults.** These panels drive Chrome with explicit OS/2-derived sizes/offsets. Chrome's *native* `<sub>`/`<sup>` instead use its own heuristic (`font-size: smaller` + `vertical-align: super/sub`), which sizes and positions scripts differently. Exposing the font's own recommendation is the point: a layout layer can honor the type designer's metrics rather than a fixed heuristic.

### Tests

- Stripped-font fixture (minimal head/hhea/maxp TTF built in-test) asserts every documented fallback exactly — and adds coverage for #291's underline/strikeout fallbacks.
- Real-font plausibility: 0 < x-height < cap-height ≤ ascender; script sizes within (0, em); subscript points down, superscript up.
- Linear scaling: metrics at size 20 exactly half of size 40.
- Placement envelope: a superscript typeset at its recommended size lifts its cap above the base x-height while staying within the ascent, and a subscript drops within the descent depth — a magnitude check (not just sign) that guards the superscript sign-normalization against a swap or mis-scale regression.
- Suites green under the ttf-parser backend (`wgpu textlayout`: 63 passed) and the swash backend (`--no-default-features --features swash` lib: 19 passed).

### Validation

- `cargo fmt --check`; rustdoc clean
- Builds: default, `wgpu`, `--no-default-features`, `--all-features`, swash
- `cargo test --features "wgpu textlayout"`


