### PR TITLE
Add color-matrix image filter (feColorMatrix / CSS filter color functions)

### DIFF
--- a/src/image.rs
+++ b/src/image.rs
@@ -343,4 +343,210 @@ pub enum ImageFilter {
         /// The standard deviation of the Gaussian blur filter.
         sigma: f32,
     },
+    /// Applies a 4x5 color matrix, the operation behind SVG `feColorMatrix` and
+    /// the CSS/Canvas `filter` color functions (`grayscale`, `sepia`, ...).
+    ///
+    /// The 20 values are row-major: the output channel `[r', g', b', a']` is
+    /// `M * [r, g, b, a, 1]`, i.e. `r' = m[0]*r + m[1]*g + m[2]*b + m[3]*a +
+    /// m[4]`, and so on for rows `m[5..10]`, `m[10..15]`, `m[15..20]`. The matrix
+    /// is applied in **unpremultiplied, sRGB** space (matching the CSS filter
+    /// functions, which are defined in sRGB) and the result is clamped to
+    /// `[0, 1]`, so overflowing matrices cannot produce out-of-range or NaN
+    /// pixels. Use the constructors below for the standard CSS functions.
+    ColorMatrix {
+        /// Row-major 4x5 color matrix.
+        matrix: [f32; 20],
+    },
+}
+
+impl ImageFilter {
+    /// The identity color matrix (leaves an image unchanged).
+    pub const IDENTITY_MATRIX: [f32; 20] = [
+        1.0, 0.0, 0.0, 0.0, 0.0, //
+        0.0, 1.0, 0.0, 0.0, 0.0, //
+        0.0, 0.0, 1.0, 0.0, 0.0, //
+        0.0, 0.0, 0.0, 1.0, 0.0,
+    ];
+
+    // sRGB / Rec.709 luma weights used by the CSS `grayscale`/`saturate`/
+    // `hue-rotate` functions (Filter Effects Level 1).
+    const LR: f32 = 0.2126;
+    const LG: f32 = 0.7152;
+    const LB: f32 = 0.0722;
+
+    /// CSS `grayscale(amount)`; `amount` is clamped to `[0, 1]` (1 = fully gray).
+    pub fn grayscale(amount: f32) -> Self {
+        let a = amount.clamp(0.0, 1.0);
+        let inv = 1.0 - a;
+        let (lr, lg, lb) = (Self::LR, Self::LG, Self::LB);
+        Self::ColorMatrix {
+            matrix: [
+                lr + 0.7874 * inv,
+                lg - lg * inv,
+                lb - lb * inv,
+                0.0,
+                0.0, //
+                lr - lr * inv,
+                lg + 0.2848 * inv,
+                lb - lb * inv,
+                0.0,
+                0.0, //
+                lr - lr * inv,
+                lg - lg * inv,
+                lb + 0.9278 * inv,
+                0.0,
+                0.0, //
+                0.0,
+                0.0,
+                0.0,
+                1.0,
+                0.0,
+            ],
+        }
+    }
+
+    /// CSS `sepia(amount)`; `amount` is clamped to `[0, 1]`.
+    pub fn sepia(amount: f32) -> Self {
+        let inv = 1.0 - amount.clamp(0.0, 1.0);
+        Self::ColorMatrix {
+            matrix: [
+                0.393 + 0.607 * inv,
+                0.769 - 0.769 * inv,
+                0.189 - 0.189 * inv,
+                0.0,
+                0.0, //
+                0.349 - 0.349 * inv,
+                0.686 + 0.314 * inv,
+                0.168 - 0.168 * inv,
+                0.0,
+                0.0, //
+                0.272 - 0.272 * inv,
+                0.534 - 0.534 * inv,
+                0.131 + 0.869 * inv,
+                0.0,
+                0.0, //
+                0.0,
+                0.0,
+                0.0,
+                1.0,
+                0.0,
+            ],
+        }
+    }
+
+    /// CSS `saturate(amount)` (`feColorMatrix type="saturate"`). `amount` >= 0;
+    /// 0 desaturates, 1 is identity, >1 over-saturates. Uses the SVG
+    /// 0.213/0.715/0.072 luma weights.
+    pub fn saturate(amount: f32) -> Self {
+        let s = amount.max(0.0);
+        let (lr, lg, lb) = (0.213f32, 0.715f32, 0.072f32);
+        Self::ColorMatrix {
+            matrix: [
+                lr + 0.787 * s,
+                lg - lg * s,
+                lb - lb * s,
+                0.0,
+                0.0, //
+                lr - lr * s,
+                lg + 0.285 * s,
+                lb - lb * s,
+                0.0,
+                0.0, //
+                lr - lr * s,
+                lg - lg * s,
+                lb + 0.928 * s,
+                0.0,
+                0.0, //
+                0.0,
+                0.0,
+                0.0,
+                1.0,
+                0.0,
+            ],
+        }
+    }
+
+    /// CSS `hue-rotate(radians)` (`feColorMatrix type="hueRotate"`).
+    pub fn hue_rotate(radians: f32) -> Self {
+        let (s, c) = radians.sin_cos();
+        let (lr, lg, lb) = (0.213f32, 0.715f32, 0.072f32);
+        Self::ColorMatrix {
+            matrix: [
+                lr + c * 0.787 - s * 0.213,
+                lg - c * lg - s * lg,
+                lb - c * lb + s * 0.928,
+                0.0,
+                0.0, //
+                lr - c * lr + s * 0.143,
+                lg + c * 0.285 + s * 0.140,
+                lb - c * lb - s * 0.283,
+                0.0,
+                0.0, //
+                lr - c * lr - s * 0.787,
+                lg - c * lg + s * lg,
+                lb + c * 0.928 + s * lb,
+                0.0,
+                0.0, //
+                0.0,
+                0.0,
+                0.0,
+                1.0,
+                0.0,
+            ],
+        }
+    }
+
+    /// CSS `brightness(amount)`; `amount` >= 0 scales each RGB channel.
+    pub fn brightness(amount: f32) -> Self {
+        let a = amount.max(0.0);
+        Self::ColorMatrix {
+            matrix: [
+                a, 0.0, 0.0, 0.0, 0.0, //
+                0.0, a, 0.0, 0.0, 0.0, //
+                0.0, 0.0, a, 0.0, 0.0, //
+                0.0, 0.0, 0.0, 1.0, 0.0,
+            ],
+        }
+    }
+
+    /// CSS `contrast(amount)`; `amount` >= 0. 1 is identity.
+    pub fn contrast(amount: f32) -> Self {
+        let a = amount.max(0.0);
+        let b = 0.5 - 0.5 * a;
+        Self::ColorMatrix {
+            matrix: [
+                a, 0.0, 0.0, 0.0, b, //
+                0.0, a, 0.0, 0.0, b, //
+                0.0, 0.0, a, 0.0, b, //
+                0.0, 0.0, 0.0, 1.0, 0.0,
+            ],
+        }
+    }
+
+    /// CSS `invert(amount)`; `amount` is clamped to `[0, 1]`.
+    pub fn invert(amount: f32) -> Self {
+        let a = amount.clamp(0.0, 1.0);
+        let d = 1.0 - 2.0 * a;
+        Self::ColorMatrix {
+            matrix: [
+                d, 0.0, 0.0, 0.0, a, //
+                0.0, d, 0.0, 0.0, a, //
+                0.0, 0.0, d, 0.0, a, //
+                0.0, 0.0, 0.0, 1.0, 0.0,
+            ],
+        }
+    }
+
+    /// CSS `opacity(amount)`; `amount` is clamped to `[0, 1]` and scales alpha.
+    pub fn opacity(amount: f32) -> Self {
+        let a = amount.clamp(0.0, 1.0);
+        Self::ColorMatrix {
+            matrix: [
+                1.0, 0.0, 0.0, 0.0, 0.0, //
+                0.0, 1.0, 0.0, 0.0, 0.0, //
+                0.0, 0.0, 1.0, 0.0, 0.0, //
+                0.0, 0.0, 0.0, a, 0.0,
+            ],
+        }
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3244,6 +3244,7 @@ fn opaque_shadow_emits_offscreen_blur_pass() {
                 "expected sigma 3.0 for blur 6.0, got {sigma}"
             );
         }
+        Some(other) => panic!("opaque shadow must run the Gaussian blur filter, got {other:?}"),
         None => panic!("opaque shadow must run the Gaussian blur filter"),
     }
 

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -246,6 +246,8 @@ pub enum ShaderType {
     FillGradientConic,
     /// Fill image conic gradient shader.
     FillImageGradientConic,
+    /// Color-matrix image filter shader (`feColorMatrix` / CSS color functions).
+    FilterImageColorMatrix,
 }
 
 impl ShaderType {
@@ -262,6 +264,7 @@ impl ShaderType {
             Self::FillColorUnclipped => 7,
             Self::FillGradientConic => 8,
             Self::FillImageGradientConic => 9,
+            Self::FilterImageColorMatrix => 10,
         }
     }
 

