### PR TITLE
Add an HtmlCanvasElement image source

### DIFF
--- a/src/image.rs
+++ b/src/image.rs
@@ -59,6 +59,9 @@ pub enum ImageSource<'a> {
     /// Image source referencing a HTML image element (only available on `wasm32` target)
     #[cfg(target_arch = "wasm32")]
     HtmlImageElement(&'a web_sys::HtmlImageElement),
+    /// Image source referencing a HTML canvas element (only available on `wasm32` target)
+    #[cfg(target_arch = "wasm32")]
+    HtmlCanvasElement(&'a web_sys::HtmlCanvasElement),
 }
 
 impl ImageSource<'_> {
@@ -69,7 +72,7 @@ impl ImageSource<'_> {
             Self::Rgba(_) => PixelFormat::Rgba8,
             Self::Gray(_) => PixelFormat::Gray8,
             #[cfg(target_arch = "wasm32")]
-            Self::HtmlImageElement(_) => PixelFormat::Rgba8,
+            Self::HtmlImageElement(_) | Self::HtmlCanvasElement(_) => PixelFormat::Rgba8,
         }
     }
 
@@ -81,6 +84,8 @@ impl ImageSource<'_> {
             Self::Gray(imgref) => Size::new(imgref.width(), imgref.height()),
             #[cfg(target_arch = "wasm32")]
             Self::HtmlImageElement(element) => Size::new(element.width() as usize, element.height() as usize),
+            #[cfg(target_arch = "wasm32")]
+            Self::HtmlCanvasElement(element) => Size::new(element.width() as usize, element.height() as usize),
         }
     }
 }
@@ -107,6 +112,13 @@ impl<'a> From<ImgRef<'a, Gray<u8>>> for ImageSource<'a> {
 impl<'a> From<&'a web_sys::HtmlImageElement> for ImageSource<'a> {
     fn from(src: &'a web_sys::HtmlImageElement) -> Self {
         Self::HtmlImageElement(src)
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+impl<'a> From<&'a web_sys::HtmlCanvasElement> for ImageSource<'a> {
+    fn from(src: &'a web_sys::HtmlCanvasElement) -> Self {
+        Self::HtmlCanvasElement(src)
     }
 }
 

--- a/src/renderer/opengl/gl_texture.rs
+++ b/src/renderer/opengl/gl_texture.rs
@@ -265,6 +265,18 @@ impl GlTexture {
                     image_element,
                 )
             },
