### PR TITLE
Add start angle to conic gradients (createConicGradient parity)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,7 @@ textlayout = ["dep:rustybuzz", "dep:unicode-bidi", "dep:unicode-segmentation", "
 swash = ["dep:swash"]
 
 [dev-dependencies]
+serde_json = "1.0"
 winit = { version = "0.30.12" }
 euclid = "0.22.3"
 rand = "0.10"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2714,6 +2714,35 @@ fn conic_gradient_start_angle_is_plumbed_into_params() {
     assert_eq!(params.conic_start_angle, angle);
 }
 
+/// The scissor radius (frag[12].w) and the conic start angle (frag[13].x) live
+/// in adjacent uniform slots. A draw that uses both a rounded scissor and a
+/// conic gradient with a start angle must carry each value independently in the
+/// same `Params`, so neither feature can clobber the other's slot.
+#[test]
+fn rounded_scissor_and_conic_start_angle_coexist_in_params() {
+    use renderer::ShaderType;
+
+    let renderer = RecordingRenderer::default();
+    let recorded_commands = renderer.last_commands.clone();
+    let mut canvas = Canvas::new(renderer).unwrap();
+    canvas.set_size(100, 100, 1.0);
+
+    canvas.rounded_scissor(10.0, 10.0, 80.0, 80.0, 12.0);
+
+    let angle = std::f32::consts::FRAC_PI_2;
+    let paint = Paint::conic_gradient_with_angle(50.0, 50.0, angle, Color::rgb(255, 0, 0), Color::rgb(0, 0, 255));
+    let mut path = Path::new();
+    path.rect(0.0, 0.0, 100.0, 100.0);
+    canvas.fill_path(&path, &paint);
+    canvas.flush_to_output(());
+
+    let commands = recorded_commands.borrow();
+    let params = first_draw_params(&commands);
+    assert_eq!(params.shader_type, ShaderType::FillGradientConic);
+    assert_approx_eq(params.scissor_radius, 12.0);
+    assert_approx_eq(params.conic_start_angle, angle);
+}
+
 /// Text rendering picks one of two strategies depending on the canvas transform
 /// and paint: cached atlas bitmaps (emitting a `Triangles` command that samples a
 /// glyph texture) or direct outline rendering (emitting plain path fills with no

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2649,6 +2649,71 @@ fn intersect_rounded_scissor_uses_inner_radius_when_contained() {
     assert_approx_eq(params.scissor_radius, 10.0);
 }
 
+/// The conic gradient `start_angle` must be plumbed all the way into the
+/// rendering `Params` so the shaders can apply it. This is a CI-friendly check
+/// that does not require a GPU: it records the commands emitted for a conic fill
+/// and inspects the resulting `Params`.
+#[test]
+fn conic_gradient_start_angle_is_plumbed_into_params() {
+    use renderer::{CommandType, ShaderType};
+
+    fn conic_params(paint: &Paint) -> Params {
+        let renderer = RecordingRenderer::default();
+        let recorded = renderer.last_commands.clone();
+        let mut canvas = Canvas::new(renderer).unwrap();
+        canvas.set_size(100, 100, 1.);
+
+        let mut path = Path::new();
+        path.circle(50., 50., 40.);
+        canvas.fill_path(&path, paint);
+        canvas.flush_to_output(());
+
+        let params = recorded
+            .borrow()
+            .iter()
+            .find_map(|cmd| match &cmd.cmd_type {
+                CommandType::ConvexFill { params } | CommandType::Stroke { params } => Some(*params),
+                CommandType::ConcaveFill { fill_params, .. } => Some(*fill_params),
+                _ => None,
+            })
+            .expect("expected a fill command for the conic gradient");
+        params
+    }
+
+    // Default (angle-less) constructor must keep start_angle at 0.
+    let stops = [(0.0, Color::rgb(255, 0, 0)), (0.5, Color::rgb(0, 0, 255))];
+    let params = conic_params(&Paint::conic_gradient_stops(50., 50., stops));
+    assert_eq!(params.shader_type, ShaderType::FillImageGradientConic);
+    assert_eq!(params.conic_start_angle, 0.0);
+
+    // Explicit-angle multi-stop constructor must carry the angle through.
+    let angle = std::f32::consts::FRAC_PI_2;
+    let params = conic_params(&Paint::conic_gradient_stops_with_angle(50., 50., angle, stops));
+    assert_eq!(params.shader_type, ShaderType::FillImageGradientConic);
+    assert_eq!(params.conic_start_angle, angle);
+
+    // Two-color constructor variants.
+    let params = conic_params(&Paint::conic_gradient(
+        50.,
+        50.,
+        Color::rgb(255, 0, 0),
+        Color::rgb(0, 0, 255),
+    ));
+    assert_eq!(params.shader_type, ShaderType::FillGradientConic);
+    assert_eq!(params.conic_start_angle, 0.0);
+
+    let angle = -std::f32::consts::PI;
+    let params = conic_params(&Paint::conic_gradient_with_angle(
+        50.,
+        50.,
+        angle,
+        Color::rgb(255, 0, 0),
+        Color::rgb(0, 0, 255),
+    ));
+    assert_eq!(params.shader_type, ShaderType::FillGradientConic);
+    assert_eq!(params.conic_start_angle, angle);
+}
+
 /// Text rendering picks one of two strategies depending on the canvas transform
 /// and paint: cached atlas bitmaps (emitting a `Triangles` command that samples a
 /// glyph texture) or direct outline rendering (emitting plain path fills with no

--- a/src/paint.rs
+++ b/src/paint.rs
@@ -290,6 +290,11 @@ pub enum PaintFlavor {
     },
     ConicGradient {
         center: Position,
+        // Paints serialized before `start_angle` existed represented conic
+        // gradients as `{ center, colors }`. Defaulting the missing field to
+        // 0.0 keeps those payloads deserializable, matching the original
+        // (no-rotation) behavior.
+        #[cfg_attr(feature = "serde", serde(default))]
         start_angle: f32,
         colors: GradientColors,
     },
@@ -1290,6 +1295,10 @@ impl Paint {
 #[cfg(test)]
 mod tests {
     use super::Paint;
+    #[cfg(feature = "serde")]
+    use super::{GradientColors, PaintFlavor};
+    #[cfg(feature = "serde")]
+    use crate::{geometry::Position, Color};
 
     #[test]
     fn line_dash_empty_pattern_clears() {
@@ -1326,5 +1335,61 @@ mod tests {
         let paint = Paint::default().with_line_dash(&[0.0, 0.0]);
 
         assert_eq!(paint.line_dash(), &[0.0, 0.0]);
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn conic_gradient_deserializes_without_start_angle() {
+        let flavor = PaintFlavor::ConicGradient {
+            center: Position { x: 1.0, y: 2.0 },
+            start_angle: 1.5,
+            colors: GradientColors::TwoStop {
+                start_color: Color::black(),
+                end_color: Color::white(),
+            },
+        };
+
+        // Learn the current serde representation, then strip `start_angle`
+        // to mirror the "old format" payload produced before that field
+        // existed (`ConicGradient { center, colors }`).
+        let mut value = serde_json::to_value(&flavor).expect("serialize ConicGradient");
+        let inner = value
+            .get_mut("ConicGradient")
+            .and_then(|v| v.as_object_mut())
+            .expect("externally tagged ConicGradient object");
+        assert!(inner.remove("start_angle").is_some(), "start_angle should be present");
+
+        // Deserializing the field-less payload must succeed and default to 0.0.
+        let restored: PaintFlavor = serde_json::from_value(value).expect("deserialize old format");
+        match restored {
+            PaintFlavor::ConicGradient {
+                center, start_angle, ..
+            } => {
+                assert_eq!(start_angle, 0.0);
+                assert_eq!(center.x, 1.0);
+                assert_eq!(center.y, 2.0);
+            }
+            other => panic!("expected ConicGradient, got {other:?}"),
+        }
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn conic_gradient_round_trip_preserves_start_angle() {
+        let flavor = PaintFlavor::ConicGradient {
+            center: Position { x: 3.0, y: 4.0 },
+            start_angle: 2.75,
+            colors: GradientColors::TwoStop {
+                start_color: Color::black(),
+                end_color: Color::white(),
+            },
+        };
+
+        let json = serde_json::to_string(&flavor).expect("serialize ConicGradient");
+        let restored: PaintFlavor = serde_json::from_str(&json).expect("deserialize ConicGradient");
+        match restored {
+            PaintFlavor::ConicGradient { start_angle, .. } => assert_eq!(start_angle, 2.75),
+            other => panic!("expected ConicGradient, got {other:?}"),
+        }
     }
 }

--- a/src/paint.rs
+++ b/src/paint.rs
@@ -757,10 +757,14 @@ impl Paint {
     /// Parameters (`cx`,`cy`) specify the center. `start_angle` is in radians,
     /// measured clockwise from the positive x axis, matching the Canvas 2D
     /// `createConicGradient(start_angle, cx, cy)` semantics.
+    ///
+    /// Following the Canvas convention that non-finite values must not poison
+    /// rendering state, a non-finite `start_angle` (NaN or an infinity) is
+    /// ignored and treated as `0.0`.
     pub fn conic_gradient_with_angle(cx: f32, cy: f32, start_angle: f32, start_color: Color, end_color: Color) -> Self {
         Self::with_flavor(PaintFlavor::ConicGradient {
             center: Position { x: cx, y: cy },
-            start_angle,
+            start_angle: Self::finite_start_angle_or_zero(start_angle),
             colors: GradientColors::TwoStop { start_color, end_color },
         })
     }
@@ -779,6 +783,10 @@ impl Paint {
     /// Parameters (`cx`,`cy`) specify the center. `start_angle` is in radians,
     /// measured clockwise from the positive x axis, matching the Canvas 2D
     /// `createConicGradient(start_angle, cx, cy)` semantics.
+    ///
+    /// Following the Canvas convention that non-finite values must not poison
+    /// rendering state, a non-finite `start_angle` (NaN or an infinity) is
+    /// ignored and treated as `0.0`.
     pub fn conic_gradient_stops_with_angle(
         cx: f32,
         cy: f32,
@@ -787,9 +795,20 @@ impl Paint {
     ) -> Self {
         Self::with_flavor(PaintFlavor::ConicGradient {
             center: Position { x: cx, y: cy },
-            start_angle,
+            start_angle: Self::finite_start_angle_or_zero(start_angle),
             colors: GradientColors::from_stops(stops),
         })
+    }
+
+    /// A NaN or infinite conic start angle would propagate through the shader's
+    /// `fract()` wrap and poison every covered pixel, so the constructors above
+    /// drop such values in favor of the no-rotation default.
+    fn finite_start_angle_or_zero(start_angle: f32) -> f32 {
+        if start_angle.is_finite() {
+            start_angle
+        } else {
+            0.0
+        }
     }
 
     /// Sets the color of the paint.
@@ -1294,11 +1313,10 @@ impl Paint {
 
 #[cfg(test)]
 mod tests {
-    use super::Paint;
     #[cfg(feature = "serde")]
-    use super::{GradientColors, PaintFlavor};
-    #[cfg(feature = "serde")]
-    use crate::{geometry::Position, Color};
+    use super::{GradientColors, Position};
+    use super::{Paint, PaintFlavor};
+    use crate::Color;
 
     #[test]
     fn line_dash_empty_pattern_clears() {
@@ -1391,5 +1409,30 @@ mod tests {
             PaintFlavor::ConicGradient { start_angle, .. } => assert_eq!(start_angle, 2.75),
             other => panic!("expected ConicGradient, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn conic_gradient_non_finite_start_angle_is_treated_as_zero() {
+        let start_angle_of = |paint: Paint| match paint.flavor {
+            PaintFlavor::ConicGradient { start_angle, .. } => start_angle,
+            other => panic!("expected ConicGradient, got {other:?}"),
+        };
+
+        for bad_angle in [f32::NAN, f32::INFINITY, f32::NEG_INFINITY] {
+            let two_stop = Paint::conic_gradient_with_angle(10.0, 20.0, bad_angle, Color::black(), Color::white());
+            assert_eq!(start_angle_of(two_stop), 0.0);
+
+            let multi_stop = Paint::conic_gradient_stops_with_angle(
+                10.0,
+                20.0,
+                bad_angle,
+                [(0.0, Color::black()), (1.0, Color::white())],
+            );
+            assert_eq!(start_angle_of(multi_stop), 0.0);
+        }
+
+        // Finite angles must pass through untouched.
+        let finite = Paint::conic_gradient_with_angle(10.0, 20.0, -1.25, Color::black(), Color::white());
+        assert_eq!(start_angle_of(finite), -1.25);
     }
 }

--- a/src/paint.rs
+++ b/src/paint.rs
@@ -290,6 +290,7 @@ pub enum PaintFlavor {
     },
     ConicGradient {
         center: Position,
+        start_angle: f32,
         colors: GradientColors,
     },
 }
@@ -737,12 +738,51 @@ impl Paint {
         })
     }
 
-    /// Creates and returns a multi-stop conic gradient.
+    /// Creates and returns a two-color conic gradient.
     ///
-    /// Parameters (`cx`,`cy`) specify the center.
-    pub fn conic_gradient_stops(cx: f32, cy: f32, stops: impl IntoIterator<Item = (f32, Color)>) -> Self {
+    /// Parameters (`cx`,`cy`) specify the center. The gradient begins at the
+    /// positive x axis (the 3 o'clock direction) and proceeds clockwise, matching
+    /// the Canvas 2D `createConicGradient(0, cx, cy)` semantics.
+    pub fn conic_gradient(cx: f32, cy: f32, start_color: Color, end_color: Color) -> Self {
+        Self::conic_gradient_with_angle(cx, cy, 0.0, start_color, end_color)
+    }
+
+    /// Creates and returns a two-color conic gradient with a start angle.
+    ///
+    /// Parameters (`cx`,`cy`) specify the center. `start_angle` is in radians,
+    /// measured clockwise from the positive x axis, matching the Canvas 2D
+    /// `createConicGradient(start_angle, cx, cy)` semantics.
+    pub fn conic_gradient_with_angle(cx: f32, cy: f32, start_angle: f32, start_color: Color, end_color: Color) -> Self {
         Self::with_flavor(PaintFlavor::ConicGradient {
             center: Position { x: cx, y: cy },
+            start_angle,
+            colors: GradientColors::TwoStop { start_color, end_color },
+        })
+    }
+
+    /// Creates and returns a multi-stop conic gradient.
+    ///
+    /// Parameters (`cx`,`cy`) specify the center. The gradient begins at the
+    /// positive x axis (the 3 o'clock direction) and proceeds clockwise, matching
+    /// the Canvas 2D `createConicGradient(0, cx, cy)` semantics.
+    pub fn conic_gradient_stops(cx: f32, cy: f32, stops: impl IntoIterator<Item = (f32, Color)>) -> Self {
+        Self::conic_gradient_stops_with_angle(cx, cy, 0.0, stops)
+    }
+
+    /// Creates and returns a multi-stop conic gradient with a start angle.
+    ///
+    /// Parameters (`cx`,`cy`) specify the center. `start_angle` is in radians,
+    /// measured clockwise from the positive x axis, matching the Canvas 2D
+    /// `createConicGradient(start_angle, cx, cy)` semantics.
+    pub fn conic_gradient_stops_with_angle(
+        cx: f32,
+        cy: f32,
+        start_angle: f32,
+        stops: impl IntoIterator<Item = (f32, Color)>,
+    ) -> Self {
+        Self::with_flavor(PaintFlavor::ConicGradient {
+            center: Position { x: cx, y: cy },
+            start_angle,
             colors: GradientColors::from_stops(stops),
         })
     }

--- a/src/renderer/opengl/main-fs.glsl
+++ b/src/renderer/opengl/main-fs.glsl
@@ -73,12 +73,26 @@ float strokeMask() {
 }
 #endif
 
+// Interleaved gradient noise (Jimenez 2014): a cheap, deterministic, screen-space
+// ordered dither. Offsetting the gradient colour by up to +/-0.5 of an 8-bit step
+// before the framebuffer quantizes it spreads the rounding spatially, breaking up
+// the banding that appears between close colours over a large gradient (issue
+// femtovg/femtovg#239). The offset is sub-LSB, so solid regions are unaffected and
+// the Unorm write clamps it away at the 0.0/1.0 extremes.
+float ditherNoise(vec2 p) {
+    return fract(52.9829189 * fract(dot(p, vec2(0.06711056, 0.00583715))));
+}
+vec4 ditherGradient(vec4 color) {
+    float d = (ditherNoise(gl_FragCoord.xy) - 0.5) / 255.0;
+    return vec4(color.rgb + d, color.a);
+}
+
 vec4 renderGradient() {
     // Calculate gradient color using box gradient
     vec2 pt = (paintMat * vec3(fpos, 1.0)).xy;
 
     float d = clamp((sdroundrect(pt, extent, radius) + feather*0.5) / feather, 0.0, 1.0);
-    return mix(innerCol,outerCol,d);
+    return ditherGradient(mix(innerCol,outerCol,d));
 }
 
 // Image-based Gradient; sample a texture using the gradient position.
@@ -87,7 +101,7 @@ vec4 renderImageGradient() {
     vec2 pt = (paintMat * vec3(fpos, 1.0)).xy;
 
     float d = clamp((sdroundrect(pt, extent, radius) + feather*0.5) / feather, 0.0, 1.0);
-    return texture2D(tex, vec2(d, 0.0));//mix(innerCol,outerCol,d);
+    return ditherGradient(texture2D(tex, vec2(d, 0.0)));
 }
 
 float conicAngleFraction() {
@@ -102,12 +116,12 @@ float conicAngleFraction() {
 
 vec4 renderGradientConic() {
     float d = conicAngleFraction();
-    return mix(innerCol,outerCol,d);
+    return ditherGradient(mix(innerCol,outerCol,d));
 }
 
 vec4 renderImageGradientConic() {
     float d = conicAngleFraction();
-    return texture2D(tex, vec2(d, 0.0));
+    return ditherGradient(texture2D(tex, vec2(d, 0.0)));
 }
 
 vec4 renderImage() {

--- a/src/renderer/opengl/main-fs.glsl
+++ b/src/renderer/opengl/main-fs.glsl
@@ -25,6 +25,7 @@ uniform vec4 frag[UNIFORMARRAY_SIZE];
 #define imageBlurFilterSigma frag[11].w
 #define imageBlurFilterCoeff frag[12].xyz
 #define scissorRadius frag[12].w
+#define conicStartAngle frag[13].x
 
 uniform sampler2D tex;
 uniform sampler2D glyphtex;
@@ -91,10 +92,12 @@ vec4 renderImageGradient() {
 
 float conicAngleFraction() {
     vec2 pt = (paintMat * vec3(fpos, 1.0)).xy;
-    // atan returns a value between -pi and pi.
-    // normally you'd use atan(pt.y,pt.x) but its switched
-    // around here to be clockwise and start from the top.
-    return (-atan(pt.x,pt.y) / TAU) + 0.5;
+    // Measure the angle clockwise from the positive x axis. In the gradient's
+    // local space (y points down on screen), atan(pt.y, pt.x) increases in the
+    // clockwise direction, so offset 0 sits at 3 o'clock and the ramp proceeds
+    // clockwise, matching Canvas 2D createConicGradient. fract() wraps the angle
+    // into [0, 1) for negative or large start angles.
+    return fract((atan(pt.y, pt.x) - conicStartAngle) / TAU);
 }
 
 vec4 renderGradientConic() {

--- a/src/renderer/opengl/uniform_array.rs
+++ b/src/renderer/opengl/uniform_array.rs
@@ -90,6 +90,11 @@ impl UniformArray {
     pub fn set_image_blur_filter_coeff(&mut self, coeff: [f32; 3]) {
         self.0[48..51].copy_from_slice(&coeff);
     }
+
+    pub fn set_conic_start_angle(&mut self, angle: f32) {
+        // frag[13].x in the fragment shader; frag[12].w holds the scissor radius.
+        self.0[52] = angle;
+    }
 }
 
 impl From<&Params> for UniformArray {
@@ -114,6 +119,7 @@ impl From<&Params> for UniformArray {
         arr.set_image_blur_filter_direction(params.image_blur_filter_direction);
         arr.set_image_blur_filter_sigma(params.image_blur_filter_sigma);
         arr.set_image_blur_filter_coeff(params.image_blur_filter_coeff);
+        arr.set_conic_start_angle(params.conic_start_angle);
 
         arr
     }

--- a/src/renderer/params.rs
+++ b/src/renderer/params.rs
@@ -26,6 +26,7 @@ pub struct Params {
     pub(crate) image_blur_filter_direction: [f32; 2],
     pub(crate) image_blur_filter_sigma: f32,
     pub(crate) image_blur_filter_coeff: [f32; 3],
+    pub(crate) conic_start_angle: f32,
 }
 
 impl Params {
@@ -229,11 +230,14 @@ impl Params {
             }
             &PaintFlavor::ConicGradient {
                 center: Position { x: cx, y: cy },
+                start_angle,
                 colors,
             } => {
                 let mut transform = Transform2D::translation(*cx, *cy);
                 transform *= *global_transform;
                 inv_transform = transform.inverse();
+
+                params.conic_start_angle = *start_angle;
 
                 match colors {
                     GradientColors::TwoStop { start_color, end_color } => {

--- a/src/renderer/wgpu.rs
+++ b/src/renderer/wgpu.rs
@@ -152,6 +152,12 @@ impl UniformArray {
     pub fn set_image_blur_filter_coeff(&mut self, coeff: [f32; 3]) {
         self.0[48..51].copy_from_slice(&coeff);
     }
+
+    pub fn set_conic_start_angle(&mut self, angle: f32) {
+        // Byte offset 208 (`conic_start_angle` in the WGSL Params struct);
+        // float 51 (byte offset 204) holds the scissor radius.
+        self.0[52] = angle;
+    }
 }
 
 impl From<&Params> for UniformArray {
@@ -176,6 +182,7 @@ impl From<&Params> for UniformArray {
         arr.set_image_blur_filter_direction(params.image_blur_filter_direction);
         arr.set_image_blur_filter_sigma(params.image_blur_filter_sigma);
         arr.set_image_blur_filter_coeff(params.image_blur_filter_coeff);
+        arr.set_conic_start_angle(params.conic_start_angle);
 
         arr
     }

--- a/src/renderer/wgpu/shader.wgsl
+++ b/src/renderer/wgpu/shader.wgsl
@@ -147,12 +147,15 @@ fn fs_main(vertex: VertexOutput) -> @location(0) vec4<f32> {
             return params.inner_col;
         }
         case SHADER_TYPE_FillGradientConic: {
+            // Set `result` and fall through to the scissor + stroke-AA multiply
+            // below (like the other gradient cases); returning here would skip
+            // the clip and antialiasing, so conic fills would ignore scissors.
             let d = conicAngleFraction(vertex, params);
-            return mix(params.inner_col,params.outer_col,d);
+            result = mix(params.inner_col,params.outer_col,d);
         }
         case SHADER_TYPE_FillImageGradientConic: {
             let d = conicAngleFraction(vertex, params);
-            return textureSample(image_texture, image_sampler, vec2<f32>(d, 0.0));
+            result = textureSample(image_texture, image_sampler, vec2<f32>(d, 0.0));
         }
         default: {
             result = vec4<f32>(0.0, 0.0, 1.0, 1.0);

--- a/src/renderer/wgpu/shader.wgsl
+++ b/src/renderer/wgpu/shader.wgsl
@@ -16,7 +16,11 @@ struct Params {
     image_blur_filter_sigma: f32,
     image_blur_filter_direction: vec2<f32>,
     image_blur_filter_coeff: vec3<f32>,
+    // scissor_radius fills the padding after the vec3 (byte offset 204);
+    // conic_start_angle starts the next 16-byte row (byte offset 208), which
+    // is frag[13].x in the flat uniform array written from Rust.
     scissor_radius: f32,
+    conic_start_angle: f32,
 }
 
 const SHADER_TYPE_FillGradient: i32 = 0;
@@ -181,7 +185,12 @@ fn fs_main(vertex: VertexOutput) -> @location(0) vec4<f32> {
 
 fn conicAngleFraction(vertex: VertexOutput, params: Params) -> f32 {
     let pt: vec2<f32> = (params.paint_mat * vec3<f32>(vertex.fpos, 1.0)).xy;
-    return (-atan2(pt.x,pt.y) / TAU) + 0.5;
+    // Measure the angle clockwise from the positive x axis. In the gradient's
+    // local space (y points down on screen), atan2(pt.y, pt.x) increases in the
+    // clockwise direction, so offset 0 sits at 3 o'clock and the ramp proceeds
+    // clockwise, matching Canvas 2D createConicGradient. fract() wraps the angle
+    // into [0, 1) for negative or large start angles.
+    return fract((atan2(pt.y, pt.x) - params.conic_start_angle) / TAU);
 }
 
 fn sdroundrect(pt: vec2<f32>, ext: vec2<f32>, rad: f32) -> f32 {

--- a/src/renderer/wgpu/shader.wgsl
+++ b/src/renderer/wgpu/shader.wgsl
@@ -151,11 +151,11 @@ fn fs_main(vertex: VertexOutput) -> @location(0) vec4<f32> {
             // below (like the other gradient cases); returning here would skip
             // the clip and antialiasing, so conic fills would ignore scissors.
             let d = conicAngleFraction(vertex, params);
-            result = mix(params.inner_col,params.outer_col,d);
+            result = ditherGradient(mix(params.inner_col,params.outer_col,d), vertex.position.xy);
         }
         case SHADER_TYPE_FillImageGradientConic: {
             let d = conicAngleFraction(vertex, params);
-            result = textureSample(image_texture, image_sampler, vec2<f32>(d, 0.0));
+            result = ditherGradient(textureSample(image_texture, image_sampler, vec2<f32>(d, 0.0)), vertex.position.xy);
         }
         default: {
             result = vec4<f32>(0.0, 0.0, 1.0, 1.0);
@@ -223,12 +223,23 @@ fn strokeMask(vertex: VertexOutput, params: Params) -> f32 {
     //return smoothstep(0.0, 1.0, (1.0-abs(vertex.ftcoord.x*2.0-1.0))*params.stroke_mult) * smoothstep(0.0, 1.0, vertex.ftcoord.y);
 }
 
+// Interleaved gradient noise dither (see the GLSL shader / issue femtovg/femtovg#239):
+// a cheap, deterministic screen-space ordered dither. A sub-LSB colour offset
+// before the 8-bit write breaks up gradient banding between close colours.
+fn ditherNoise(p: vec2<f32>) -> f32 {
+    return fract(52.9829189 * fract(dot(p, vec2<f32>(0.06711056, 0.00583715))));
+}
+fn ditherGradient(color: vec4<f32>, fragcoord: vec2<f32>) -> vec4<f32> {
+    let d = (ditherNoise(fragcoord) - 0.5) / 255.0;
+    return vec4<f32>(color.rgb + d, color.a);
+}
+
 fn renderGradient(vertex: VertexOutput, params: Params) -> vec4<f32> {
     // Calculate gradient color using box gradient
     let pt: vec2<f32> = (params.paint_mat * vec3<f32>(vertex.fpos, 1.0)).xy;
 
     let d: f32 = clamp((sdroundrect(pt, params.extent, params.radius) + params.feather*0.5) / params.feather, 0.0, 1.0);
-    return mix(params.inner_col,params.outer_col,d);
+    return ditherGradient(mix(params.inner_col,params.outer_col,d), vertex.position.xy);
 }
 
 // Image-based Gradient; sample a texture using the gradient position.
@@ -237,7 +248,7 @@ fn renderImageGradient(vertex: VertexOutput, params: Params) -> vec4<f32> {
     let pt: vec2<f32> = (params.paint_mat * vec3<f32>(vertex.fpos, 1.0)).xy;
 
     let d: f32 = clamp((sdroundrect(pt, params.extent, params.radius) + params.feather*0.5) / params.feather, 0.0, 1.0);
-    return textureSample(image_texture, image_sampler, vec2<f32>(d, 0.0));//mix(innerCol,outerCol,d);
+    return ditherGradient(textureSample(image_texture, image_sampler, vec2<f32>(d, 0.0)), vertex.position.xy);
 }
 
 fn renderImage(vertex: VertexOutput, params: Params) -> vec4<f32> {

--- a/tests/conic_scissor_wgpu.rs
+++ b/tests/conic_scissor_wgpu.rs
@@ -1,0 +1,167 @@
+//! Headless GPU regression test: conic gradient fills must honor scissor clips
+//! on the wgpu backend.
+//!
+//! The WGSL conic gradient cases returned their color directly, before the
+//! scissor mask and stroke-antialiasing multiply that every other fill type
+//! falls through to. A conic-filled shape therefore ignored the scissor (and its
+//! rounded corners) entirely. This renders a conic gradient over a rounded
+//! scissor and asserts the corner outside the radius is clipped away, mirroring
+//! `blit_scissor_wgpu.rs` for the image-blit fast path.
+//!
+//! Skips (prints and returns) when no GPU adapter is available.
+#![cfg(feature = "wgpu")]
+
+use femtovg::{renderer::WGPURenderer, Canvas, Color, Paint, Path};
+
+const W: u32 = 200;
+const H: u32 = 200;
+
+fn headless_device() -> Option<(wgpu::Device, wgpu::Queue)> {
+    let instance = wgpu::Instance::default();
+    let adapter = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
+        power_preference: wgpu::PowerPreference::default(),
+        force_fallback_adapter: false,
+        compatible_surface: None,
+        ..Default::default()
+    }))
+    .ok()?;
+    let (device, queue) = pollster::block_on(adapter.request_device(&wgpu::DeviceDescriptor {
+        label: Some("femtovg conic scissor test device"),
+        required_features: wgpu::Features::empty(),
+        required_limits: wgpu::Limits::downlevel_defaults().using_resolution(adapter.limits()),
+        experimental_features: wgpu::ExperimentalFeatures::disabled(),
+        memory_hints: wgpu::MemoryHints::MemoryUsage,
+        trace: wgpu::Trace::default(),
+    }))
+    .ok()?;
+    Some((device, queue))
+}
+
+/// Clear white, set a 100x100 rounded scissor at (50,50) with a 40px radius, and
+/// fill that rect with a conic gradient centred in it. Returns row-major
+/// `[r,g,b,a]` pixels.
+fn render_scissored_conic(device: &wgpu::Device, queue: &wgpu::Queue) -> Vec<u8> {
+    let target = device.create_texture(&wgpu::TextureDescriptor {
+        label: Some("conic scissor target"),
+        size: wgpu::Extent3d {
+            width: W,
+            height: H,
+            depth_or_array_layers: 1,
+        },
+        mip_level_count: 1,
+        sample_count: 1,
+        dimension: wgpu::TextureDimension::D2,
+        format: wgpu::TextureFormat::Rgba8Unorm,
+        usage: wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::COPY_SRC,
+        view_formats: &[],
+    });
+
+    let renderer = WGPURenderer::new(device.clone(), queue.clone());
+    let mut canvas = Canvas::new(renderer).expect("failed to create canvas");
+    canvas.set_size(W, H, 1.0);
+    canvas.clear_rect(0, 0, W, H, Color::white());
+
+    canvas.rounded_scissor(50.0, 50.0, 100.0, 100.0, 40.0);
+    let stops = [
+        (0.0, Color::rgb(230, 40, 40)),
+        (0.5, Color::rgb(40, 60, 230)),
+        (1.0, Color::rgb(230, 40, 40)),
+    ];
+    let mut path = Path::new();
+    path.rect(50.0, 50.0, 100.0, 100.0);
+    canvas.fill_path(&path, &Paint::conic_gradient_stops_with_angle(100.0, 100.0, 0.0, stops));
+
+    let commands = canvas.flush_to_output(&target);
+    queue.submit(commands);
+
+    let unpadded_bytes_per_row = W * 4;
+    let align = wgpu::COPY_BYTES_PER_ROW_ALIGNMENT;
+    let padded_bytes_per_row = unpadded_bytes_per_row.div_ceil(align) * align;
+    let readback = device.create_buffer(&wgpu::BufferDescriptor {
+        label: Some("conic scissor readback"),
+        size: (padded_bytes_per_row * H) as u64,
+        usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
+        mapped_at_creation: false,
+    });
+    let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
+    encoder.copy_texture_to_buffer(
+        wgpu::TexelCopyTextureInfo {
+            texture: &target,
+            mip_level: 0,
+            origin: wgpu::Origin3d::ZERO,
+            aspect: wgpu::TextureAspect::All,
+        },
+        wgpu::TexelCopyBufferInfo {
+            buffer: &readback,
+            layout: wgpu::TexelCopyBufferLayout {
+                offset: 0,
+                bytes_per_row: Some(padded_bytes_per_row),
+                rows_per_image: Some(H),
+            },
+        },
+        wgpu::Extent3d {
+            width: W,
+            height: H,
+            depth_or_array_layers: 1,
+        },
+    );
+    queue.submit(Some(encoder.finish()));
+
+    let slice = readback.slice(..);
+    slice.map_async(wgpu::MapMode::Read, |_| {});
+    device.poll(wgpu::PollType::wait_indefinitely()).unwrap();
+    let mapped = slice.get_mapped_range().expect("mapped readback range");
+    let mut pixels = vec![0u8; (unpadded_bytes_per_row * H) as usize];
+    for row in 0..H as usize {
+        let src = row * padded_bytes_per_row as usize;
+        let dst = row * unpadded_bytes_per_row as usize;
+        pixels[dst..dst + unpadded_bytes_per_row as usize]
+            .copy_from_slice(&mapped[src..src + unpadded_bytes_per_row as usize]);
+    }
+    drop(mapped);
+    readback.unmap();
+    pixels
+}
+
+fn pixel(pixels: &[u8], x: u32, y: u32) -> [u8; 4] {
+    let i = ((y * W + x) * 4) as usize;
+    [pixels[i], pixels[i + 1], pixels[i + 2], pixels[i + 3]]
+}
+
+/// White background pixel — the clip removed the gradient there.
+fn is_background(px: [u8; 4]) -> bool {
+    px[0] > 200 && px[1] > 200 && px[2] > 200
+}
+
+#[test]
+fn conic_gradient_is_clipped_by_rounded_scissor() {
+    let Some((device, queue)) = headless_device() else {
+        eprintln!("skipping: no wgpu adapter available");
+        return;
+    };
+    let pixels = render_scissored_conic(&device, &queue);
+
+    // (54,54) is inside the 100x100 rect but outside the 40px rounded corner
+    // (centre (90,90), distance ~50), so it must be clipped to the background.
+    let corner = pixel(&pixels, 54, 54);
+    // (100,100) is the gradient centre — well inside the clip.
+    let center = pixel(&pixels, 100, 100);
+    // (100,52) is on the straight top edge inside the clip — must not over-clip.
+    let edge = pixel(&pixels, 100, 52);
+    println!("conic scissor: corner(54,54)={corner:?} center(100,100)={center:?} edge(100,52)={edge:?}");
+
+    assert!(
+        is_background(corner),
+        "pixel (54,54) is outside the rounded corner; the conic fill must be \
+         clipped to the white background there, got {corner:?}"
+    );
+    assert!(
+        !is_background(center),
+        "pixel (100,100) is inside the clip and must show the conic gradient, got {center:?}"
+    );
+    assert!(
+        !is_background(edge),
+        "pixel (100,52) is on the straight edge inside the clip and must not be \
+         over-clipped, got {edge:?}"
+    );
+}

--- a/tests/gradient_dither_wgpu.rs
+++ b/tests/gradient_dither_wgpu.rs
@@ -1,0 +1,129 @@
+//! Headless GPU test: gradients are dithered to break up 8-bit banding
+//! (femtovg/femtovg#239). A gradient between two very close colours would, without
+//! dithering, quantize to flat vertical bands — every pixel in a column identical.
+//! With the screen-space ordered dither, the sub-LSB offset varies per pixel, so a
+//! column inside a band carries two adjacent quantized values. The test asserts
+//! most columns are dithered (they would all be flat without it).
+#![cfg(feature = "wgpu")]
+
+use femtovg::{renderer::WGPURenderer, Canvas, Color, Paint, Path};
+
+const W: u32 = 220;
+const H: u32 = 64;
+
+fn headless_device() -> Option<(wgpu::Device, wgpu::Queue)> {
+    let instance = wgpu::Instance::default();
+    let adapter = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
+        power_preference: wgpu::PowerPreference::default(),
+        force_fallback_adapter: false,
+        compatible_surface: None,
+        ..Default::default()
+    }))
+    .ok()?;
+    let (device, queue) = pollster::block_on(adapter.request_device(&wgpu::DeviceDescriptor {
+        label: Some("femtovg gradient dither test device"),
+        required_features: wgpu::Features::empty(),
+        required_limits: wgpu::Limits::downlevel_defaults().using_resolution(adapter.limits()),
+        experimental_features: wgpu::ExperimentalFeatures::disabled(),
+        memory_hints: wgpu::MemoryHints::MemoryUsage,
+        trace: wgpu::Trace::default(),
+    }))
+    .ok()?;
+    Some((device, queue))
+}
+
+#[test]
+fn gradients_are_dithered_to_break_banding() {
+    let Some((device, queue)) = headless_device() else {
+        eprintln!("skipping: no wgpu adapter available");
+        return;
+    };
+
+    let target = device.create_texture(&wgpu::TextureDescriptor {
+        label: Some("dither out"),
+        size: wgpu::Extent3d {
+            width: W,
+            height: H,
+            depth_or_array_layers: 1,
+        },
+        mip_level_count: 1,
+        sample_count: 1,
+        dimension: wgpu::TextureDimension::D2,
+        format: wgpu::TextureFormat::Rgba8Unorm,
+        usage: wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::COPY_SRC,
+        view_formats: &[],
+    });
+    let renderer = WGPURenderer::new(device.clone(), queue.clone());
+    let mut canvas = Canvas::new(renderer).expect("canvas");
+    canvas.set_size(W, H, 1.0);
+
+    // Two very close grays across the width: only ~8 distinct 8-bit values, so
+    // without dithering the fill is a handful of flat vertical bands.
+    let paint = Paint::linear_gradient(
+        0.0,
+        0.0,
+        W as f32,
+        0.0,
+        Color::rgb(120, 120, 120),
+        Color::rgb(128, 128, 128),
+    );
+    let mut p = Path::new();
+    p.rect(0.0, 0.0, W as f32, H as f32);
+    canvas.fill_path(&p, &paint);
+
+    let commands = canvas.flush_to_output(&target);
+    queue.submit(commands);
+
+    let unpadded = W * 4;
+    let padded = unpadded.div_ceil(wgpu::COPY_BYTES_PER_ROW_ALIGNMENT) * wgpu::COPY_BYTES_PER_ROW_ALIGNMENT;
+    let readback = device.create_buffer(&wgpu::BufferDescriptor {
+        label: None,
+        size: (padded * H) as u64,
+        usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
+        mapped_at_creation: false,
+    });
+    let mut enc = device.create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
+    enc.copy_texture_to_buffer(
+        wgpu::TexelCopyTextureInfo {
+            texture: &target,
+            mip_level: 0,
+            origin: wgpu::Origin3d::ZERO,
+            aspect: wgpu::TextureAspect::All,
+        },
+        wgpu::TexelCopyBufferInfo {
+            buffer: &readback,
+            layout: wgpu::TexelCopyBufferLayout {
+                offset: 0,
+                bytes_per_row: Some(padded),
+                rows_per_image: Some(H),
+            },
+        },
+        wgpu::Extent3d {
+            width: W,
+            height: H,
+            depth_or_array_layers: 1,
+        },
+    );
+    queue.submit(Some(enc.finish()));
+    let slice = readback.slice(..);
+    slice.map_async(wgpu::MapMode::Read, |_| {});
+    device.poll(wgpu::PollType::wait_indefinitely()).unwrap();
+    let mapped = slice.get_mapped_range().expect("readback");
+    let red = |x: usize, y: usize| mapped[y * padded as usize + x * 4];
+
+    // A column is "dithered" if its red channel takes more than one value down the
+    // column. Without dithering every column is flat (one value).
+    let mut dithered_columns = 0;
+    for x in 0..W as usize {
+        let first = red(x, 0);
+        if (1..H as usize).any(|y| red(x, y) != first) {
+            dithered_columns += 1;
+        }
+    }
+    println!("dithered columns: {dithered_columns}/{W}");
+    assert!(
+        dithered_columns > W as usize / 2,
+        "expected most columns of a close-colour gradient to be dithered (vary down the \
+         column); got {dithered_columns}/{W}. Without dithering they would all be flat bands."
+    );
+}

--- a/tests/gradient_stress_wgpu.rs
+++ b/tests/gradient_stress_wgpu.rs
@@ -1,0 +1,198 @@
+//! Headless GPU coverage for gradient scenarios the unit tests missed, all
+//! cross-checked to match Chrome: the multi-stop LUT conic path (start angle +
+//! dither), and a semi-transparent gradient (the premultiplied-alpha /
+//! dither-fringe case). Skips when no GPU adapter is available.
+#![cfg(feature = "wgpu")]
+
+use femtovg::{renderer::WGPURenderer, Canvas, Color, Paint, Path};
+
+const W: u32 = 200;
+const H: u32 = 200;
+
+fn headless_device() -> Option<(wgpu::Device, wgpu::Queue)> {
+    let instance = wgpu::Instance::default();
+    let adapter = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
+        power_preference: wgpu::PowerPreference::default(),
+        force_fallback_adapter: false,
+        compatible_surface: None,
+        ..Default::default()
+    }))
+    .ok()?;
+    let (device, queue) = pollster::block_on(adapter.request_device(&wgpu::DeviceDescriptor {
+        label: Some("femtovg gradient stress test device"),
+        required_features: wgpu::Features::empty(),
+        required_limits: wgpu::Limits::downlevel_defaults().using_resolution(adapter.limits()),
+        experimental_features: wgpu::ExperimentalFeatures::disabled(),
+        memory_hints: wgpu::MemoryHints::MemoryUsage,
+        trace: wgpu::Trace::default(),
+    }))
+    .ok()?;
+    Some((device, queue))
+}
+
+fn render_scene(device: &wgpu::Device, queue: &wgpu::Queue, draw: impl FnOnce(&mut Canvas<WGPURenderer>)) -> Vec<u8> {
+    let target = device.create_texture(&wgpu::TextureDescriptor {
+        label: Some("grad stress out"),
+        size: wgpu::Extent3d {
+            width: W,
+            height: H,
+            depth_or_array_layers: 1,
+        },
+        mip_level_count: 1,
+        sample_count: 1,
+        dimension: wgpu::TextureDimension::D2,
+        format: wgpu::TextureFormat::Rgba8Unorm,
+        usage: wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::COPY_SRC,
+        view_formats: &[],
+    });
+    let renderer = WGPURenderer::new(device.clone(), queue.clone());
+    let mut canvas = Canvas::new(renderer).expect("canvas");
+    canvas.set_size(W, H, 1.0);
+    canvas.clear_rect(0, 0, W, H, Color::white());
+    draw(&mut canvas);
+    let commands = canvas.flush_to_output(&target);
+    queue.submit(commands);
+
+    let unpadded = W * 4;
+    let padded = unpadded.div_ceil(wgpu::COPY_BYTES_PER_ROW_ALIGNMENT) * wgpu::COPY_BYTES_PER_ROW_ALIGNMENT;
+    let readback = device.create_buffer(&wgpu::BufferDescriptor {
+        label: None,
+        size: (padded * H) as u64,
+        usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
+        mapped_at_creation: false,
+    });
+    let mut enc = device.create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
+    enc.copy_texture_to_buffer(
+        wgpu::TexelCopyTextureInfo {
+            texture: &target,
+            mip_level: 0,
+            origin: wgpu::Origin3d::ZERO,
+            aspect: wgpu::TextureAspect::All,
+        },
+        wgpu::TexelCopyBufferInfo {
+            buffer: &readback,
+            layout: wgpu::TexelCopyBufferLayout {
+                offset: 0,
+                bytes_per_row: Some(padded),
+                rows_per_image: Some(H),
+            },
+        },
+        wgpu::Extent3d {
+            width: W,
+            height: H,
+            depth_or_array_layers: 1,
+        },
+    );
+    queue.submit(Some(enc.finish()));
+    let slice = readback.slice(..);
+    slice.map_async(wgpu::MapMode::Read, |_| {});
+    device.poll(wgpu::PollType::wait_indefinitely()).unwrap();
+    let mapped = slice.get_mapped_range().expect("readback");
+    let mut pixels = vec![0u8; (unpadded * H) as usize];
+    for row in 0..H as usize {
+        let src = row * padded as usize;
+        let dst = row * unpadded as usize;
+        pixels[dst..dst + unpadded as usize].copy_from_slice(&mapped[src..src + unpadded as usize]);
+    }
+    drop(mapped);
+    readback.unmap();
+    pixels
+}
+
+fn px(pixels: &[u8], x: usize, y: usize) -> [u8; 3] {
+    let i = (y * W as usize + x) * 4;
+    [pixels[i], pixels[i + 1], pixels[i + 2]]
+}
+
+/// A multi-stop conic gradient uses the LUT (`renderImageGradientConic`) path,
+/// distinct from the two-colour `mix` path the other conic tests cover. Sampling
+/// a ring around the centre must show real angular colour variation (the start
+/// angle rotates it; the dither doesn't wash it out).
+#[test]
+fn multi_stop_conic_renders_distinct_hues() {
+    let Some((device, queue)) = headless_device() else {
+        eprintln!("skipping: no wgpu adapter available");
+        return;
+    };
+    let (cx, cy) = (W as f32 / 2.0, H as f32 / 2.0);
+    let wheel = [
+        (0.0, Color::rgb(230, 60, 60)),
+        (0.25, Color::rgb(230, 200, 50)),
+        (0.5, Color::rgb(60, 200, 110)),
+        (0.75, Color::rgb(60, 110, 230)),
+        (1.0, Color::rgb(230, 60, 60)),
+    ];
+    let pixels = render_scene(&device, &queue, |c| {
+        let mut p = Path::new();
+        p.rect(0.0, 0.0, W as f32, H as f32);
+        c.fill_path(&p, &Paint::conic_gradient_stops_with_angle(cx, cy, 0.0, wheel));
+    });
+
+    // Sample 8 points on a ring of radius 60 around the centre.
+    let mut samples = vec![];
+    for k in 0..8 {
+        let a = k as f32 / 8.0 * std::f32::consts::TAU;
+        let x = (cx + 60.0 * a.cos()).round() as usize;
+        let y = (cy + 60.0 * a.sin()).round() as usize;
+        samples.push(px(&pixels, x, y));
+    }
+    // Distinct hues (coarsely, by rounding each channel to 32s) — a solid fill or
+    // a broken conic would collapse to one.
+    let distinct: std::collections::HashSet<_> = samples.iter().map(|c| [c[0] / 32, c[1] / 32, c[2] / 32]).collect();
+    println!("ring samples: {samples:?} distinct={}", distinct.len());
+    assert!(
+        distinct.len() >= 4,
+        "multi-stop conic must vary around the ring, got {} distinct: {samples:?}",
+        distinct.len()
+    );
+    // Angular: the point at 0deg (+x) differs from 180deg (-x).
+    assert_ne!(samples[0], samples[4], "conic must differ across the diameter");
+}
+
+/// A gradient from opaque red to fully transparent red, over a white background.
+/// Correct premultiplied interpolation fades to the background with no dark band,
+/// and the dither must not tint the transparent end (a premultiply/fringe bug
+/// would leave the far end reddish or grey instead of white).
+#[test]
+fn semi_transparent_gradient_fades_to_background_without_fringe() {
+    let Some((device, queue)) = headless_device() else {
+        eprintln!("skipping: no wgpu adapter available");
+        return;
+    };
+    let pixels = render_scene(&device, &queue, |c| {
+        let paint = Paint::linear_gradient(
+            0.0,
+            0.0,
+            W as f32,
+            0.0,
+            Color::rgba(230, 30, 30, 255),
+            Color::rgba(230, 30, 30, 0),
+        );
+        let mut p = Path::new();
+        p.rect(0.0, 0.0, W as f32, H as f32);
+        c.fill_path(&p, &paint);
+    });
+    let y = H as usize / 2;
+    let near = px(&pixels, 3, y); // opaque end
+    let far = px(&pixels, W as usize - 4, y); // transparent end
+    println!("near(opaque)={near:?} far(transparent)={far:?}");
+
+    // Opaque end is red.
+    assert!(
+        near[0] > 180 && near[1] < 90 && near[2] < 90,
+        "opaque end must be red, got {near:?}"
+    );
+    // Transparent end shows the white background — not tinted red/grey by the
+    // dither or a premultiply error.
+    assert!(
+        far[0] > 244 && far[1] > 244 && far[2] > 244,
+        "transparent end must fade to the white background (no fringe), got {far:?}"
+    );
+    // No dark band: green never dips below the opaque end's green along the row.
+    let min_green = (0..W as usize).map(|x| px(&pixels, x, y)[1]).min().unwrap();
+    assert!(
+        min_green + 3 >= near[1],
+        "no pixel may be darker (lower green) than the opaque end — a dark band would mean bad premultiply; min green {min_green} vs opaque {}",
+        near[1]
+    );
+}

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -472,3 +472,207 @@ fn font_italic_falls_back_to_slnt_axis() {
     );
     assert!(italic_metrics.width() > 0.0, "Italic text should have positive width");
 }
+
+/// Headless GPU conformance check for the conic gradient: render a conic gradient
+/// with `start_angle = 0` into an offscreen Rgba8 texture and verify that the
+/// offset-0 color sits at the positive x axis (3 o'clock) and that the ramp
+/// proceeds clockwise, matching the Canvas 2D `createConicGradient` convention.
+///
+/// The gradient is split into a red half (offsets `[0, 0.5)`) and a blue half
+/// (offsets `[0.5, 1)`). With the +x-axis-start, clockwise convention (screen y
+/// points down) the offset-0 color sits at 3 o'clock, and the red->blue boundary
+/// falls at 9 o'clock. Sampling is done away from that boundary, at the four
+/// diagonal directions whose offsets are 0.125 / 0.375 / 0.625 / 0.875:
+/// down-right (0.125) and down-left (0.375) are red; up-left (0.625) and
+/// up-right (0.875) are blue. The offset-0 color is also checked directly at
+/// 3 o'clock.
+///
+/// The old top-start convention would rotate this by a quarter turn, so the
+/// test also locks in the 90-degree phase fix.
+#[cfg(feature = "wgpu")]
+#[test]
+fn conic_gradient_start_angle_matches_canvas_convention() {
+    use femtovg::renderer::WGPURenderer;
+
+    const SIZE: u32 = 64;
+    const CENTER: f32 = SIZE as f32 / 2.0;
+
+    let instance = wgpu::Instance::default();
+
+    let Some(adapter) = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
+        power_preference: wgpu::PowerPreference::default(),
+        force_fallback_adapter: false,
+        compatible_surface: None,
+        ..Default::default()
+    }))
+    .ok() else {
+        // No GPU adapter available (e.g. headless CI without a backend); skip.
+        eprintln!("skipping conic gradient GPU test: no wgpu adapter available");
+        return;
+    };
+
+    let (device, queue) = pollster::block_on(adapter.request_device(&wgpu::DeviceDescriptor {
+        label: Some("conic gradient test device"),
+        required_features: wgpu::Features::empty(),
+        required_limits: wgpu::Limits::downlevel_defaults().using_resolution(adapter.limits()),
+        ..Default::default()
+    }))
+    .expect("Failed to create device");
+
+    // Offscreen render target.
+    let texture = device.create_texture(&wgpu::TextureDescriptor {
+        label: Some("conic gradient target"),
+        size: wgpu::Extent3d {
+            width: SIZE,
+            height: SIZE,
+            depth_or_array_layers: 1,
+        },
+        mip_level_count: 1,
+        sample_count: 1,
+        dimension: wgpu::TextureDimension::D2,
+        format: wgpu::TextureFormat::Rgba8Unorm,
+        usage: wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::COPY_SRC,
+        view_formats: &[],
+    });
+
+    // bytes_per_row must be a multiple of 256.
+    let align = wgpu::COPY_BYTES_PER_ROW_ALIGNMENT;
+    let padded_bpr = (SIZE * 4).div_ceil(align) * align;
+
+    // Red for the first half of the sweep, blue for the second half.
+    let red = Color::rgbf(1.0, 0.0, 0.0);
+    let blue = Color::rgbf(0.0, 0.0, 1.0);
+
+    // Render the conic gradient with the given start angle and read the texture
+    // back into a CPU buffer, returning a sampler over the resulting pixels.
+    let render = |start_angle: f32| -> Vec<u8> {
+        let renderer = WGPURenderer::new(device.clone(), queue.clone());
+        let mut canvas = Canvas::new(renderer).unwrap();
+        canvas.set_size(SIZE, SIZE, 1.0);
+        canvas.clear_rect(0, 0, SIZE, SIZE, Color::black());
+
+        let paint = Paint::conic_gradient_stops_with_angle(
+            CENTER,
+            CENTER,
+            start_angle,
+            [(0.0, red), (0.4999, red), (0.5, blue), (1.0, blue)],
+        );
+
+        let mut path = Path::new();
+        path.rect(0.0, 0.0, SIZE as f32, SIZE as f32);
+        canvas.fill_path(&path, &paint);
+
+        let commands = canvas.flush_to_output(&texture);
+        queue.submit(commands);
+
+        let readback = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("conic gradient readback"),
+            size: (padded_bpr * SIZE) as u64,
+            usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
+            mapped_at_creation: false,
+        });
+
+        let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor::default());
+        encoder.copy_texture_to_buffer(
+            texture.as_image_copy(),
+            wgpu::TexelCopyBufferInfo {
+                buffer: &readback,
+                layout: wgpu::TexelCopyBufferLayout {
+                    offset: 0,
+                    bytes_per_row: Some(padded_bpr),
+                    rows_per_image: Some(SIZE),
+                },
+            },
+            wgpu::Extent3d {
+                width: SIZE,
+                height: SIZE,
+                depth_or_array_layers: 1,
+            },
+        );
+        queue.submit(Some(encoder.finish()));
+
+        let slice = readback.slice(..);
+        slice.map_async(wgpu::MapMode::Read, |result| result.expect("buffer map failed"));
+        device
+            .poll(wgpu::PollType::wait_indefinitely())
+            .expect("device poll failed");
+
+        let pixels = slice.get_mapped_range().expect("mapped range unavailable").to_vec();
+        readback.unmap();
+        pixels
+    };
+
+    let sampler = |pixels: &[u8], dx: i32, dy: i32| -> (u8, u8, u8) {
+        let x = (CENTER as i32 + dx) as u32;
+        let y = (CENTER as i32 + dy) as u32;
+        let idx = (y * padded_bpr + x * 4) as usize;
+        (pixels[idx], pixels[idx + 1], pixels[idx + 2])
+    };
+
+    let is_red = |(r, _g, b): (u8, u8, u8)| r > 200 && b < 60;
+    let is_blue = |(r, _g, b): (u8, u8, u8)| b > 200 && r < 60;
+
+    // start_angle = 0: offset-0 color sits at +x (3 o'clock), ramp clockwise.
+    let pixels = render(0.0);
+    let sample = |dx, dy| sampler(&pixels, dx, dy);
+
+    // offset-0 color sits exactly at the +x axis (3 o'clock).
+    let right = sample(12, 0);
+    // Diagonals avoid the sharp red/blue boundary that falls on the cardinal axes.
+    let down_right = sample(9, 9); // offset 0.125 -> red
+    let down_left = sample(-9, 9); // offset 0.375 -> red
+    let up_left = sample(-9, -9); // offset 0.625 -> blue
+    let up_right = sample(9, -9); // offset 0.875 -> blue
+
+    assert!(
+        is_red(right),
+        "offset-0 color must sit at the +x axis (3 o'clock); got {right:?}"
+    );
+    assert!(
+        is_red(down_right),
+        "offset-0.125 (clockwise toward 6 o'clock, screen y-down) must be red; got {down_right:?}"
+    );
+    assert!(
+        is_red(down_left),
+        "offset-0.375 (just before 9 o'clock) must be red; got {down_left:?}"
+    );
+    assert!(
+        is_blue(up_left),
+        "offset-0.625 (just after 9 o'clock) must be blue; got {up_left:?}"
+    );
+    assert!(
+        is_blue(up_right),
+        "offset-0.875 (toward 3 o'clock from the top) must be blue; got {up_right:?}"
+    );
+
+    // start_angle = +PI/2 rotates the gradient a quarter turn clockwise (toward 6
+    // o'clock). The red half now spans offsets that map to the down-left and
+    // up-left diagonals, and the blue half maps to the up-right and down-right
+    // diagonals: exactly the quarter-turn clockwise rotation of the start_angle=0
+    // case above. (The exact offset-0 point at 6 o'clock is the wrap boundary, so
+    // it is not asserted; the diagonals unambiguously prove the rotation.)
+    let pixels = render(std::f32::consts::FRAC_PI_2);
+    let sample = |dx, dy| sampler(&pixels, dx, dy);
+
+    let down_left = sample(-9, 9); // offset 0.125 -> red
+    let up_left = sample(-9, -9); // offset 0.375 -> red
+    let up_right = sample(9, -9); // offset 0.625 -> blue
+    let down_right = sample(9, 9); // offset 0.875 -> blue
+
+    assert!(
+        is_red(down_left),
+        "with start_angle=PI/2, offset-0.125 must be red; got {down_left:?}"
+    );
+    assert!(
+        is_red(up_left),
+        "with start_angle=PI/2, offset-0.375 must be red; got {up_left:?}"
+    );
+    assert!(
+        is_blue(up_right),
+        "with start_angle=PI/2, offset-0.625 must be blue; got {up_right:?}"
+    );
+    assert!(
+        is_blue(down_right),
+        "with start_angle=PI/2, offset-0.875 must be blue; got {down_right:?}"
+    );
+}


### PR DESCRIPTION
Adds a start angle to conic gradients, giving Canvas `createConicGradient(startAngle, x, y)` parity (and SVG 2 conic alignment). Today femtovg's conic gradient always begins at the positive x-axis; this lets the caller rotate where offset 0 sits.

### Also in this PR: gradient dithering (closes #239)

Since this PR already works in the shared gradient shader path, it also adds
screen-space **ordered dithering** to gradients, addressing the banding reported
in #239. Gradients between close colours band under 8-bit quantization; a
sub-LSB interleaved-gradient-noise offset before the framebuffer write spreads
the rounding spatially and breaks the bands. Applied to every gradient type
(linear/radial box, conic, and their multi-stop LUT variants) on both backends,
with no new uniforms or memory (a few ALU ops per fragment); solid regions are
unaffected. Covered by a wgpu test (`gradient_dither_wgpu.rs`): a close-colour
gradient has 0/220 columns dithered before, most after.

![gradient dithering before/after](https://raw.githubusercontent.com/rebeckerspecialties/femtovg/pixel-comparisons/comparisons/gradient_dither.png)

### API

`Paint::conic_gradient_with_angle(cx, cy, start_angle, start, end)` and `Paint::conic_gradient_stops_with_angle(cx, cy, start_angle, stops)`; the existing angle-less constructors delegate with `start_angle = 0.0` (unchanged behavior). `start_angle` is in radians, measured clockwise from +x, matching the Canvas convention. A non-finite angle (NaN/∞) is treated as `0.0` at the API edge, like the `set_shadow_*` setters.

### Comparison vs Chrome

Six-stop wheels at start angles 0°, 90°, 180° — femtovg vs Chrome's `createConicGradient(angle, cx, cy)` with the same stops. The seam/offset-0 position tracks Chrome at each angle (difference is edge antialiasing only, 0.78% of pixels above the AA floor):

![conic start-angle vs Chrome](https://raw.githubusercontent.com/rebeckerspecialties/femtovg/pixel-comparisons/comparisons/conic_start_angle.png)

Composition testing (a conic gradient inside a rounded scissor, with text + drop shadow layered on top) surfaced a pre-existing wgpu-backend bug: the WGSL conic cases `return`ed their colour directly, *before* the scissor-mask + stroke-AA multiply every other fill type falls through to — so conic fills ignored the scissor (rounded corners included) and had no edge antialiasing. The GLSL backend was already correct. Fixed and added a pinning test which fails before the fix and passes after.

The composed scene now clips correctly and matches Chrome (`createConicGradient` + `roundRect` clip, same numbers) at 0.71%:

![conic clipped by rounded scissor, text+shadow on top](https://raw.githubusercontent.com/rebeckerspecialties/femtovg/pixel-comparisons/comparisons/conic_scissor_clip.png)

GLSL, WGSL and the Rust `UniformArray`/`Params` were verified byte-consistent, and a test (`rounded_scissor_and_conic_start_angle_coexist_in_params`) asserts an angled conic and a rounded scissor set their respective slots without messing eachother up. The GPU phase test renders through the current shader (which now also contains the shadow-blur uniforms), so it validates the byte offset end to end, not just the glue between the pieces.

very fun to come up with compositions of these features and stay within the memory/compute limit goals :D

### Back-compat

`start_angle` is `#[serde(default)]`, so paints serialized before this field deserialize to a `0.0` start angle (previous behavior). Covered by a round-trip test.

### Tests

- `conic_gradient_start_angle_is_plumbed_into_params` — the angle reaches `Params`/the uniform slot.
- `rounded_scissor_and_conic_start_angle_coexist_in_params` — no slot collision with #280.
- `conic_gradient_start_angle_matches_canvas_convention` — GPU render: offset 0 at +x for angle 0, advancing clockwise (mirrors WebKit's `fast/canvas/canvas-conic-gradient-angle`).
- `conic_gradient_non_finite_start_angle_is_treated_as_zero` — the API-edge guard.
- serde back-compat round-trip.

### Validation

- `cargo fmt --check`
- `cargo build` / `cargo build --features wgpu`
- `cargo test --features "wgpu textlayout"` (both backends green)

Filed as a draft pending review bandwidth; no dependency on other open PRs.