--- a/src/renderer/opengl.rs
+++ b/src/renderer/opengl.rs
@@ -42,9 +42,9 @@ pub struct OpenGl {
     view: [f32; 2],
     screen_view: [f32; 2],
     // All types of the vertex/fragment shader, indexed by shader_type when has_glyph_texture is true
-    main_programs_with_glyph_texture: [Option<MainProgram>; 10],
+    main_programs_with_glyph_texture: [Option<MainProgram>; 11],
     // Same shader programs but with has_glyph_texture being false
-    main_programs_without_glyph_texture: [Option<MainProgram>; 10],
+    main_programs_without_glyph_texture: [Option<MainProgram>; 11],
     current_program: u8,
     current_program_needs_glyph_texture: bool,
     vert_arr: Option<<glow::Context as glow::HasContext>::VertexArray>,
@@ -183,6 +183,17 @@ impl OpenGl {
                     ShaderType::FillImageGradientConic,
                     with_glyph_texture,
                 )?),
+                if with_glyph_texture {
+                    // Image filter is unrelated to glyph rendering
+                    None
+                } else {
+                    Some(MainProgram::new(
+                        &context,
+                        antialias,
+                        ShaderType::FilterImageColorMatrix,
+                        false,
+                    )?)
+                },
             ])
         };
 
