### PR TITLE
Use RED for Gray texture sub-uploads

### DIFF
--- a/src/renderer/opengl/gl_texture.rs
+++ b/src/renderer/opengl/gl_texture.rs
@@ -203,7 +203,7 @@ impl GlTexture {
 
         match src {
             ImageSource::Gray(data) => unsafe {
-                let format = if opengles_2_0 { glow::LUMINANCE } else { glow::R8 };
+                let format = if opengles_2_0 { glow::LUMINANCE } else { glow::RED };
 
                 context.tex_sub_image_2d(
                     glow::TEXTURE_2D,


### PR DESCRIPTION
Hey, I've encountered an issue when using FemtoVG on a device with llvmpipe. That implementatoin seems to be too strict and not allow the internal R8 format for the pixel format passed to tex_sub_image_2d. From the docs it seems to me the correct format to actually pass is the RED format (despite the name, it just means it's one component per pixel, not that the pixel would have to be red)

Pass GL_RED, not the sized internal format GL_R8, as the external format argument of glTexSubImage2D. A sized format there is invalid on GLES3 and desktop GL and raises GL_INVALID_ENUM, so strict drivers silently drop every Gray texture update. Texture creation correctly uses R8 as the internal format and stays unchanged.