### PR TITLE
Report out-of-range image updates instead of aborting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@ All notable changes to this project will be documented in this file.
   the corner square instead of bulging it outwards or emitting NaN coordinates,
   and an infinite radius rounds as far as the box allows. This changes rendering
   for shapes whose radii did not fit.
+- Fixed the WGPU renderer aborting instead of reporting an error when
+  `update_image()` is given a copy that reaches past the destination image, or a
+  source in a different pixel format. Both now return
+  `ErrorKind::ImageUpdateOutOfBounds` and
+  `ErrorKind::ImageUpdateWithDifferentFormat`, as the OpenGL and `Void`
+  renderers already did. The shared check is exposed as
+  `ImageSource::check_update()` for out-of-tree renderers, and reports rather
+  than overflows for an origin close to `usize::MAX`.
 
 ## [0.26.0] - 2026-07-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+- Fixed the WGPU renderer aborting instead of reporting an error when
+  `update_image()` is given a copy that reaches past the destination image, or a
+  source in a different pixel format. Both now return
+  `ErrorKind::ImageUpdateOutOfBounds` and
+  `ErrorKind::ImageUpdateWithDifferentFormat`, as the OpenGL and `Void`
+  renderers already did. The shared check is exposed as
+  `ImageSource::check_update()` for out-of-tree renderers, and reports rather
+  than overflows for an origin close to `usize::MAX`.
+
 ## [0.26.0] - 2026-07-20
 
 - Added Canvas 2D drop shadows for fills, strokes and text. New `Canvas` methods

--- a/src/image.rs
+++ b/src/image.rs
@@ -88,6 +88,35 @@ impl ImageSource<'_> {
             Self::HtmlCanvasElement(element) => Size::new(element.width() as usize, element.height() as usize),
         }
     }