@@ -582,7 +593,60 @@ impl OpenGl {
     ) {
         match filter {
             ImageFilter::GaussianBlur { sigma } => self.render_gaussian_blur(images, cmd, target_image, sigma),
+            ImageFilter::ColorMatrix { matrix } => self.render_color_matrix(images, cmd, target_image, matrix),
         }
+    }
+
+    fn render_color_matrix(
+        &mut self,
+        images: &mut ImageStore<GlTexture>,
+        cmd: Command,
+        target_image: ImageId,
+        matrix: [f32; 20],
+    ) {
+        let original_render_target = self.current_render_target;
+        let source_image_info = images.get(cmd.image.unwrap()).unwrap().info();
+
+        let image_paint = crate::Paint::image(
+            cmd.image.unwrap(),
+            0.,
+            0.,
+            source_image_info.width() as _,
+            source_image_info.height() as _,
+            0.,
+            1.,
+        );
+        let mut params = Params::new(
+            images,
+            &Transform2D::default(),
+            &image_paint.flavor,
+            &GlyphTexture::default(),
+            &Scissor::default(),
+            0.,
+            0.,
+            0.,
+        );
+        params.shader_type = ShaderType::FilterImageColorMatrix;
+        // The color matrix rides the scissor/paint-matrix uniform slots, which are
+        // dead during a filter pass (no scissor, no paint gradient): frag[0..2]
+        // hold the first 12 values, frag[3..4] the last 8, so no uniform-array
+        // growth is needed. The shader reads them back as a row-major 4x5 matrix.
+        params.scissor_mat.copy_from_slice(&matrix[..12]);
+        params.paint_mat[..8].copy_from_slice(&matrix[12..20]);
+
+        self.set_target(images, RenderTarget::Image(target_image));
+        self.main_program().set_view(self.view);
+        self.clear_rect(
+            0,
+            0,
+            source_image_info.width() as _,
+            source_image_info.height() as _,
+            Color::rgbaf(0., 0., 0., 0.),
+        );
+        self.triangles(images, &cmd, &params);
+
+        self.set_target(images, original_render_target);
+        self.main_program().set_view(self.view);
     }
 
     fn render_gaussian_blur(

--- a/src/renderer/opengl/main-fs.glsl
+++ b/src/renderer/opengl/main-fs.glsl
@@ -43,6 +43,7 @@ varying vec2 fpos;
  #define SHADER_TYPE_TextureCopyUnclipped 6
  #define SHADER_TYPE_FillGradientConic 8
  #define SHADER_TYPE_FillImageGradientConic 9
+ #define SHADER_TYPE_FilterImageColorMatrix 10
 
 float sdroundrect(vec2 pt, vec2 ext, float rad) {
     vec2 ext2 = ext - vec2(rad,rad);
@@ -180,6 +181,25 @@ vec4 renderFilteredImage() {
     return color;
 }
 
+vec4 renderColorMatrix() {
+    // The 4x5 color matrix is packed row-major into frag[0..4] (the scissor/paint
+    // matrix slots, unused during a filter pass). Apply it in unpremultiplied
+    // sRGB space, clamp to [0,1], then re-premultiply: unpremultiplying avoids
+    // edge halos and the clamp keeps overflowing matrices from producing
+    // out-of-range or NaN pixels.
+    vec4 c = texture2D(tex, fpos.xy / extent);
+    if (c.a > 0.0) {
+        c.rgb /= c.a;
+    }
+    float r = frag[0].x * c.r + frag[0].y * c.g + frag[0].z * c.b + frag[0].w * c.a + frag[1].x;
+    float g = frag[1].y * c.r + frag[1].z * c.g + frag[1].w * c.b + frag[2].x * c.a + frag[2].y;
+    float b = frag[2].z * c.r + frag[2].w * c.g + frag[3].x * c.b + frag[3].y * c.a + frag[3].z;
+    float a = frag[3].w * c.r + frag[4].x * c.g + frag[4].y * c.b + frag[4].z * c.a + frag[4].w;
+    vec4 outc = clamp(vec4(r, g, b, a), 0.0, 1.0);
+    outc.rgb *= outc.a;
+    return outc;
+}
+
 void main(void) {
     vec4 result;
 
@@ -219,6 +239,8 @@ void main(void) {
     result = renderGradientConic();
 #elif SELECT_SHADER == SHADER_TYPE_FillImageGradientConic
     result = renderImageGradientConic();
+#elif SELECT_SHADER == SHADER_TYPE_FilterImageColorMatrix
+    result = renderColorMatrix();
 #else
 #error A shader variant must be selected with the SELECT_SHADER pre-processor variable
 #endif
@@ -239,7 +261,7 @@ void main(void) {
     mask *= scissor;
     result *= mask;
 #else
-#if SELECT_SHADER != SHADER_TYPE_Stencil && SELECT_SHADER != SHADER_TYPE_FilterImage
+#if SELECT_SHADER != SHADER_TYPE_Stencil && SELECT_SHADER != SHADER_TYPE_FilterImage && SELECT_SHADER != SHADER_TYPE_FilterImageColorMatrix
         // Not stencil fill
         // Combine alpha
         result *= strokeAlpha * scissor;

--- a/src/renderer/wgpu.rs
+++ b/src/renderer/wgpu.rs
@@ -608,6 +608,17 @@ impl Renderer for WGPURenderer {
                             target_image,
                         );
                     }
+                    crate::ImageFilter::ColorMatrix { matrix } => {
+                        color_matrix_filter(
+                            &mut current_render_target,
+                            images,
+                            command,
+                            matrix,
+                            &mut render_pass_builder,
+                            &mut pipeline_and_bindgroup_mapper,
+                            target_image,
+                        );
+                    }
                 },
             }
         }
@@ -858,6 +869,75 @@ fn gaussian_blur_filter(
             &blur_params,
             images,
             Some(ImageOrTexture::Texture(horizontal_blur_buffer)),
+            command.glyph_texture,
+        );
+        render_pass_builder.draw(start as u32..(start + count) as u32);
+    }
+
+    *current_render_target = previous_render_target;
+    match *current_render_target {
+        RenderTarget::Screen => {
+            render_pass_builder.set_render_target_screen();
+        }
+        RenderTarget::Image(image_id) => {
+            render_pass_builder.set_render_target_image(images, image_id, wgpu::LoadOp::Load);
+        }
+    }
+}
+
+/// Single-pass color-matrix filter: sample the source once and apply the 4x5
+/// matrix. Mirrors `gaussian_blur_filter` but without the intermediate texture.
+#[allow(clippy::too_many_arguments)]
+fn color_matrix_filter(
+    current_render_target: &mut RenderTarget,
+    images: &mut ImageStore<Image>,
+    command: super::Command,
+    matrix: [f32; 20],
+    render_pass_builder: &mut RenderPassBuilder<'_>,
+    pipeline_and_bindgroup_mapper: &mut CommandToPipelineAndBindGroupMapper,
+    target_image: ImageId,
+) {
+    let blend_state = blend_state(&command).into();
+    let previous_render_target = *current_render_target;
+
+    let source_image = images.get(command.image.unwrap()).unwrap();
+    let image_paint = crate::Paint::image(
+        command.image.unwrap(),
+        0.,
+        0.,
+        source_image.info.width() as _,
+        source_image.info.height() as _,
+        0.,
+        1.,
+    );
+    let mut params = Params::new(
+        images,
+        &Default::default(),
+        &image_paint.flavor,
+        &Default::default(),
+        &Scissor::default(),
+        0.,
+        0.,
+        0.,
+    );
+    params.shader_type = ShaderType::FilterImageColorMatrix;
+    // The 4x5 matrix rides the dead scissor/paint-mat slots during the filter
+    // pass (see `renderColorMatrix` in the shader) — no uniform-array growth.
+    params.scissor_mat.copy_from_slice(&matrix[..12]);
+    params.paint_mat[..8].copy_from_slice(&matrix[12..20]);
+
+    render_pass_builder.set_render_target_image(images, target_image, wgpu::LoadOp::Clear(wgpu::Color::default()));
+
+    if let Some((start, count)) = command.triangles_verts {
+        pipeline_and_bindgroup_mapper.update_renderpass(
+            render_pass_builder,
+            blend_state,
+            wgpu::PrimitiveTopology::TriangleList,
+            StencilTest::Disabled,
+            Some(wgpu::Face::Back),
+            &params,
+            images,
+            command.image.map(ImageOrTexture::Image),
             command.glyph_texture,
         );
         render_pass_builder.draw(start as u32..(start + count) as u32);

--- a/src/renderer/wgpu/shader.wgsl
+++ b/src/renderer/wgpu/shader.wgsl
@@ -33,6 +33,7 @@ const SHADER_TYPE_TextureCopyUnclipped: i32 = 6;
 const SHADER_TYPE_FillColorUnclipped: i32 = 7;
 const SHADER_TYPE_FillGradientConic: i32 = 8;
 const SHADER_TYPE_FillImageGradientConic: i32 = 9;
+const SHADER_TYPE_FilterImageColorMatrix: i32 = 10;
 
 const TAU: f32 = 6.28318530717958647692528676655900577;
 
@@ -157,6 +158,9 @@ fn fs_main(vertex: VertexOutput) -> @location(0) vec4<f32> {
             let d = conicAngleFraction(vertex, params);
             result = ditherGradient(textureSample(image_texture, image_sampler, vec2<f32>(d, 0.0)), vertex.position.xy);
         }
+        case SHADER_TYPE_FilterImageColorMatrix: {
+            return renderColorMatrix(vertex, params);
+        }
         default: {
             result = vec4<f32>(0.0, 0.0, 1.0, 1.0);
         }
@@ -184,6 +188,29 @@ fn fs_main(vertex: VertexOutput) -> @location(0) vec4<f32> {
     }
 
     return result;
+}
+
+fn renderColorMatrix(vertex: VertexOutput, params: Params) -> vec4<f32> {
+    // The 4x5 color matrix is packed into the scissor/paint matrix slots (dead
+    // during a filter pass): scissor_mat columns 0..2 hold the first 12 values,
+    // paint_mat columns 0..1 the last 8. Apply in unpremultiplied sRGB space,
+    // clamp to [0,1], then re-premultiply — unpremultiplying avoids edge halos
+    // and the clamp keeps overflowing matrices from producing out-of-range/NaN.
+    var c: vec4<f32> = textureSample(image_texture, image_sampler, vertex.fpos.xy / params.extent);
+    if (c.a > 0.0) {
+        c = vec4<f32>(c.rgb / c.a, c.a);
+    }
+    let m0 = params.scissor_mat[0];
+    let m1 = params.scissor_mat[1];
+    let m2 = params.scissor_mat[2];
+    let m3 = params.paint_mat[0];
+    let m4 = params.paint_mat[1];
+    let r = m0.x * c.r + m0.y * c.g + m0.z * c.b + m0.w * c.a + m1.x;
+    let g = m1.y * c.r + m1.z * c.g + m1.w * c.b + m2.x * c.a + m2.y;
+    let b = m2.z * c.r + m2.w * c.g + m3.x * c.b + m3.y * c.a + m3.z;
+    let a = m3.w * c.r + m4.x * c.g + m4.y * c.b + m4.z * c.a + m4.w;
+    let outc = clamp(vec4<f32>(r, g, b, a), vec4<f32>(0.0), vec4<f32>(1.0));
+    return vec4<f32>(outc.rgb * outc.a, outc.a);
 }
 
 fn conicAngleFraction(vertex: VertexOutput, params: Params) -> f32 {

--- a/tests/color_matrix_wgpu.rs
+++ b/tests/color_matrix_wgpu.rs
@@ -1,0 +1,205 @@
+//! Headless GPU tests for the color-matrix image filter (`ImageFilter::ColorMatrix`
+//! and the CSS filter-function constructors). The assertions are the property
+//! checks that guard the classic feColorMatrix bug classes: exact Rec.709 luma
+//! weights, identity round-trips, hue-rotate periodicity, clamping (no overflow
+//! or NaN), and channel correctness. Skips when no GPU adapter is available.
+#![cfg(feature = "wgpu")]
+
+use femtovg::{renderer::WGPURenderer, Canvas, Color, ImageFilter, ImageFlags, Paint, Path, PixelFormat, RenderTarget};
+
+const W: u32 = 32;
+const H: u32 = 32;
+
+fn headless_device() -> Option<(wgpu::Device, wgpu::Queue)> {
+    let instance = wgpu::Instance::default();
+    let adapter = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
+        power_preference: wgpu::PowerPreference::default(),
+        force_fallback_adapter: false,
+        compatible_surface: None,
+        ..Default::default()
+    }))
+    .ok()?;
+    let (device, queue) = pollster::block_on(adapter.request_device(&wgpu::DeviceDescriptor {
+        label: Some("femtovg color matrix test device"),
+        required_features: wgpu::Features::empty(),
+        required_limits: wgpu::Limits::downlevel_defaults().using_resolution(adapter.limits()),
+        experimental_features: wgpu::ExperimentalFeatures::disabled(),
+        memory_hints: wgpu::MemoryHints::MemoryUsage,
+        trace: wgpu::Trace::default(),
+    }))
+    .ok()?;
+    Some((device, queue))
+}
+
+/// Fill a source image with `src`, apply `filter` into a target image, draw the
+/// target to the output, and return the centre pixel `[r,g,b,a]`.
+fn filtered_center(device: &wgpu::Device, queue: &wgpu::Queue, src: Color, filter: ImageFilter) -> [u8; 4] {
+    let target = device.create_texture(&wgpu::TextureDescriptor {
+        label: Some("cmat out"),
+        size: wgpu::Extent3d {
+            width: W,
+            height: H,
+            depth_or_array_layers: 1,
+        },
+        mip_level_count: 1,
+        sample_count: 1,
+        dimension: wgpu::TextureDimension::D2,
+        format: wgpu::TextureFormat::Rgba8Unorm,
+        usage: wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::COPY_SRC,
+        view_formats: &[],
+    });
+
+    let renderer = WGPURenderer::new(device.clone(), queue.clone());
+    let mut canvas = Canvas::new(renderer).expect("canvas");
+    canvas.set_size(W, H, 1.0);
+
+    let source = canvas
+        .create_image_empty(W as usize, H as usize, PixelFormat::Rgba8, ImageFlags::empty())
+        .expect("source image");
+    canvas.set_render_target(RenderTarget::Image(source));
+    canvas.clear_rect(0, 0, W, H, src);
+    canvas.set_render_target(RenderTarget::Screen);
+
+    let filtered = canvas
+        .create_image_empty(W as usize, H as usize, PixelFormat::Rgba8, ImageFlags::empty())
+        .expect("target image");
+    canvas.filter_image(filtered, filter, source);
+
+    // Composite the filtered image onto the (white) output so we can read it back.
+    canvas.clear_rect(0, 0, W, H, Color::white());
+    let mut p = Path::new();
+    p.rect(0.0, 0.0, W as f32, H as f32);
+    canvas.fill_path(&p, &Paint::image(filtered, 0.0, 0.0, W as f32, H as f32, 0.0, 1.0));
+
+    let commands = canvas.flush_to_output(&target);
+    queue.submit(commands);
+
+    let unpadded = W * 4;
+    let align = wgpu::COPY_BYTES_PER_ROW_ALIGNMENT;
+    let padded = unpadded.div_ceil(align) * align;
+    let readback = device.create_buffer(&wgpu::BufferDescriptor {
+        label: None,
+        size: (padded * H) as u64,
+        usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
+        mapped_at_creation: false,
+    });
+    let mut enc = device.create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
+    enc.copy_texture_to_buffer(
+        wgpu::TexelCopyTextureInfo {
+            texture: &target,
+            mip_level: 0,
+            origin: wgpu::Origin3d::ZERO,
+            aspect: wgpu::TextureAspect::All,
+        },
+        wgpu::TexelCopyBufferInfo {
+            buffer: &readback,
+            layout: wgpu::TexelCopyBufferLayout {
+                offset: 0,
+                bytes_per_row: Some(padded),
+                rows_per_image: Some(H),
+            },
+        },
+        wgpu::Extent3d {
+            width: W,
+            height: H,
+            depth_or_array_layers: 1,
+        },
+    );
+    queue.submit(Some(enc.finish()));
+    let slice = readback.slice(..);
+    slice.map_async(wgpu::MapMode::Read, |_| {});
+    device.poll(wgpu::PollType::wait_indefinitely()).unwrap();
+    let mapped = slice.get_mapped_range().expect("readback");
+    let (cx, cy) = (W as usize / 2, H as usize / 2);
+    let i = cy * padded as usize + cx * 4;
+    [mapped[i], mapped[i + 1], mapped[i + 2], mapped[i + 3]]
+}
+
+fn close(a: u8, b: i32) -> bool {
+    (a as i32 - b).abs() <= 3
+}
+
+#[test]
+fn color_matrix_filter_properties() {
+    let Some((device, queue)) = headless_device() else {
+        eprintln!("skipping: no wgpu adapter available");
+        return;
+    };
+    let f = |src: Color, filter| filtered_center(&device, &queue, src, filter);
+    let red = Color::rgb(255, 0, 0);
+    let green = Color::rgb(0, 255, 0);
+    let blue = Color::rgb(0, 0, 255);
+
+    // 1. grayscale(1) uses Rec.709 luma (0.2126/0.7152/0.0722), NOT the 1/3
+    //    average (85) or Rec.601 (76 for red).
+    let g = f(red, ImageFilter::grayscale(1.0));
+    println!("grayscale(red) = {g:?}");
+    assert!(
+        close(g[0], 54) && close(g[1], 54) && close(g[2], 54),
+        "grayscale(red) luma must be ~54, got {g:?}"
+    );
+    assert!(
+        close(f(green, ImageFilter::grayscale(1.0))[0], 182),
+        "grayscale(green) luma must be ~182"
+    );
+    assert!(
+        close(f(blue, ImageFilter::grayscale(1.0))[0], 18),
+        "grayscale(blue) luma must be ~18"
+    );
+
+    // 2. Identities: these must all leave a color unchanged.
+    for (name, filt) in [
+        ("grayscale(0)", ImageFilter::grayscale(0.0)),
+        ("saturate(1)", ImageFilter::saturate(1.0)),
+        ("brightness(1)", ImageFilter::brightness(1.0)),
+        ("contrast(1)", ImageFilter::contrast(1.0)),
+        ("sepia(0)", ImageFilter::sepia(0.0)),
+        ("invert(0)", ImageFilter::invert(0.0)),
+        ("opacity(1)", ImageFilter::opacity(1.0)),
+        ("hue_rotate(0)", ImageFilter::hue_rotate(0.0)),
+        ("hue_rotate(2pi)", ImageFilter::hue_rotate(std::f32::consts::TAU)),
+    ] {
+        let probe = Color::rgb(200, 120, 40);
+        let out = f(probe, filt);
+        assert!(
+            close(out[0], 200) && close(out[1], 120) && close(out[2], 40),
+            "{name} must be an identity, got {out:?}"
+        );
+    }
+
+    // 3. invert(1) of red -> cyan.
+    let inv = f(red, ImageFilter::invert(1.0));
+    assert!(
+        close(inv[0], 0) && close(inv[1], 255) && close(inv[2], 255),
+        "invert(red) must be cyan, got {inv:?}"
+    );
+
+    // 4. Clamp: brightness(5) of a bright color saturates to 255 (no overflow/NaN
+    //    wrap to a small value).
+    let bright = f(Color::rgb(200, 200, 200), ImageFilter::brightness(5.0));
+    assert!(
+        bright[0] == 255 && bright[1] == 255 && bright[2] == 255,
+        "brightness(5) must clamp to 255, got {bright:?}"
+    );
+
+    // 5. hue-rotate periodicity: three 120-degree rotations return near identity.
+    // A mid-tone gray-ish probe stays in gamut so clamping doesn't accumulate.
+    let orig = [150u8, 120, 90];
+    let mut cur = Color::rgb(orig[0], orig[1], orig[2]);
+    for _ in 0..3 {
+        let out = f(cur, ImageFilter::hue_rotate(std::f32::consts::TAU / 3.0));
+        cur = Color::rgb(out[0], out[1], out[2]);
+    }
+    let final_rgb = [
+        (cur.r * 255.0).round() as i32,
+        (cur.g * 255.0).round() as i32,
+        (cur.b * 255.0).round() as i32,
+    ];
+    for (ch, &o) in orig.iter().enumerate() {
+        assert!(
+            (final_rgb[ch] - o as i32).abs() <= 10,
+            "3x hue_rotate(120deg) must return near the original; channel {ch}: {} vs {o}",
+            final_rgb[ch]
+        );
+    }
+}