+            #[cfg(target_arch = "wasm32")]
+            ImageSource::HtmlCanvasElement(canvas_element) => unsafe {
+                context.tex_sub_image_2d_with_html_canvas(
+                    glow::TEXTURE_2D,
+                    0,
+                    x as i32,
+                    y as i32,
+                    glow::RGBA,
+                    glow::UNSIGNED_BYTE,
+                    canvas_element,
+                )
+            },
         }
 
         if self.info.flags().contains(ImageFlags::GENERATE_MIPMAPS) {

--- a/src/renderer/wgpu.rs
+++ b/src/renderer/wgpu.rs
@@ -603,13 +603,23 @@ impl Renderer for WGPURenderer {
         y: usize,
     ) -> Result<(), crate::ErrorKind> {
         #[cfg(target_arch = "wasm32")]
-        if let crate::ImageSource::HtmlImageElement(htmlimage) = data {
+        let external_source = match data {
+            crate::ImageSource::HtmlImageElement(element) => {
+                Some(wgpu::ExternalImageSource::HTMLImageElement(element.clone()))
+            }
+            crate::ImageSource::HtmlCanvasElement(element) => {
+                Some(wgpu::ExternalImageSource::HTMLCanvasElement(element.clone()))
+            }
+            _ => None,
+        };
+        #[cfg(target_arch = "wasm32")]
+        if let Some(source) = external_source {
             let Texture::Internal(texture) = &image.texture else {
                 return Err(crate::ErrorKind::UnsupportedOperation);
             };
             self.queue.copy_external_image_to_texture(
                 &wgpu::CopyExternalImageSourceInfo {
-                    source: wgpu::ExternalImageSource::HTMLImageElement(htmlimage.clone()),
+                    source,
                     origin: wgpu::Origin2d::ZERO,
                     flip_y: false,
                 },
@@ -653,7 +663,7 @@ impl Renderer for WGPURenderer {
             crate::ImageSource::Rgba(img) => (img.buf().as_bytes(), 4),
             crate::ImageSource::Gray(img) => (img.buf().as_bytes(), 1),
             #[cfg(target_arch = "wasm32")]
-            crate::ImageSource::HtmlImageElement(..) => {
+            crate::ImageSource::HtmlImageElement(..) | crate::ImageSource::HtmlCanvasElement(..) => {
                 unreachable!()
             }
         };

--- a/src/renderer/wgpu.rs
+++ b/src/renderer/wgpu.rs
@@ -240,6 +240,46 @@ pub struct WGPURenderer {
 }
 
 impl WGPURenderer {
+    /// Uploads a browser-side image source straight into an image's texture.
+    #[cfg(target_arch = "wasm32")]
+    fn copy_external_image(
+        &self,
+        image: &Image,
+        source: wgpu::ExternalImageSource,
+        size: crate::image::Size,
+        x: usize,
+        y: usize,
+    ) -> Result<(), crate::ErrorKind> {
+        let Texture::Internal(texture) = &image.texture else {
+            return Err(crate::ErrorKind::UnsupportedOperation);
+        };
+        self.queue.copy_external_image_to_texture(
+            &wgpu::CopyExternalImageSourceInfo {
+                source,
+                origin: wgpu::Origin2d::ZERO,
+                flip_y: false,
+            },
+            wgpu::CopyExternalImageDestInfo {
+                texture,
+                mip_level: 0,
+                origin: wgpu::Origin3d {
+                    x: x as u32,
+                    y: y as u32,
+                    z: 0,
+                },
+                aspect: wgpu::TextureAspect::All,
+                color_space: wgpu::PredefinedColorSpace::Srgb,
+                premultiplied_alpha: true,
+            },
+            wgpu::Extent3d {
+                width: size.width as _,
+                height: size.height as _,
+                depth_or_array_layers: 1,
+            },
+        );
+        Ok(())
+    }
+
     /// Creates a new renderer for the device.
     pub fn new(device: wgpu::Device, queue: wgpu::Queue) -> Self {
         let module = wgpu::include_wgsl!("wgpu/shader.wgsl");
@@ -602,48 +642,6 @@ impl Renderer for WGPURenderer {
         x: usize,
         y: usize,
     ) -> Result<(), crate::ErrorKind> {
-        #[cfg(target_arch = "wasm32")]
-        let external_source = match data {
-            crate::ImageSource::HtmlImageElement(element) => {
-                Some(wgpu::ExternalImageSource::HTMLImageElement(element.clone()))
-            }
-            crate::ImageSource::HtmlCanvasElement(element) => {
-                Some(wgpu::ExternalImageSource::HTMLCanvasElement(element.clone()))
-            }
-            _ => None,
-        };
-        #[cfg(target_arch = "wasm32")]
-        if let Some(source) = external_source {
-            let Texture::Internal(texture) = &image.texture else {
-                return Err(crate::ErrorKind::UnsupportedOperation);
-            };
-            self.queue.copy_external_image_to_texture(
-                &wgpu::CopyExternalImageSourceInfo {
-                    source,
-                    origin: wgpu::Origin2d::ZERO,
-                    flip_y: false,
-                },
-                wgpu::CopyExternalImageDestInfo {
-                    texture,
-                    mip_level: 0,
-                    origin: wgpu::Origin3d {
-                        x: x as u32,
-                        y: y as u32,
-                        z: 0,
-                    },
-                    aspect: wgpu::TextureAspect::All,
-                    color_space: wgpu::PredefinedColorSpace::Srgb,
-                    premultiplied_alpha: true,
-                },
-                wgpu::Extent3d {
-                    width: data.dimensions().width as _,
-                    height: data.dimensions().height as _,
-                    depth_or_array_layers: 1,
-                },
-            );
-            return Ok(());
-        }
-
         use rgb::ComponentBytes;
 
         let converted_rgba;
@@ -663,8 +661,14 @@ impl Renderer for WGPURenderer {
             crate::ImageSource::Rgba(img) => (img.buf().as_bytes(), 4),
             crate::ImageSource::Gray(img) => (img.buf().as_bytes(), 1),
             #[cfg(target_arch = "wasm32")]
-            crate::ImageSource::HtmlImageElement(..) | crate::ImageSource::HtmlCanvasElement(..) => {
-                unreachable!()
+            crate::ImageSource::HtmlImageElement(element) => {
+                let source = wgpu::ExternalImageSource::HTMLImageElement(element.clone());
+                return self.copy_external_image(image, source, data.dimensions(), x, y);
+            }
+            #[cfg(target_arch = "wasm32")]
+            crate::ImageSource::HtmlCanvasElement(element) => {
+                let source = wgpu::ExternalImageSource::HTMLCanvasElement(element.clone());
+                return self.copy_external_image(image, source, data.dimensions(), x, y);
             }
         };
 


### PR DESCRIPTION
Refs #299.

`ImageSource::dimensions()` returns an `HtmlImageElement`'s attribute size, which is what the OpenGL renderer needs: the browser rasterizes an SVG at those attributes when uploading through `tex_sub_image_2d_with_html_image`. WebGPU reads the same element at its natural size and validates the copy rect against that, so a caller enlarging the attributes for a sharper hidpi rasterization gets an out of bounds copy and a panic out of wgpu. The issue has a self-contained page measuring this: for a 16x16 SVG whose attributes are set to 20x20, a 20x20 copy fails and a 16x16 copy succeeds.

A canvas carries one size for both backends, so this adds `ImageSource::HtmlCanvasElement` and lets a caller rasterize a scalable source at the size it wants before handing it over. The same measurement shows a 20x20 canvas uploading cleanly and holding a real 20x20 rasterization rather than a stretched 16x16 one.

The variant is wasm only, alongside the existing `HtmlImageElement`, and both backends already have what it needs: `tex_sub_image_2d_with_html_canvas` in glow, `ExternalImageSource::HTMLCanvasElement` in wgpu. `ImageSource` is `#[non_exhaustive]`, so adding it does not break downstream matches.

The second commit is a small restructure of `update_image`. Handling the browser-side sources before the byte upload meant naming both variants twice, once to detect them and once more to satisfy exhaustiveness in the byte match where they could only be `unreachable!()`. Uploading from the arm that matched them keeps each variant to a single mention and removes the unreachable arm, at the cost of moving the shared copy into a helper. Behaviour is unchanged, and the commit is separable if you would rather keep the existing shape.

The `HtmlImageElement` path can still panic when a caller enlarges the attributes, and I left that out of this PR because the sensible response is a judgement call: clamping the extent to the natural size contains it but silently uploads a smaller image, while returning `ErrorKind::ImageUpdateOutOfBounds` makes the mismatch visible and matches how `update_image` already reports a destination overflow. I have the clamp written and will send whichever you prefer.

**Testing**

`cargo check` passes for wasm32 with `--features wgpu --no-default-features`, for wasm32 with the OpenGL backend, and for the native default build. `cargo fmt --check` is clean.

I have not exercised the new variant through a browser end to end. The WebGPU behaviour it relies on is measured in the issue, and the wiring on both backends is a single call each, but a rendering test would be a fair thing to ask for and I am happy to add one if you point me at where it belongs.

