### PR TITLE
Interpolate two-stop gradients in straight space, matching multi-stop and browsers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+- Fixed two-stop gradients fading a transparent stop through the wrong colors:
+  the stop's own color was discarded, so `transparent` to blue turned a plain
+  light blue instead of darkening, and transparent red to blue lost its red.
+  Two-stop and multi-stop gradients now interpolate the same way, matching
+  Canvas and SVG gradients in browsers.
+
 ## [0.27.0] - 2026-08-31
 
 - Added text decoration for `fill_text()` and `stroke_text()`: underline,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,9 @@ All notable changes to this project will be documented in this file.
 - Fixed two-stop gradients fading a transparent stop through the wrong colors:
   the stop's own color was discarded, so `transparent` to blue turned a plain
   light blue instead of darkening, and transparent red to blue lost its red.
-  Two-stop and multi-stop gradients now interpolate the same way, matching
-  Canvas and SVG gradients in browsers.
+  Two-stop and multi-stop gradients now interpolate the same way, fixing flame
+  gradient accuracy in Firefox's kit.svg embedded art, and now matching
+  Canvas and SVG gradient behaviors in multiple web browsers.
 
 ## [0.27.0] - 2026-08-31
 

--- a/src/renderer/opengl/main-fs.glsl
+++ b/src/renderer/opengl/main-fs.glsl
@@ -93,7 +93,11 @@ vec4 renderGradient() {
     vec2 pt = (paintMat * vec3(fpos, 1.0)).xy;
 
     float d = clamp((sdroundrect(pt, extent, radius) + feather*0.5) / feather, 0.0, 1.0);
-    return ditherGradient(mix(innerCol,outerCol,d));
+    // Endpoints arrive straight (unpremultiplied) so transparent stops keep
+    // their hue through the mix - the interpolation Canvas and SVG gradients
+    // apply; premultiply here for the compositing pipeline.
+    vec4 color = ditherGradient(mix(innerCol,outerCol,d));
+    return vec4(color.rgb * color.a, color.a);
 }
 
 // Image-based Gradient; sample a texture using the gradient position.