--- a/tests/color_matrix_wgpu.rs
+++ b/tests/color_matrix_wgpu.rs
@@ -203,3 +203,115 @@ fn color_matrix_filter_properties() {
         );
     }
 }
+
+/// A mirrored filter pass survives every solid-color test in this file, so
+/// this one filters an asymmetric source: top half red, bottom half blue,
+/// uploaded as pixel data. Image render targets store their content
+/// vertically flipped (the render-target convention documented on
+/// `filter_image`), so the caller samples the result upright by creating the
+/// target with `ImageFlags::FLIP_Y` — after which red must still be on top
+/// and blue on the bottom, where browsers put them for the same filter.
+#[test]
+fn filter_preserves_source_orientation() {
+    let Some((device, queue)) = headless_device() else {
+        eprintln!("skipping: no wgpu adapter available");
+        return;
+    };
+
+    let target = device.create_texture(&wgpu::TextureDescriptor {
+        label: Some("cmat orientation out"),
+        size: wgpu::Extent3d {
+            width: W,
+            height: H,
+            depth_or_array_layers: 1,
+        },
+        mip_level_count: 1,
+        sample_count: 1,
+        dimension: wgpu::TextureDimension::D2,
+        format: wgpu::TextureFormat::Rgba8Unorm,
+        usage: wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::COPY_SRC,
+        view_formats: &[],
+    });
+
+    let renderer = WGPURenderer::new(device.clone(), queue.clone());
+    let mut canvas = Canvas::new(renderer).expect("canvas");
+    canvas.set_size(W, H, 1.0);
+
+    let mut buf = vec![femtovg::rgb::RGBA8::new(0, 0, 255, 255); (W * H) as usize];
+    for px in buf.iter_mut().take((W * H / 2) as usize) {
+        *px = femtovg::rgb::RGBA8::new(255, 0, 0, 255);
+    }
+    let source = canvas
+        .create_image(
+            femtovg::imgref::Img::new(buf.as_slice(), W as usize, H as usize),
+            ImageFlags::empty(),
+        )
+        .expect("source image");
+
+    let filtered = canvas
+        .create_image_empty(W as usize, H as usize, PixelFormat::Rgba8, ImageFlags::FLIP_Y)
+        .expect("target image");
+    // An identity-strength filter isolates orientation from color math.
+    canvas.filter_image(filtered, ImageFilter::brightness(1.0), source);
+
+    canvas.clear_rect(0, 0, W, H, Color::white());
+    let mut p = Path::new();
+    p.rect(0.0, 0.0, W as f32, H as f32);
+    canvas.fill_path(&p, &Paint::image(filtered, 0.0, 0.0, W as f32, H as f32, 0.0, 1.0));
+
+    let commands = canvas.flush_to_output(&target);
+    queue.submit(commands);
+
+    let unpadded = W * 4;
+    let align = wgpu::COPY_BYTES_PER_ROW_ALIGNMENT;
+    let padded = unpadded.div_ceil(align) * align;
+    let readback = device.create_buffer(&wgpu::BufferDescriptor {
+        label: None,
+        size: (padded * H) as u64,
+        usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
+        mapped_at_creation: false,
+    });
+    let mut enc = device.create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
+    enc.copy_texture_to_buffer(
+        wgpu::TexelCopyTextureInfo {
+            texture: &target,
+            mip_level: 0,
+            origin: wgpu::Origin3d::ZERO,
+            aspect: wgpu::TextureAspect::All,
+        },
+        wgpu::TexelCopyBufferInfo {
+            buffer: &readback,
+            layout: wgpu::TexelCopyBufferLayout {
+                offset: 0,
+                bytes_per_row: Some(padded),
+                rows_per_image: Some(H),
+            },
+        },
+        wgpu::Extent3d {
+            width: W,
+            height: H,
+            depth_or_array_layers: 1,
+        },
+    );
+    queue.submit(Some(enc.finish()));
+    let slice = readback.slice(..);
+    slice.map_async(wgpu::MapMode::Read, |_| {});
+    device.poll(wgpu::PollType::wait_indefinitely()).unwrap();
+    let mapped = slice.get_mapped_range().expect("readback");
+
+    let probe = |x: usize, y: usize| {
+        let i = y * padded as usize + x * 4;
+        [mapped[i], mapped[i + 1], mapped[i + 2]]
+    };
+    let top = probe(W as usize / 2, 4);
+    let bottom = probe(W as usize / 2, H as usize - 4);
+    assert!(
+        close(top[0], 255) && close(top[2], 0),
+        "top half should stay red after filtering, got {top:?}"
+    );
+    assert!(
+        close(bottom[0], 0) && close(bottom[2], 255),
+        "bottom half should stay blue after filtering, got {bottom:?} - \
+         a swapped pair means the filter pass mirrored the image"
+    );
+}


