### PR TITLE
perf(wgpu): cache the samplers and empty texture view instead of rebuilding them per draw

### DIFF
--- a/src/renderer/wgpu.rs
+++ b/src/renderer/wgpu.rs
@@ -213,6 +213,24 @@ pub struct Image {
     info: ImageInfo,
 }
 
+/// The only flags a sampler descriptor reads. Keying on all of `ImageFlags` would miss on the rest.
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+struct SamplerKey {
+    repeat_x: bool,
+    repeat_y: bool,
+    nearest: bool,
+}
+
+impl From<crate::ImageFlags> for SamplerKey {
+    fn from(flags: crate::ImageFlags) -> Self {
+        Self {
+            repeat_x: flags.contains(crate::ImageFlags::REPEAT_X),
+            repeat_y: flags.contains(crate::ImageFlags::REPEAT_Y),
+            nearest: flags.contains(crate::ImageFlags::NEAREST),
+        }
+    }
+}
+
 #[derive(Debug)]
 struct CachedPipeline {
     pipeline: wgpu::RenderPipeline,
@@ -230,6 +248,9 @@ pub struct WGPURenderer {
     screen_view: [f32; 2],
 
     empty_texture: wgpu::Texture,
+    /// View of the 1x1 empty texture. Never varies, and rebuilding it per draw cost a wasm round trip.
+    empty_texture_view: wgpu::TextureView,
+    sampler_cache: Rc<RefCell<HashMap<SamplerKey, wgpu::Sampler>>>,
     stencil_buffer: Option<wgpu::Texture>,
     stencil_buffer_for_textures: HashMap<wgpu::Texture, wgpu::Texture>,
 
@@ -388,7 +409,9 @@ impl WGPURenderer {
 
             screen_view: [0.0, 0.0],
 
+            empty_texture_view: empty_texture.create_view(&Default::default()),
             empty_texture,
+            sampler_cache: Rc::new(RefCell::new(HashMap::new())),
             stencil_buffer: None,
             stencil_buffer_for_textures: HashMap::new(),
             bind_group_layout,
@@ -478,7 +501,8 @@ impl Renderer for WGPURenderer {
 
         let mut pipeline_and_bindgroup_mapper = CommandToPipelineAndBindGroupMapper::new(
             self.device.clone(),
-            self.empty_texture.clone(),
+            self.empty_texture_view.clone(),
+            self.sampler_cache.clone(),
             self.shader_module.clone(),
             self.bind_group_layout.clone(),
             self.pipeline_layout.clone(),
@@ -1379,7 +1403,8 @@ impl BindGroupState {
         device: &wgpu::Device,
         images: &ImageStore<Image>,
         bind_group_layout: &wgpu::BindGroupLayout,
-        empty_texture: &wgpu::Texture,
+        empty_texture_view: &wgpu::TextureView,
+        sampler_cache: &RefCell<HashMap<SamplerKey, wgpu::Sampler>>,
     ) -> wgpu::BindGroup {
         let uniform_buf = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
             label: Some("Fragment Uniform Buffer"),
@@ -1387,13 +1412,19 @@ impl BindGroupState {
             usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
         });
 
-        let (main_texture_view, main_sampler) =
-            RenderPassBuilder::create_binding_resource_and_sampler(device, images, self.image.as_ref(), empty_texture);
+        let (main_texture_view, main_sampler) = RenderPassBuilder::create_binding_resource_and_sampler(
+            device,
+            images,
+            self.image.as_ref(),
+            empty_texture_view,
+            sampler_cache,
+        );
         let (glyph_texture_view, glyph_sampler) = RenderPassBuilder::create_binding_resource_and_sampler(
             device,
             images,
             self.glyph_texture.image_id().map(ImageOrTexture::Image).as_ref(),
-            empty_texture,
+            empty_texture_view,
+            sampler_cache,
         );
 
         if main_texture_view.is_external() || glyph_texture_view.is_external() {
@@ -1522,7 +1553,8 @@ impl<'a> RenderPassBuilder<'a> {
         device: &wgpu::Device,
         images: &ImageStore<Image>,
         image: Option<&ImageOrTexture>,
-        empty_texture: &wgpu::Texture,
+        empty_texture_view: &wgpu::TextureView,
+        sampler_cache: &RefCell<HashMap<SamplerKey, wgpu::Sampler>>,
     ) -> (OwnedBindingResource, wgpu::Sampler) {
         let flags = image
             .and_then(|image_or_texture| match image_or_texture {
@@ -1537,22 +1569,28 @@ impl<'a> RenderPassBuilder<'a> {
             wgpu::FilterMode::Linear
         };
 
-        let sampler = device.create_sampler(&wgpu::SamplerDescriptor {
-            address_mode_u: if flags.contains(crate::ImageFlags::REPEAT_X) {
-                wgpu::AddressMode::Repeat
-            } else {
-                wgpu::AddressMode::ClampToEdge
-            },
-            address_mode_v: if flags.contains(crate::ImageFlags::REPEAT_Y) {
-                wgpu::AddressMode::Repeat
-            } else {
-                wgpu::AddressMode::ClampToEdge
-            },
-            address_mode_w: wgpu::AddressMode::ClampToEdge,
-            mag_filter: filter_mode,
-            min_filter: filter_mode,
-            ..Default::default()
-        });
+        let sampler = sampler_cache
+            .borrow_mut()
+            .entry(SamplerKey::from(flags))
+            .or_insert_with(|| {
+                device.create_sampler(&wgpu::SamplerDescriptor {
+                    address_mode_u: if flags.contains(crate::ImageFlags::REPEAT_X) {
+                        wgpu::AddressMode::Repeat
+                    } else {
+                        wgpu::AddressMode::ClampToEdge
+                    },
+                    address_mode_v: if flags.contains(crate::ImageFlags::REPEAT_Y) {
+                        wgpu::AddressMode::Repeat
+                    } else {
+                        wgpu::AddressMode::ClampToEdge
+                    },
+                    address_mode_w: wgpu::AddressMode::ClampToEdge,
+                    mag_filter: filter_mode,
+                    min_filter: filter_mode,
+                    ..Default::default()
+                })
+            })
+            .clone();
 
         let binding_resource = image
             .and_then(|image_or_texture| match image_or_texture {
@@ -1566,7 +1604,7 @@ impl<'a> RenderPassBuilder<'a> {
                     texture.create_view(&Default::default()),
                 )),
             })
-            .unwrap_or_else(|| OwnedBindingResource::TextureView(empty_texture.create_view(&Default::default())));
+            .unwrap_or_else(|| OwnedBindingResource::TextureView(empty_texture_view.clone()));
 
         (binding_resource, sampler)
     }
@@ -1679,7 +1717,8 @@ impl<'a> RenderPassBuilder<'a> {
 
 struct CommandToPipelineAndBindGroupMapper {
     device: wgpu::Device,
-    empty_texture: wgpu::Texture,
+    empty_texture_view: wgpu::TextureView,
+    sampler_cache: Rc<RefCell<HashMap<SamplerKey, wgpu::Sampler>>>,
     shader_module: Rc<wgpu::ShaderModule>,
 
     current_bind_group_state: Option<BindGroupState>,
@@ -1692,7 +1731,8 @@ struct CommandToPipelineAndBindGroupMapper {
 impl CommandToPipelineAndBindGroupMapper {
     fn new(
         device: wgpu::Device,
-        empty_texture: wgpu::Texture,
+        empty_texture_view: wgpu::TextureView,
+        sampler_cache: Rc<RefCell<HashMap<SamplerKey, wgpu::Sampler>>>,
         shader_module: Rc<wgpu::ShaderModule>,
         bind_group_layout: wgpu::BindGroupLayout,
         pipeline_layout: wgpu::PipelineLayout,
@@ -1700,7 +1740,8 @@ impl CommandToPipelineAndBindGroupMapper {
     ) -> Self {
         Self {
             device: device.clone(),
-            empty_texture,
+            empty_texture_view,
+            sampler_cache,
             shader_module,
             current_bind_group_state: None,
             current_bind_group: None,
@@ -1738,7 +1779,13 @@ impl CommandToPipelineAndBindGroupMapper {
 
         if self.current_bind_group_state != Some(bind_group_state.clone()) {
             self.current_bind_group = bind_group_state
-                .materialize(&self.device, images, &self.bind_group_layout, &self.empty_texture)
+                .materialize(
+                    &self.device,
+                    images,
+                    &self.bind_group_layout,
+                    &self.empty_texture_view,
+                    &self.sampler_cache,
+                )
                 .into();
             self.current_bind_group_state = Some(bind_group_state);
         }

--- a/src/renderer/wgpu.rs
+++ b/src/renderer/wgpu.rs
@@ -214,22 +214,9 @@ pub struct Image {
 }
 
 /// The only flags a sampler descriptor reads. Keying on all of `ImageFlags` would miss on the rest.
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
-struct SamplerKey {
-    repeat_x: bool,
-    repeat_y: bool,
-    nearest: bool,
-}
-
-impl From<crate::ImageFlags> for SamplerKey {
-    fn from(flags: crate::ImageFlags) -> Self {
-        Self {
-            repeat_x: flags.contains(crate::ImageFlags::REPEAT_X),
-            repeat_y: flags.contains(crate::ImageFlags::REPEAT_Y),
-            nearest: flags.contains(crate::ImageFlags::NEAREST),
-        }
-    }
-}
+const SAMPLER_FLAGS: crate::ImageFlags = crate::ImageFlags::REPEAT_X
+    .union(crate::ImageFlags::REPEAT_Y)
+    .union(crate::ImageFlags::NEAREST);
 
 #[derive(Debug)]
 struct CachedPipeline {
@@ -247,10 +234,11 @@ pub struct WGPURenderer {
 
     screen_view: [f32; 2],
 
-    empty_texture: wgpu::Texture,
-    /// View of the 1x1 empty texture. Never varies, and rebuilding it per draw cost a wasm round trip.
+    /// View of the 1x1 empty texture, which keeps the texture alive. Never varies, and rebuilding it
+    /// per draw cost a wasm round trip.
     empty_texture_view: wgpu::TextureView,
-    sampler_cache: Rc<RefCell<HashMap<SamplerKey, wgpu::Sampler>>>,
+    /// One sampler per distinct `SAMPLER_FLAGS` combination, created on first use.
+    sampler_cache: Rc<RefCell<HashMap<crate::ImageFlags, wgpu::Sampler>>>,
     stencil_buffer: Option<wgpu::Texture>,
     stencil_buffer_for_textures: HashMap<wgpu::Texture, wgpu::Texture>,
 
@@ -410,7 +398,6 @@ impl WGPURenderer {
             screen_view: [0.0, 0.0],
 
             empty_texture_view: empty_texture.create_view(&Default::default()),
-            empty_texture,
             sampler_cache: Rc::new(RefCell::new(HashMap::new())),
             stencil_buffer: None,
             stencil_buffer_for_textures: HashMap::new(),
@@ -1404,7 +1391,7 @@ impl BindGroupState {
         images: &ImageStore<Image>,
         bind_group_layout: &wgpu::BindGroupLayout,
         empty_texture_view: &wgpu::TextureView,
-        sampler_cache: &RefCell<HashMap<SamplerKey, wgpu::Sampler>>,
+        sampler_cache: &RefCell<HashMap<crate::ImageFlags, wgpu::Sampler>>,
     ) -> wgpu::BindGroup {
         let uniform_buf = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
             label: Some("Fragment Uniform Buffer"),
@@ -1554,7 +1541,7 @@ impl<'a> RenderPassBuilder<'a> {
         images: &ImageStore<Image>,
         image: Option<&ImageOrTexture>,
         empty_texture_view: &wgpu::TextureView,
-        sampler_cache: &RefCell<HashMap<SamplerKey, wgpu::Sampler>>,
+        sampler_cache: &RefCell<HashMap<crate::ImageFlags, wgpu::Sampler>>,
     ) -> (OwnedBindingResource, wgpu::Sampler) {
         let flags = image
             .and_then(|image_or_texture| match image_or_texture {
@@ -1571,7 +1558,7 @@ impl<'a> RenderPassBuilder<'a> {
 
         let sampler = sampler_cache
             .borrow_mut()
-            .entry(SamplerKey::from(flags))
+            .entry(flags & SAMPLER_FLAGS)
             .or_insert_with(|| {
                 device.create_sampler(&wgpu::SamplerDescriptor {
                     address_mode_u: if flags.contains(crate::ImageFlags::REPEAT_X) {
@@ -1718,7 +1705,7 @@ impl<'a> RenderPassBuilder<'a> {
 struct CommandToPipelineAndBindGroupMapper {
     device: wgpu::Device,
     empty_texture_view: wgpu::TextureView,
-    sampler_cache: Rc<RefCell<HashMap<SamplerKey, wgpu::Sampler>>>,
+    sampler_cache: Rc<RefCell<HashMap<crate::ImageFlags, wgpu::Sampler>>>,
     shader_module: Rc<wgpu::ShaderModule>,
 
     current_bind_group_state: Option<BindGroupState>,
@@ -1732,7 +1719,7 @@ impl CommandToPipelineAndBindGroupMapper {
     fn new(
         device: wgpu::Device,
         empty_texture_view: wgpu::TextureView,
-        sampler_cache: Rc<RefCell<HashMap<SamplerKey, wgpu::Sampler>>>,
+        sampler_cache: Rc<RefCell<HashMap<crate::ImageFlags, wgpu::Sampler>>>,
         shader_module: Rc<wgpu::ShaderModule>,
         bind_group_layout: wgpu::BindGroupLayout,
         pipeline_layout: wgpu::PipelineLayout,

--- a/src/renderer/wgpu.rs
+++ b/src/renderer/wgpu.rs
@@ -213,7 +213,7 @@ pub struct Image {
     info: ImageInfo,
 }
 
-/// The only flags a sampler descriptor reads. Keying on all of `ImageFlags` would miss on the rest.
+// Only these flags change a sampler descriptor; the rest would split the cache for nothing.
 const SAMPLER_FLAGS: crate::ImageFlags = crate::ImageFlags::REPEAT_X
     .union(crate::ImageFlags::REPEAT_Y)
     .union(crate::ImageFlags::NEAREST);
@@ -234,10 +234,7 @@ pub struct WGPURenderer {
 
     screen_view: [f32; 2],
 
-    /// View of the 1x1 empty texture, which keeps the texture alive. Never varies, and rebuilding it
-    /// per draw cost a wasm round trip.
     empty_texture_view: wgpu::TextureView,
-    /// One sampler per distinct `SAMPLER_FLAGS` combination, created on first use.
     sampler_cache: Rc<RefCell<HashMap<crate::ImageFlags, wgpu::Sampler>>>,
     stencil_buffer: Option<wgpu::Texture>,
     stencil_buffer_for_textures: HashMap<wgpu::Texture, wgpu::Texture>,


### PR DESCRIPTION
Addresses part of #305, with #302 stacked on it for the rest.

## What this does

On a bind group cache miss the backend creates a uniform buffer, two samplers,
two texture views and a bind group. The two samplers and two views are of the
1x1 empty texture and never vary with the scene, so this keeps the view on the
renderer and caches samplers by the three flags that reach the descriptor.

That removes four of the six objects created per draw. It buys about 10% on its
own, which is what showed that the uniform buffer and the bind group carry the
rest. Those need the binding layout to change and are #302.

## Measurements

Method and full figures are in #305. Reproduce with `examples/many_rects.rs`
from #304.

| rectangles | before | with this PR |
| --- | --- | --- |
| 200 | 103.06ms, 8.1fps | 97.12ms, 9.9fps |
| 1000 | 434.46ms, 2.0fps | 378.47ms, 2.3fps |

Per-rectangle sampler and texture view creation goes from two of each to zero.

## Status

Measured only on wasm through Chrome, where crossing the JS boundary makes each
resource creation expensive. Native was not measured and may show little.