@@ -117,7 +121,9 @@ float conicAngleFraction() {
 
 vec4 renderGradientConic() {
     float d = conicAngleFraction();
-    return ditherGradient(mix(innerCol,outerCol,d));
+    // Straight endpoints, premultiplied post-mix (see renderGradient).
+    vec4 color = ditherGradient(mix(innerCol,outerCol,d));
+    return vec4(color.rgb * color.a, color.a);
 }
 
 vec4 renderImageGradientConic() {

--- a/src/renderer/params.rs
+++ b/src/renderer/params.rs
@@ -164,8 +164,13 @@ impl Params {
 
                 match colors {
                     GradientColors::TwoStop { start_color, end_color } => {
-                        params.inner_col = start_color.premultiplied().to_array();
-                        params.outer_col = end_color.premultiplied().to_array();
+                        // Two-stop endpoints upload straight (unpremultiplied):
+                        // the shader mixes them per fragment and premultiplies
+                        // the result, so transparent stops keep their hue - the
+                        // interpolation Canvas and SVG gradients apply, and the
+                        // same one the multi-stop LUT bakes texel by texel.
+                        params.inner_col = start_color.to_array();
+                        params.outer_col = end_color.to_array();
                         params.shader_type = ShaderType::FillGradient;
                     }
                     GradientColors::MultiStop { .. } => {
@@ -191,8 +196,10 @@ impl Params {
                 params.feather = *feather;
                 match colors {
                     GradientColors::TwoStop { start_color, end_color } => {
-                        params.inner_col = start_color.premultiplied().to_array();
-                        params.outer_col = end_color.premultiplied().to_array();
+                        // Straight endpoints; the shader premultiplies post-mix
+                        // (see the linear-gradient arm).
+                        params.inner_col = start_color.to_array();
+                        params.outer_col = end_color.to_array();
                         params.shader_type = ShaderType::FillGradient;
                     }
                     GradientColors::MultiStop { .. } => {
@@ -223,8 +230,10 @@ impl Params {
                 params.feather = 1.0f32.max(f);
                 match colors {
                     GradientColors::TwoStop { start_color, end_color } => {
-                        params.inner_col = start_color.premultiplied().to_array();
-                        params.outer_col = end_color.premultiplied().to_array();
+                        // Straight endpoints; the shader premultiplies post-mix
+                        // (see the linear-gradient arm).
+                        params.inner_col = start_color.to_array();
+                        params.outer_col = end_color.to_array();
                         params.shader_type = ShaderType::FillGradient;
                     }
                     GradientColors::MultiStop { .. } => {
@@ -245,8 +254,10 @@ impl Params {
 
                 match colors {
                     GradientColors::TwoStop { start_color, end_color } => {
-                        params.inner_col = start_color.premultiplied().to_array();
-                        params.outer_col = end_color.premultiplied().to_array();
+                        // Straight endpoints; the shader premultiplies post-mix
+                        // (see the linear-gradient arm).
+                        params.inner_col = start_color.to_array();
+                        params.outer_col = end_color.to_array();
                         params.shader_type = ShaderType::FillGradientConic;
                     }
                     GradientColors::MultiStop { .. } => {

--- a/src/renderer/wgpu/shader.wgsl
+++ b/src/renderer/wgpu/shader.wgsl
@@ -152,7 +152,9 @@ fn fs_main(vertex: VertexOutput) -> @location(0) vec4<f32> {
             // below (like the other gradient cases); returning here would skip
             // the clip and antialiasing, so conic fills would ignore scissors.
             let d = conicAngleFraction(vertex, params);
-            result = ditherGradient(mix(params.inner_col,params.outer_col,d), vertex.position.xy);
+            // Straight endpoints, premultiplied post-mix (see renderGradient).
+            let mixed = ditherGradient(mix(params.inner_col,params.outer_col,d), vertex.position.xy);
+            result = vec4<f32>(mixed.rgb * mixed.a, mixed.a);
         }
         case SHADER_TYPE_FillImageGradientConic: {
             let d = conicAngleFraction(vertex, params);
@@ -266,7 +268,11 @@ fn renderGradient(vertex: VertexOutput, params: Params) -> vec4<f32> {
     let pt: vec2<f32> = (params.paint_mat * vec3<f32>(vertex.fpos, 1.0)).xy;
 
     let d: f32 = clamp((sdroundrect(pt, params.extent, params.radius) + params.feather*0.5) / params.feather, 0.0, 1.0);
-    return ditherGradient(mix(params.inner_col,params.outer_col,d), vertex.position.xy);
+    // Endpoints arrive straight (unpremultiplied) so transparent stops keep
+    // their hue through the mix - the interpolation Canvas and SVG gradients
+    // apply; premultiply here for the compositing pipeline.
+    let color: vec4<f32> = ditherGradient(mix(params.inner_col,params.outer_col,d), vertex.position.xy);
+    return vec4<f32>(color.rgb * color.a, color.a);
 }
 
 // Image-based Gradient; sample a texture using the gradient position.

--- a/tests/gradient_stop_interpolation_wgpu.rs
+++ b/tests/gradient_stop_interpolation_wgpu.rs
@@ -1,0 +1,221 @@
+//! Headless GPU tests: gradient stops interpolate in straight (unpremultiplied)
+//! space, the interpolation Canvas 2D and SVG gradients apply - Chromium 149
+//! renders `createLinearGradient` / `<linearGradient>` from transparent red to
+//! opaque blue with midpoint (192, 158, 193) over white, the straight-space
+//! mix, and SVG 1.1/2 define stop interpolation per channel on the straight
+//! color plus stop-opacity. The multi-stop LUT already bakes texels this way
+//! (interpolate straight, premultiply the texel); these tests pin the two-stop
+//! shader path to the same space, endpoint hue included.
+#![cfg(feature = "wgpu")]
+
+use femtovg::{renderer::WGPURenderer, Canvas, Color, Paint, Path};
+
+const W: u32 = 256;
+const H: u32 = 64;
+
+fn headless_device() -> Option<(wgpu::Device, wgpu::Queue)> {
+    let instance = wgpu::Instance::default();
+    let adapter = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
+        power_preference: wgpu::PowerPreference::default(),
+        force_fallback_adapter: false,
+        compatible_surface: None,
+        ..Default::default()
+    }))
+    .ok()?;
+    let (device, queue) = pollster::block_on(adapter.request_device(&wgpu::DeviceDescriptor {
+        label: Some("femtovg gradient interpolation test device"),
+        required_features: wgpu::Features::empty(),
+        required_limits: wgpu::Limits::downlevel_defaults().using_resolution(adapter.limits()),
+        experimental_features: wgpu::ExperimentalFeatures::disabled(),
+        memory_hints: wgpu::MemoryHints::MemoryUsage,
+        trace: wgpu::Trace::default(),
+    }))
+    .ok()?;
+    Some((device, queue))
+}
+
+fn render(device: &wgpu::Device, queue: &wgpu::Queue, draw: impl FnOnce(&mut Canvas<WGPURenderer>)) -> Vec<u8> {
+    let target = device.create_texture(&wgpu::TextureDescriptor {
+        label: Some("gradient interpolation out"),
+        size: wgpu::Extent3d {
+            width: W,
+            height: H,
+            depth_or_array_layers: 1,
+        },
+        mip_level_count: 1,
+        sample_count: 1,
+        dimension: wgpu::TextureDimension::D2,
+        format: wgpu::TextureFormat::Rgba8Unorm,
+        usage: wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::COPY_SRC,
+        view_formats: &[],
+    });
+    let renderer = WGPURenderer::new(device.clone(), queue.clone());
+    let mut canvas = Canvas::new(renderer).expect("canvas");
+    canvas.set_size(W, H, 1.0);
+    canvas.clear_rect(0, 0, W, H, Color::white());
+    draw(&mut canvas);
+    let commands = canvas.flush_to_output(&target);
+    queue.submit(commands);
+
+    let unpadded = W * 4;
+    let padded = unpadded.div_ceil(wgpu::COPY_BYTES_PER_ROW_ALIGNMENT) * wgpu::COPY_BYTES_PER_ROW_ALIGNMENT;
+    let readback = device.create_buffer(&wgpu::BufferDescriptor {
+        label: None,
+        size: (padded * H) as u64,
+        usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
+        mapped_at_creation: false,
+    });
+    let mut enc = device.create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
+    enc.copy_texture_to_buffer(
+        wgpu::TexelCopyTextureInfo {
+            texture: &target,
+            mip_level: 0,
+            origin: wgpu::Origin3d::ZERO,
+            aspect: wgpu::TextureAspect::All,
+        },
+        wgpu::TexelCopyBufferInfo {
+            buffer: &readback,
+            layout: wgpu::TexelCopyBufferLayout {
+                offset: 0,
+                bytes_per_row: Some(padded),
+                rows_per_image: Some(H),
+            },
+        },
+        wgpu::Extent3d {
+            width: W,
+            height: H,
+            depth_or_array_layers: 1,
+        },
+    );
+    queue.submit(Some(enc.finish()));
+    let slice = readback.slice(..);
+    slice.map_async(wgpu::MapMode::Read, |_| {});
+    device.poll(wgpu::PollType::wait_indefinitely()).unwrap();
+    let mapped = slice.get_mapped_range().expect("readback");
+
+    let mut out = vec![0u8; (W * H * 4) as usize];
+    for y in 0..H as usize {
+        let src = y * padded as usize;
+        let dst = y * (W * 4) as usize;
+        out[dst..dst + (W * 4) as usize].copy_from_slice(&mapped[src..src + (W * 4) as usize]);
+    }
+    out
+}
+
+fn px(buf: &[u8], x: u32, y: u32) -> [i32; 3] {
+    let i = ((y * W + x) * 4) as usize;
+    [buf[i] as i32, buf[i + 1] as i32, buf[i + 2] as i32]
+}
+
+fn close(a: [i32; 3], b: [i32; 3], tol: i32) -> bool {
+    a.iter().zip(b).all(|(x, y)| (x - y).abs() <= tol)
+}
+
+const TRANSPARENT_RED: (u8, u8, u8) = (220, 40, 40);
+const BLUE: (u8, u8, u8) = (40, 80, 220);
+
+fn transparent_red() -> Color {
+    Color::rgba(TRANSPARENT_RED.0, TRANSPARENT_RED.1, TRANSPARENT_RED.2, 0)
+}
+
+fn blue() -> Color {
+    Color::rgb(BLUE.0, BLUE.1, BLUE.2)
+}
+
+/// The straight-space expectation at gradient fraction `t`, composited over
+/// white: mix the straight channels, then alpha-blend.
+fn straight_over_white(t: f32) -> [i32; 3] {
+    let a = t;
+    let mix = |c0: u8, c1: u8| {
+        let straight = f32::from(c0) * (1.0 - t) + f32::from(c1) * t;
+        (straight * a + 255.0 * (1.0 - a)).round() as i32
+    };
+    [
+        mix(TRANSPARENT_RED.0, BLUE.0),
+        mix(TRANSPARENT_RED.1, BLUE.1),
+        mix(TRANSPARENT_RED.2, BLUE.2),
+    ]
+}
+
+/// A two-stop gradient from transparent red to opaque blue must keep the red
+/// hue while fading - the straight-space interpolation browsers apply. A
+/// premultiplied mix loses the transparent stop's hue entirely (its
+/// premultiplied channels are zero) and lands ~45/255 away at the midpoint.
+#[test]
+fn two_stop_transparent_stop_keeps_hue() {
+    let Some((device, queue)) = headless_device() else {
+        eprintln!("skipping: no wgpu adapter available");
+        return;
+    };
+    let out = render(&device, &queue, |canvas| {
+        let paint = Paint::linear_gradient(0.0, 0.0, W as f32, 0.0, transparent_red(), blue());
+        let mut p = Path::new();
+        p.rect(0.0, 0.0, W as f32, H as f32);
+        canvas.fill_path(&p, &paint);
+    });
+    for t in [0.25f32, 0.5, 0.75] {
+        let x = (t * W as f32) as u32;
+        let got = px(&out, x, H / 2);
+        let want = straight_over_white(t);
+        assert!(
+            close(got, want, 3),
+            "at t={t}: got {got:?}, straight-space expects {want:?} (Chromium 149 matches this)"
+        );
+    }
+}
+
+/// The two-stop shader path and the multi-stop LUT must agree: both are
+/// documented as the same gradient, differing only in how many stops forced
+/// the LUT. The LUT quantizes to 256 texels, so allow its rounding.
+#[test]
+fn two_stop_matches_multi_stop_lut() {
+    let Some((device, queue)) = headless_device() else {
+        eprintln!("skipping: no wgpu adapter available");
+        return;
+    };
+    let two = render(&device, &queue, |canvas| {
+        let paint = Paint::linear_gradient(0.0, 0.0, W as f32, 0.0, transparent_red(), blue());
+        let mut p = Path::new();
+        p.rect(0.0, 0.0, W as f32, H as f32);
+        canvas.fill_path(&p, &paint);
+    });
+    let lut = render(&device, &queue, |canvas| {
+        // The duplicate trailing stop forces the multi-stop LUT path.
+        let stops = vec![(0.0, transparent_red()), (1.0, blue()), (1.0, blue())];
+        let paint = Paint::linear_gradient_stops(0.0, 0.0, W as f32, 0.0, stops);
+        let mut p = Path::new();
+        p.rect(0.0, 0.0, W as f32, H as f32);
+        canvas.fill_path(&p, &paint);
+    });
+    for x in (8..W - 8).step_by(16) {
+        let a = px(&two, x, H / 2);
+        let b = px(&lut, x, H / 2);
+        assert!(
+            close(a, b, 3),
+            "two-stop and LUT paths diverge at x={x}: {a:?} vs {b:?}"
+        );
+    }
+}
+
+/// Conic gradients share the two-stop shader path; the fragment opposite the
+/// start angle sits at fraction 0.5 and must show the straight-space mix.
+#[test]
+fn conic_two_stop_interpolates_straight() {
+    let Some((device, queue)) = headless_device() else {
+        eprintln!("skipping: no wgpu adapter available");
+        return;
+    };
+    let out = render(&device, &queue, |canvas| {
+        let paint = Paint::conic_gradient(W as f32 / 2.0, H as f32 / 2.0, transparent_red(), blue());
+        let mut p = Path::new();
+        p.rect(0.0, 0.0, W as f32, H as f32);
+        canvas.fill_path(&p, &paint);
+    });
+    // Left of centre = angle PI = fraction 0.5 along the ramp.
+    let got = px(&out, W / 2 - 20, H / 2);
+    let want = straight_over_white(0.5);
+    assert!(
+        close(got, want, 3),
+        "conic midpoint: got {got:?}, straight-space expects {want:?}"
+    );
+}


### PR DESCRIPTION
Found while cross-checking the open PR stack against a 26-file corpus of Firefox-ecosystem SVGs. The probe below is a reduction of a real corpus case: the flame gradients in Mozilla's `kit.svg` mascot art ([full file](https://raw.githubusercontent.com/rebeckerspecialties/femtovg/demo-assets/kit.svg)) — `#ffd400` → `#ff9c00` at `stop-opacity="0"`, stops at offsets 0/1, which is exactly the shape femtovg routes to its two-stop shader path.

A gradient from a transparent stop to an opaque one must keep the transparent stop's hue while fading. femtovg's two code paths disagreed on the interpolation space:

- the **multi-stop LUT** interpolates each channel on the straight (unpremultiplied) color and premultiplies the baked texel — with a comment in `gradient_store.rs` explaining exactly why ("if we have a stop that is fully transparent red … we should see some red in the gradient");
- the **two-stop shader path** uploaded already-premultiplied endpoint colors and mixed those, so a transparent stop's channels were already zeroed before the mix — the fade collapses toward colorless.

The LUT is the conformant one. Chromium 149 renders both `createLinearGradient` and SVG `<linearGradient>` from `rgba(220,40,40,0)` to `rgb(40,80,220)` with the straight-space midpoint — (192, 158, 193) over white, measured to the pixel on both surfaces — and SVG 1.1/2 define stop interpolation per channel on the straight color plus `stop-opacity`. (CSS *gradients* interpolate premultiplied, but Canvas and SVG — femtovg's reference surfaces — do not.) Skia's `SkGradientShader` likewise interpolates unpremultiplied by default (`kInterpolateColorsInPremul` is opt-in).

**The Firefox case, reduced:** `kit-flame-reduction.svg` ([SVG](https://raw.githubusercontent.com/rebeckerspecialties/femtovg/demo-assets/kit-flame-reduction.svg)) is the flame path and its gradient lifted verbatim from `kit.svg`. Before the fix, the premultiplied mix drains the fading orange toward white; after, femtovg matches Chromium's warm fade and the residual is edge AA only. Diff overlays at >8/255 (the two hues are close, so the divergence sits below the 20/255 threshold the corpus sweep uses — which is how it hid inside `kit.svg`'s 4.4% number):

![kit flame reduction](https://raw.githubusercontent.com/rebeckerspecialties/femtovg/demo-assets/gradient-stop-kit-flame.png)

| zoom | px >8/255 before | px >8/255 after |
|------|------------------|-----------------|
| 1.0× | 4.45% | 0.13% |
| 2.1× | 18.22% | 0.21% |

Most of the corpus's other transparent-stop gradients (the `background-noodles` fades, `br-fxa-fox-mirror`'s pink glows) author their stops at inset offsets like `.47`, which `GradientColors::from_stops` already routes to the (correct) LUT — the two-stop shader path only serves stops at exactly 0/1, which is why this class survived the earlier sweeps.

**Amplified probe:** the same class with hues chosen far apart so the failure is unmistakable — two bars (`transparent`→blue, transparent-red→blue) over white, pivot-zoom ladder vs Chromium 149 headless (>20/255 threshold). This also covers the everyday Canvas idiom `addColorStop(0, 'transparent')` — CSS `transparent` is transparent *black*, so the premultiplied mix dropped the darkening browsers show. Before, the two-stop path diverged on **36%** of gradient pixels at 1.0×; after, both paths are **0.00%** at every zoom:

| zoom | two-stop before | two-stop after | multi-stop LUT |
|------|-----------------|----------------|----------------|
| 0.6× | 12.9% | 0.00% | 0.00% |
| 1.0× | 36.0% | 0.00% | 0.00% |
| 1.4× | 70.4% | 0.00% | 0.00% |
| 1.8× | 72.3% | 0.00% | 0.00% |
| 2.2× | 66.2% | 0.00% | 0.00% |

![before/after](https://raw.githubusercontent.com/rebeckerspecialties/femtovg/demo-assets/gradient-stop-interpolation-before-after.png)

Top bar is the `transparent` keyword (note the gray tinge Chromium shows, restored by the fix); bottom bar is transparent red (note the pink). Rows: femtovg before / femtovg after / Chromium / diff overlays.

**Fix:** two-stop endpoints now upload straight, and both backends premultiply after the mix — one fragment multiply, no extra uniforms, no extra passes. Applies to linear, box, radial, and conic two-stop gradients (they share the shader family).

Tests pin the two-stop path to the browser-verified straight-space values at three fractions, pin conic gradients (same shader family), and lock the two-stop and LUT paths to each other so the two spaces can't drift apart again.