### PR DESCRIPTION
Adds a color-matrix image filter — the operation behind SVG `feColorMatrix` and the CSS/Canvas `filter` color functions.

### API

`ImageFilter::ColorMatrix { matrix: [f32; 20] }` (row-major 4×5: `[r' g' b' a'] = M · [r g b a 1]`), plus constructors for the standard CSS functions: `grayscale`, `sepia`, `saturate`, `hue_rotate`, `brightness`, `contrast`, `invert`, `opacity`, using the Filter Effects Level 1 matrices (sRGB, Rec.709 luma).

### Reuse (not new plumbing)

- Extends the existing `filter_image` / `RenderFilteredImage` path and the `ImageFilter` enum — a single full-screen pass, mirroring `gaussian_blur_filter` minus the intermediate texture.
- **No uniform-array growth.** During a filter pass the `scissorMat`/`paintMat` uniform slots are dead (no scissor, no paint gradient), so the 4×5 matrix rides `frag[0..4]` and the array stays at 14 vec4s — the per-draw upload size is unchanged for every other draw.

### Correctness (guards the classic feColorMatrix bug classes)

The shader applies the matrix in **unpremultiplied** space and **clamps to [0, 1]**, so overflowing matrices can't halo at edges or produce out-of-range / NaN pixels. Operates in **sRGB**, matching the CSS filter functions (documented on the type). Both GLSL and wgpu backends.