+
+    /// Checks that this source may be copied into the image described by `info`
+    /// with its top left corner at (`x`, `y`).
+    ///
+    /// Every [`Renderer::update_image`](crate::Renderer::update_image)
+    /// implementation should call this before touching the graphics API. A copy
+    /// that reaches past the destination, or that carries a pixel format the
+    /// destination was not created with, is a caller mistake and has to be
+    /// reported as [`ErrorKind::ImageUpdateOutOfBounds`] or
+    /// [`ErrorKind::ImageUpdateWithDifferentFormat`]. Passing one down to the
+    /// graphics API instead produces a driver side validation failure, which
+    /// backends are generally not able to turn back into a recoverable error:
+    /// the usual outcome is an abort that takes the whole process, or on wasm
+    /// the whole application, rather than the single failed call.
+    pub fn check_update(&self, info: &ImageInfo, x: usize, y: usize) -> Result<(), ErrorKind> {
+        let size = self.dimensions();
+
+        // Saturating, so that an origin close to `usize::MAX` reports the error
+        // rather than wrapping into a range that looks valid.
+        if x.saturating_add(size.width) > info.width() || y.saturating_add(size.height) > info.height() {
+            return Err(ErrorKind::ImageUpdateOutOfBounds);
+        }
+
+        if info.format() != self.format() {
+            return Err(ErrorKind::ImageUpdateWithDifferentFormat);
+        }
+
+        Ok(())
+    }
 }
 
 impl<'a> From<ImgRef<'a, RGB8>> for ImageSource<'a> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2395,17 +2395,7 @@ impl Renderer for RecordingRenderer {
         x: usize,
         y: usize,
     ) -> Result<(), ErrorKind> {
-        let size = data.dimensions();
-
-        if x + size.width > image.info.width() {
-            return Err(ErrorKind::ImageUpdateOutOfBounds);
-        }
-
-        if y + size.height > image.info.height() {
-            return Err(ErrorKind::ImageUpdateOutOfBounds);
-        }
-
-        Ok(())
+        data.check_update(&image.info, x, y)
     }
 
     fn delete_image(&mut self, _image: Self::Image, _image_id: crate::ImageId) {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2398,17 +2398,7 @@ impl Renderer for RecordingRenderer {
         x: usize,
         y: usize,
     ) -> Result<(), ErrorKind> {
-        let size = data.dimensions();
-
-        if x + size.width > image.info.width() {
-            return Err(ErrorKind::ImageUpdateOutOfBounds);
-        }
-
-        if y + size.height > image.info.height() {
-            return Err(ErrorKind::ImageUpdateOutOfBounds);
-        }
-
-        Ok(())
+        data.check_update(&image.info, x, y)
     }
 
     fn delete_image(&mut self, _image: Self::Image, _image_id: crate::ImageId) {}

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -160,6 +160,11 @@ pub trait Renderer {
     ) -> Result<Self::Image, ErrorKind>;
 
     /// Update an image with new data.
+    ///
+    /// Implementations should start by calling [`ImageSource::check_update`], so
+    /// that a copy reaching past the image, or carrying a pixel format the image
+    /// was not created with, is reported as an error instead of being handed to
+    /// the graphics API, where it fails validation and usually aborts.
     fn update_image(&mut self, image: &mut Self::Image, data: ImageSource, x: usize, y: usize)
         -> Result<(), ErrorKind>;
 

--- a/src/renderer/opengl/gl_texture.rs
+++ b/src/renderer/opengl/gl_texture.rs
@@ -191,17 +191,7 @@ impl GlTexture {
     ) -> Result<(), ErrorKind> {
         let size = src.dimensions();
 
-        if x + size.width > self.info.width() {
-            return Err(ErrorKind::ImageUpdateOutOfBounds);
-        }
-
-        if y + size.height > self.info.height() {
-            return Err(ErrorKind::ImageUpdateOutOfBounds);
-        }
-
-        if self.info.format() != src.format() {
-            return Err(ErrorKind::ImageUpdateWithDifferentFormat);
-        }
+        src.check_update(&self.info, x, y)?;
 
         unsafe {
             context.bind_texture(glow::TEXTURE_2D, Some(self.id));

--- a/src/renderer/void.rs
+++ b/src/renderer/void.rs
@@ -56,17 +56,7 @@ impl Renderer for Void {
         x: usize,
         y: usize,
     ) -> Result<(), ErrorKind> {
-        let size = data.dimensions();
-
-        if x + size.width > image.info.width() {
-            return Err(ErrorKind::ImageUpdateOutOfBounds);
-        }
-
-        if y + size.height > image.info.height() {
-            return Err(ErrorKind::ImageUpdateOutOfBounds);
-        }
-
-        Ok(())
+        data.check_update(&image.info, x, y)
     }
 
     fn delete_image(&mut self, image: Self::Image, _image_id: ImageId) {}

--- a/src/renderer/wgpu.rs
+++ b/src/renderer/wgpu.rs
@@ -680,6 +680,8 @@ impl Renderer for WGPURenderer {
     ) -> Result<(), crate::ErrorKind> {
         use rgb::ComponentBytes;
 
+        data.check_update(&image.info, x, y)?;
+
         let converted_rgba;
         let (bytes, bpp) = match data {
             crate::ImageSource::Rgb(img) => {

--- a/tests/image_update_bounds_wgpu.rs
+++ b/tests/image_update_bounds_wgpu.rs
@@ -1,0 +1,143 @@
+//! `Renderer::update_image` must reject a copy that would fall outside the
+//! destination image, or that carries a different pixel format, by returning the
+//! documented error. The trait's own default implementation, the `Void` renderer
+//! and the OpenGL backend all do this; when a backend instead forwards an
+//! out-of-range copy to the graphics API, validation fails inside the driver and
+//! takes the process (or, on wasm, the whole application) down with it.
+#![cfg(feature = "wgpu")]
+
+use femtovg::{renderer::WGPURenderer, Canvas, ErrorKind, ImageFlags};
+use imgref::Img;
+use rgb::{alt::Gray, RGBA8};
+
+fn headless_device() -> Option<(wgpu::Device, wgpu::Queue)> {
+    let instance = wgpu::Instance::default();
+    let adapter = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
+        power_preference: wgpu::PowerPreference::default(),
+        force_fallback_adapter: false,
+        compatible_surface: None,
+        ..Default::default()
+    }))
+    .ok()?;
+    let (device, queue) = pollster::block_on(adapter.request_device(&wgpu::DeviceDescriptor {
+        label: Some("femtovg image update bounds test device"),
+        required_features: wgpu::Features::empty(),
+        required_limits: wgpu::Limits::downlevel_defaults().using_resolution(adapter.limits()),
+        experimental_features: wgpu::ExperimentalFeatures::disabled(),
+        memory_hints: wgpu::MemoryHints::MemoryUsage,
+        trace: wgpu::Trace::default(),
+    }))
+    .ok()?;
+    Some((device, queue))
+}
+
+fn canvas() -> Option<Canvas<WGPURenderer>> {
+    let (device, queue) = headless_device()?;
+    let mut canvas = Canvas::new(WGPURenderer::new(device, queue)).expect("canvas");
+    canvas.set_size(64, 64, 1.0);
+    Some(canvas)
+}
+
+fn rgba(w: usize, h: usize) -> Vec<RGBA8> {
+    vec![RGBA8::new(255, 0, 0, 255); w * h]
+}
+
+/// A copy whose origin pushes it past the right/bottom edge must be refused
+/// rather than handed to the graphics API.
+#[test]
+fn update_image_past_the_edge_is_rejected() {
+    let Some(mut canvas) = canvas() else {
+        eprintln!("skipping: no wgpu adapter available");
+        return;
+    };
+    let dst = rgba(32, 32);
+    let id = canvas
+        .create_image(Img::new(dst.as_slice(), 32, 32), ImageFlags::empty())
+        .expect("create");
+
+    let src = rgba(32, 32);
+    // 32x32 written at (8, 8) reaches 40x40 inside a 32x32 image.
+    let result = canvas.update_image(id, Img::new(src.as_slice(), 32, 32), 8, 8);
+    assert!(
+        matches!(result, Err(ErrorKind::ImageUpdateOutOfBounds)),
+        "expected ImageUpdateOutOfBounds, got {result:?}"
+    );
+}
+
+/// The same rule with the overflow only on one axis, and with a source that is
+/// larger than the destination outright.
+#[test]
+fn update_image_larger_than_destination_is_rejected() {
+    let Some(mut canvas) = canvas() else {
+        eprintln!("skipping: no wgpu adapter available");
+        return;
+    };
+    let dst = rgba(16, 16);
+    let id = canvas
+        .create_image(Img::new(dst.as_slice(), 16, 16), ImageFlags::empty())
+        .expect("create");
+
+    let wide = rgba(24, 16);
+    let result = canvas.update_image(id, Img::new(wide.as_slice(), 24, 16), 0, 0);
+    assert!(
+        matches!(result, Err(ErrorKind::ImageUpdateOutOfBounds)),
+        "expected ImageUpdateOutOfBounds for an oversized source, got {result:?}"
+    );
+
+    let tall = rgba(16, 24);
+    let result = canvas.update_image(id, Img::new(tall.as_slice(), 16, 24), 0, 0);
+    assert!(
+        matches!(result, Err(ErrorKind::ImageUpdateOutOfBounds)),
+        "expected ImageUpdateOutOfBounds on the y axis, got {result:?}"
+    );
+}
+
+/// Updating with a source whose format differs from the texture's would compute
+/// a bytes-per-row from the wrong pixel size; the OpenGL backend reports this
+/// instead of writing, and so must every other backend.
+#[test]
+fn update_image_with_a_different_format_is_rejected() {
+    let Some(mut canvas) = canvas() else {
+        eprintln!("skipping: no wgpu adapter available");
+        return;
+    };
+    let dst = rgba(16, 16);
+    let id = canvas
+        .create_image(Img::new(dst.as_slice(), 16, 16), ImageFlags::empty())
+        .expect("create");
+
+    let gray = vec![Gray(128u8); 16 * 16];
+    let result = canvas.update_image(id, Img::new(gray.as_slice(), 16, 16), 0, 0);
+    assert!(
+        matches!(result, Err(ErrorKind::ImageUpdateWithDifferentFormat)),
+        "expected ImageUpdateWithDifferentFormat, got {result:?}"
+    );
+}
+
+/// The guard must not turn away a copy that does fit, including one placed hard
+/// against the far corner.
+#[test]
+fn update_image_within_bounds_still_succeeds() {
+    let Some(mut canvas) = canvas() else {
+        eprintln!("skipping: no wgpu adapter available");
+        return;
+    };
+    let dst = rgba(32, 32);
+    let id = canvas
+        .create_image(Img::new(dst.as_slice(), 32, 32), ImageFlags::empty())
+        .expect("create");
+
+    let patch = rgba(8, 8);
+    canvas
+        .update_image(id, Img::new(patch.as_slice(), 8, 8), 0, 0)
+        .expect("origin update must succeed");
+    // Exactly flush with the far corner: 24 + 8 == 32.
+    canvas
+        .update_image(id, Img::new(patch.as_slice(), 8, 8), 24, 24)
+        .expect("flush-with-the-edge update must succeed");
+    // A full-size update at the origin.
+    let full = rgba(32, 32);
+    canvas
+        .update_image(id, Img::new(full.as_slice(), 32, 32), 0, 0)
+        .expect("full-size update must succeed");
+}

--- a/tests/image_update_contract.rs
+++ b/tests/image_update_contract.rs
@@ -1,0 +1,117 @@
+//! `update_image` is specified to report a copy it cannot perform, rather than
+//! forwarding it to the graphics API. These run on the `Void` renderer so they
+//! hold on every platform and in CI without a GPU; the backend-specific
+//! regression lives in `image_update_bounds_wgpu.rs`.
+
+use femtovg::{renderer::Void, Canvas, ErrorKind, ImageFlags};
+use imgref::Img;
+use rgb::{alt::Gray, RGBA8};
+
+fn canvas() -> Canvas<Void> {
+    let mut canvas = Canvas::new(Void).expect("canvas");
+    canvas.set_size(64, 64, 1.0);
+    canvas
+}
+
+fn rgba(w: usize, h: usize) -> Vec<RGBA8> {
+    vec![RGBA8::new(255, 0, 0, 255); w * h]
+}
+
+#[test]
+fn a_copy_reaching_past_the_destination_is_reported() {
+    let mut canvas = canvas();
+    let dst = rgba(32, 32);
+    let id = canvas
+        .create_image(Img::new(dst.as_slice(), 32, 32), ImageFlags::empty())
+        .expect("create");
+
+    let src = rgba(32, 32);
+    for (x, y) in [(8, 0), (0, 8), (8, 8), (32, 0), (0, 32)] {
+        let result = canvas.update_image(id, Img::new(src.as_slice(), 32, 32), x, y);
+        assert!(
+            matches!(result, Err(ErrorKind::ImageUpdateOutOfBounds)),
+            "({x}, {y}) should be out of bounds, got {result:?}"
+        );
+    }
+}
+
+#[test]
+fn a_source_larger_than_the_destination_is_reported() {
+    let mut canvas = canvas();
+    let dst = rgba(16, 16);
+    let id = canvas
+        .create_image(Img::new(dst.as_slice(), 16, 16), ImageFlags::empty())
+        .expect("create");
+
+    for (w, h) in [(24, 16), (16, 24), (24, 24)] {
+        let src = rgba(w, h);
+        let result = canvas.update_image(id, Img::new(src.as_slice(), w, h), 0, 0);
+        assert!(
+            matches!(result, Err(ErrorKind::ImageUpdateOutOfBounds)),
+            "a {w}x{h} source into a 16x16 image should be out of bounds, got {result:?}"
+        );
+    }
+}
+
+/// An origin near the top of the address space must report the error rather than
+/// wrapping around while the bound is computed, which in a release build would
+/// let an enormous origin look like a valid one.
+#[test]
+fn an_origin_that_would_overflow_is_reported() {
+    let mut canvas = canvas();
+    let dst = rgba(16, 16);
+    let id = canvas
+        .create_image(Img::new(dst.as_slice(), 16, 16), ImageFlags::empty())
+        .expect("create");
+
+    let src = rgba(8, 8);
+    let result = canvas.update_image(id, Img::new(src.as_slice(), 8, 8), usize::MAX, 0);
+    assert!(
+        matches!(result, Err(ErrorKind::ImageUpdateOutOfBounds)),
+        "an overflowing x origin should be out of bounds, got {result:?}"
+    );
+    let result = canvas.update_image(id, Img::new(src.as_slice(), 8, 8), 0, usize::MAX);
+    assert!(
+        matches!(result, Err(ErrorKind::ImageUpdateOutOfBounds)),
+        "an overflowing y origin should be out of bounds, got {result:?}"
+    );
+}
+
+#[test]
+fn a_source_in_another_format_is_reported() {
+    let mut canvas = canvas();
+    let dst = rgba(16, 16);
+    let id = canvas
+        .create_image(Img::new(dst.as_slice(), 16, 16), ImageFlags::empty())
+        .expect("create");
+
+    let gray = vec![Gray(128u8); 16 * 16];
+    let result = canvas.update_image(id, Img::new(gray.as_slice(), 16, 16), 0, 0);
+    assert!(
+        matches!(result, Err(ErrorKind::ImageUpdateWithDifferentFormat)),
+        "a Gray8 source into an Rgba8 image should be refused, got {result:?}"
+    );
+}
+
+/// The guard must leave every copy that does fit alone, including one flush with
+/// the far corner and one covering the image exactly.
+#[test]
+fn copies_that_fit_are_left_alone() {
+    let mut canvas = canvas();
+    let dst = rgba(32, 32);
+    let id = canvas
+        .create_image(Img::new(dst.as_slice(), 32, 32), ImageFlags::empty())
+        .expect("create");
+
+    let patch = rgba(8, 8);
+    for (x, y) in [(0, 0), (24, 0), (0, 24), (24, 24), (12, 12)] {
+        canvas
+            .update_image(id, Img::new(patch.as_slice(), 8, 8), x, y)
+            .unwrap_or_else(|e| panic!("({x}, {y}) fits and should succeed, got {e:?}"));
+    }
+
+    let full = rgba(32, 32);
+    canvas
+        .update_image(id, Img::new(full.as_slice(), 32, 32), 0, 0)
+        .expect("a full size update at the origin should succeed");
+}


### PR DESCRIPTION
## Summary

`Renderer::update_image` is specified to reject a copy it cannot perform. The `Void`
renderer, the OpenGL backend and the in-tree test recorder each check that the copy fits
inside the destination image; OpenGL additionally checks that the source's pixel format
matches the one the image was created with. They return `ErrorKind::ImageUpdateOutOfBounds`
and `ErrorKind::ImageUpdateWithDifferentFormat`.

The WGPU backend performed **neither** check. It passed the copy straight to
`Queue::write_texture`, or on wasm to `copyExternalImageToTexture`, both of which fail
graphics API validation — and wgpu surfaces that as a panic. So a recoverable caller
mistake takes down the process instead of the single call. On wasm it takes down the
application: the instance is dead, the canvas keeps its last painted frame, and no further
input is processed.

## Reproducing it

This is not wasm-specific — it reproduces natively on any adapter. A 32x32 source written
at (8, 8) into a 32x32 image, which every other backend reports as
`ImageUpdateOutOfBounds`:

```
thread 'update_image_past_the_edge_is_rejected' panicked at wgpu-30.0.0/src/backend/wgpu_core.rs:2068:22:
wgpu error: Validation Error

Caused by:
  In Queue::write_texture
    Copy of X 8..40 would end up overrunning the bounds of the Destination texture of X size 32
```

And a `Gray8` source into an `Rgba8` image, which OpenGL reports as
`ImageUpdateWithDifferentFormat`:

```
  In Queue::write_texture
    Number of bytes per row is less than the number of bytes in a complete row
```

Both tests in this PR fail that way on `master` and pass with the change.

## The fix

Three implementations had each derived the same rule and the fourth had none, which is how
the divergence arose in the first place. Rather than write it a fourth time, this moves it
into `ImageSource::check_update()` and calls that from all of them, so a backend cannot
quietly omit it. `Renderer::update_image` now documents that implementations should call
it. The helper is public because `Renderer` is public and out-of-tree backends need the
same guarantee.

Behaviour per backend:

| | before | after |
| --- | --- | --- |
| OpenGL | bounds + format | unchanged |
| `Void` | bounds | bounds + format |
| WGPU | **neither** | bounds + format |

The check also saturates when adding the origin to the source size, so an origin near
`usize::MAX` is reported rather than wrapping into a range that looks valid — in a release
build the previous `x + size.width` wrapped and let an enormous origin through to the
graphics API.

## Relationship to #300 / 1c174fd

This is complementary to the `HtmlCanvasElement` source and the resized-`HtmlImageElement`
rasterization that went into 0.26.0. Those fixed the **source** side of one specific case:
an `HtmlImageElement` enlarged for hidpi has a copy extent larger than the natural size
WebGPU reads, so the copy rect fell outside the *source*. This fixes the **destination**
side, which is unguarded for every caller and every geometry, and which no rasterization
step can catch. The two do not overlap: the wasm paths keep rasterizing exactly as they do
today, and now also validate against the destination first.

Reported downstream as slint-ui/slint#12540, where the hidpi SVG case aborted a Slint
application in the browser. Its author suggested exactly this, independently of the narrow
fix: *"femtovg's WGPU renderer could clamp the copy extent ... so that other consumers of
the same API do not hit a panic."* Returning the documented error rather than clamping
keeps it consistent with the other backends, and does not silently paint something the
caller did not ask for.

## Tests

- `tests/image_update_contract.rs` — the contract over the `Void` renderer, so it holds on
  every platform and runs in CI without a GPU: past the edge, a source larger than the
  destination, an overflowing origin, a mismatched format, and the copies that do fit
  (including one flush with the far corner) still succeeding.
- `tests/image_update_bounds_wgpu.rs` — the same cases against the WGPU backend, which is
  where they aborted. Skips when no adapter is available.

## Verification

`cargo fmt --all -- --check`, `cargo clippy --all-features --no-deps` (warning count
unchanged from `master`), `cargo doc --no-deps --all-features`, default and `--all-features`
test suites (71 and 97 passing), and builds for default / `--all-features` /
`--no-default-features` / `wasm32-unknown-unknown` / `wasm32-unknown-unknown --features wgpu`,
the last being the configuration in the downstream report.
