### PR TITLE
Rasterize resized HtmlImageElement uploads through a canvas

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ glutin = { version = "0.32", optional = true, default-features = false }
 web_sys = { version = "0.3", package = "web-sys", features = [
     "WebGlContextAttributes",
     "HtmlImageElement",
+    "CanvasRenderingContext2d",
     "WebGl2RenderingContext",
 ] }
 wasm-bindgen = "0.2"

--- a/src/renderer/wgpu.rs
+++ b/src/renderer/wgpu.rs
@@ -239,6 +239,35 @@ pub struct WGPURenderer {
     pipeline_cache: Rc<RefCell<HashMap<PipelineState, CachedPipeline>>>,
 }
 
+/// Rasterizes an image element into an offscreen canvas at the given size.
+#[cfg(target_arch = "wasm32")]
+fn rasterize_to_canvas(
+    element: &web_sys::HtmlImageElement,
+    size: crate::image::Size,
+) -> Result<web_sys::HtmlCanvasElement, crate::ErrorKind> {
+    use wasm_bindgen::JsCast;
+
+    let canvas = web_sys::window()
+        .and_then(|window| window.document())
+        .and_then(|document| document.create_element("canvas").ok())
+        .and_then(|element| element.dyn_into::<web_sys::HtmlCanvasElement>().ok())
+        .ok_or(crate::ErrorKind::UnsupportedOperation)?;
+    canvas.set_width(size.width as u32);
+    canvas.set_height(size.height as u32);
+
+    let context = canvas
+        .get_context("2d")
+        .ok()
+        .flatten()
+        .and_then(|context| context.dyn_into::<web_sys::CanvasRenderingContext2d>().ok())
+        .ok_or(crate::ErrorKind::UnsupportedOperation)?;
+    context
+        .draw_image_with_html_image_element_and_dw_and_dh(element, 0., 0., size.width as f64, size.height as f64)
+        .map_err(|_| crate::ErrorKind::UnsupportedOperation)?;
+
+    Ok(canvas)
+}
+
 impl WGPURenderer {
     /// Uploads a browser-side image source straight into an image's texture.
     #[cfg(target_arch = "wasm32")]
@@ -662,8 +691,16 @@ impl Renderer for WGPURenderer {
             crate::ImageSource::Gray(img) => (img.buf().as_bytes(), 1),
             #[cfg(target_arch = "wasm32")]
             crate::ImageSource::HtmlImageElement(element) => {
-                let source = wgpu::ExternalImageSource::HTMLImageElement(element.clone());
-                return self.copy_external_image(image, source, data.dimensions(), x, y);
+                let size = data.dimensions();
+                // WebGPU copies from the natural size, so attribute sizes would overflow or crop the rect.
+                let resized =
+                    element.width() != element.natural_width() || element.height() != element.natural_height();
+                let source = if resized {
+                    wgpu::ExternalImageSource::HTMLCanvasElement(rasterize_to_canvas(element, size)?)
+                } else {
+                    wgpu::ExternalImageSource::HTMLImageElement(element.clone())
+                };
+                return self.copy_external_image(image, source, size, x, y);
             }
             #[cfg(target_arch = "wasm32")]
             crate::ImageSource::HtmlCanvasElement(element) => {


### PR DESCRIPTION
Fixes the panic tracked in #299: WebGPU copies an `HtmlImageElement` from its
natural size, so a caller that enlarges the `width`/`height` attributes asks
for a copy extent larger than the source and validation rejects it. Slint does
exactly this to get sharper icons on hidpi displays.

When the attribute size differs from the natural size, the upload now goes
through an offscreen canvas drawn at the attribute size, reusing the
`HTMLCanvasElement` path added in #300. Matching sizes stay on the direct path,
and the OpenGL backend is untouched, since the attribute size is already the
truth there. Callers need no change.

The condition triggers on any mismatch, so an element whose attributes are
*smaller* than its natural size now takes the canvas route as well. My reading
of `copyExternalImageToTexture` is that the direct path crops from the source
origin there rather than scaling down, which would make this a fix too, but I
have only measured the enlarging case. If you would rather keep the change
strictly to the reported panic, narrowing the condition to `>` is a one line
edit and I will push it.

## On ImageBitmap

@tronical suggested an intermediate `ImageBitmap` in #299, and this does the
same thing with a different primitive. `createImageBitmap` returns a Promise,
while `Renderer::update_image` is a synchronous trait method. A wasm main
thread cannot wait for that Promise to resolve: the event loop that would
settle it is the one being blocked. Making the path async would spread up
through `Canvas::update_image`, into the glyph atlas uploads in `text.rs`, and
therefore into `fill_text`, forcing all three backends to change for a branch
that only ever runs on wasm with WebGPU.

`drawImage` is synchronous and produces the same result. It also has evidence
behind it: the measurement in #299 reads back three distinct shades along the
diagonal of a 20x20 upload, so the SVG really is re-rasterized rather than
stretched. `resizeWidth`/`resizeHeight` on `createImageBitmap` is specified as
resizing the decoded bitmap, which does not guarantee re-rasterization.

## Testing

Verified by hand in a browser, since the path needs wasm, WebGPU and a DOM
`<img>` at once. The repository has no wasm test harness to hook into, and the
existing headless GPU tests run against a native adapter where
`HtmlImageElement` does not exist. Happy to add one if you want the tooling.

Two edge cases are left alone: an image that has not finished loading, and an
SVG with no intrinsic size, both give `drawImage` nothing to draw and upload a
blank canvas where the direct path would raise an error. Guarding those changes
the error semantics of the API, so it seemed better as a separate discussion.