### Validation vs Chromium and Firefox

**Before/after.** femtovg master has no color-matrix API, so the closest an application gets is drawing the source unfiltered — 10.44% of scene pixels wrong versus Chromium rendering SVG `feColorMatrix` (sRGB interpolation) of the same six filters. With this PR the same scene is **0.00% different from Chromium** at the >40/255 threshold, and within Firefox's own 0.77% disagreement with Chromium:

![before/after: unfiltered master vs this PR vs Chromium vs Firefox, with diff overlays](https://raw.githubusercontent.com/rebeckerspecialties/femtovg/demo-assets/color-matrix-before-after.png)

**Zoom durability.** The same scene swept through an 8-step zoom in/out ladder (0.6x–2.35x, camera zoom about the canvas center): femtovg stays 0.00% vs Chromium at every step, and femtovg-vs-Firefox tracks Chromium-vs-Firefox (the cross-browser envelope) throughout:

![zoom ladder: femtovg vs Chromium vs Firefox with diff overlays](https://raw.githubusercontent.com/rebeckerspecialties/femtovg/demo-assets/color-matrix-zoom.gif)

Per-function swatch strip vs Chrome `ctx.filter` (mean diff 0.0 for grayscale/sepia/saturate/hue-rotate/brightness/contrast; 0.7 for invert — sub-pixel rounding):

![color-matrix vs Chrome](https://raw.githubusercontent.com/rebeckerspecialties/femtovg/pixel-comparisons/comparisons/color_matrix_filter.png)

### Tests (`tests/color_matrix_wgpu.rs`)

Research-derived property checks that would catch the shipped browser bugs in this area (luma-weight swaps, missing clamp, premultiply halos, degrees/radians and sin/cos matrix errors):

- `grayscale(1)` is exactly Rec.709 luma — red→54, green→182, blue→18 (not the 1/3 average of 85, not Rec.601's 76);
- `grayscale(0)`, `saturate(1)`, `brightness(1)`, `contrast(1)`, `sepia(0)`, `invert(0)`, `opacity(1)`, `hue-rotate(0)` and `hue-rotate(2π)` are all identities;
- `invert(red)` = cyan;
- `brightness(5)` clamps to 255 (no overflow / NaN);
- three `hue-rotate(120°)` rotations return to the original;
- an asymmetric (red-top / blue-bottom) uploaded source keeps its orientation through the filter pass — solid-color tests can't catch a mirrored pass, and the render-target `FLIP_Y` convention is exercised end to end.

### Follow-up this enables

Filter-list / chain execution (Canvas `ctx.filter` accepting `"blur(5px) brightness(1.2)"`, SVG filter chains) builds directly on this: runs of adjacent color matrices fold by multiplication into a single matrix on the CPU, so a chain of N color ops stays one GPU pass. We plan to propose that as a follow-up PR once this lands.

### Femto budget

No new heap allocations, no new textures, no uniform-array growth; cost is one full-screen pass per filtered image, only when a color-matrix filter is used.

