### PR TITLE
Clear every stencil bit after even-odd fills (wgpu)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+- Fixed the WGPU backend painting a nonzero fill's whole bounding box after an
+  even-odd fill, because the even-odd fill left winding counts in the stencil
+  buffer. Showed as a block above the bow tie of the DuckDuckGo logo.
+
 ## [0.27.0] - 2026-08-31
 
 - Added text decoration for `fill_text()` and `stroke_text()`: underline,

--- a/src/renderer/wgpu.rs
+++ b/src/renderer/wgpu.rs
@@ -1341,10 +1341,13 @@ fn concave_fill(
                         FillRule::NonZero => 0xff,
                         FillRule::EvenOdd => 0x1,
                     },
-                    write_mask: match command.fill_rule {
-                        FillRule::NonZero => 0xff,
-                        FillRule::EvenOdd => 0x1,
-                    },
+                    // Even-odd reads only the parity bit, but the winding pass
+                    // wrote the full count (2 in overlaps, 0xff for a wrapped
+                    // -1). Clearing only bit 0 left those high bits behind,
+                    // and the next nonzero fill's NotEqual-0 test painted its
+                    // whole bounding quad over them. Clear every bit, as the
+                    // OpenGL backend's 0xff stencil mask already does.
+                    write_mask: 0xff,
                 },
                 stencil_reference: 0,
             },

--- a/tests/evenodd_stencil_wgpu.rs
+++ b/tests/evenodd_stencil_wgpu.rs
@@ -1,0 +1,204 @@
+//! Headless GPU tests: an even-odd fill must leave the stencil clean for the
+//! next fill. The winding pass writes the full count, so overlaps hold 2 and a
+//! wrapped -1 holds 0xff; the cover pass reads parity (bit 0) but must clear
+//! every bit, or the next nonzero fill paints its whole bounding quad over the
+//! leftovers. Regression for DuckDuckGo's logo (duckduckgo-com@2x.svg): the
+//! even-odd white body followed by the nonzero bow tie grew a dark-green block.
+#![cfg(feature = "wgpu")]
+
+use femtovg::{renderer::WGPURenderer, Canvas, Color, FillRule, Paint, Path};
+
+const W: u32 = 128;
+const H: u32 = 128;
+
+fn headless_device() -> Option<(wgpu::Device, wgpu::Queue)> {
+    let instance = wgpu::Instance::default();
+    let adapter = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
+        power_preference: wgpu::PowerPreference::default(),
+        force_fallback_adapter: false,
+        compatible_surface: None,
+        ..Default::default()
+    }))
+    .ok()?;
+    let (device, queue) = pollster::block_on(adapter.request_device(&wgpu::DeviceDescriptor {
+        label: Some("femtovg gradient dither test device"),
+        required_features: wgpu::Features::empty(),
+        required_limits: wgpu::Limits::downlevel_defaults().using_resolution(adapter.limits()),
+        experimental_features: wgpu::ExperimentalFeatures::disabled(),
+        memory_hints: wgpu::MemoryHints::MemoryUsage,
+        trace: wgpu::Trace::default(),
+    }))
+    .ok()?;
+    Some((device, queue))
+}
+
+fn render(device: &wgpu::Device, queue: &wgpu::Queue, draw: impl FnOnce(&mut Canvas<WGPURenderer>)) -> Vec<u8> {
+    let target = device.create_texture(&wgpu::TextureDescriptor {
+        label: Some("evenodd stencil out"),
+        size: wgpu::Extent3d {
+            width: W,
+            height: H,
+            depth_or_array_layers: 1,
+        },
+        mip_level_count: 1,
+        sample_count: 1,
+        dimension: wgpu::TextureDimension::D2,
+        format: wgpu::TextureFormat::Rgba8Unorm,
+        usage: wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::COPY_SRC,
+        view_formats: &[],
+    });
+    let renderer = WGPURenderer::new(device.clone(), queue.clone());
+    let mut canvas = Canvas::new(renderer).expect("canvas");
+    canvas.set_size(W, H, 1.0);
+    canvas.clear_rect(0, 0, W, H, Color::white());
+    draw(&mut canvas);
+    let commands = canvas.flush_to_output(&target);
+    queue.submit(commands);
+
+    let unpadded = W * 4;
+    let padded = unpadded.div_ceil(wgpu::COPY_BYTES_PER_ROW_ALIGNMENT) * wgpu::COPY_BYTES_PER_ROW_ALIGNMENT;
+    let readback = device.create_buffer(&wgpu::BufferDescriptor {
+        label: None,
+        size: (padded * H) as u64,
+        usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
+        mapped_at_creation: false,
+    });
+    let mut enc = device.create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
+    enc.copy_texture_to_buffer(
+        wgpu::TexelCopyTextureInfo {
+            texture: &target,
+            mip_level: 0,
+            origin: wgpu::Origin3d::ZERO,
+            aspect: wgpu::TextureAspect::All,
+        },
+        wgpu::TexelCopyBufferInfo {
+            buffer: &readback,
+            layout: wgpu::TexelCopyBufferLayout {
+                offset: 0,
+                bytes_per_row: Some(padded),
+                rows_per_image: Some(H),
+            },
+        },
+        wgpu::Extent3d {
+            width: W,
+            height: H,
+            depth_or_array_layers: 1,
+        },
+    );
+    queue.submit(Some(enc.finish()));
+    let slice = readback.slice(..);
+    slice.map_async(wgpu::MapMode::Read, |_| {});
+    device.poll(wgpu::PollType::wait_indefinitely()).unwrap();
+    let mapped = slice.get_mapped_range().expect("readback");
+    let mut out = vec![0u8; (W * H * 4) as usize];
+    for y in 0..H as usize {
+        let src = y * padded as usize;
+        let dst = y * (W * 4) as usize;
+        out[dst..dst + (W * 4) as usize].copy_from_slice(&mapped[src..src + (W * 4) as usize]);
+    }
+    out
+}
+
+fn px(buf: &[u8], x: u32, y: u32) -> [u8; 3] {
+    let i = ((y * W + x) * 4) as usize;
+    [buf[i], buf[i + 1], buf[i + 2]]
+}
+
+/// A concave nonzero shape (an L) drawn after an even-odd fill: pixels inside
+/// the L's bounding box but outside the L must stay white, whatever the
+/// even-odd predecessor left in the stencil.
+fn l_shape() -> Path {
+    let mut p = Path::new();
+    p.move_to(20.0, 20.0);
+    p.line_to(60.0, 20.0);
+    p.line_to(60.0, 40.0);
+    p.line_to(40.0, 40.0);
+    p.line_to(40.0, 108.0);
+    p.line_to(20.0, 108.0);
+    p.close();
+    p
+}
+
+fn assert_l_only(out: &[u8], label: &str) {
+    assert_eq!(
+        px(out, 30, 30),
+        [0, 160, 0],
+        "{label}: inside the L's top bar should be green"
+    );
+    assert_eq!(
+        px(out, 30, 100),
+        [0, 160, 0],
+        "{label}: inside the L's stem should be green"
+    );
+    // Inside the L's bounding box, outside the L: must be untouched.
+    assert_eq!(
+        px(out, 55, 80),
+        [255, 255, 255],
+        "{label}: the L's concavity must stay white"
+    );
+    assert_eq!(
+        px(out, 55, 100),
+        [255, 255, 255],
+        "{label}: the L's concavity must stay white"
+    );
+}
+
+/// Two overlapping same-direction squares under even-odd: the overlap holds
+/// winding 2 (parity 0, unfilled). The next fill must not see those bits.
+#[test]
+fn evenodd_overlap_leaves_stencil_clean() {
+    let Some((device, queue)) = headless_device() else {
+        eprintln!("skipping: no wgpu adapter available");
+        return;
+    };
+    let out = render(&device, &queue, |canvas| {
+        let mut p = Path::new();
+        p.rect(10.0, 10.0, 80.0, 80.0);
+        p.rect(30.0, 30.0, 90.0, 90.0);
+        let mut white = Paint::color(Color::white());
+        white.set_fill_rule(FillRule::EvenOdd);
+        canvas.fill_path(&p, &white);
+        canvas.fill_path(&l_shape(), &Paint::color(Color::rgb(0, 160, 0)));
+    });
+    assert_l_only(&out, "overlap");
+}
+
+/// A single contour wound each way under even-odd: one direction wraps the
+/// stencil to 0xff, which only clearing bit 0 would leave as 0xfe. Both
+/// orientations must leave the next fill clean.
+#[test]
+fn evenodd_single_contour_leaves_stencil_clean_both_windings() {
+    let Some((device, queue)) = headless_device() else {
+        eprintln!("skipping: no wgpu adapter available");
+        return;
+    };
+    for clockwise in [false, true] {
+        let out = render(&device, &queue, |canvas| {
+            // A concave contour, so the fill takes the stencil path.
+            let mut p = Path::new();
+            let pts = [
+                (5.0, 5.0),
+                (120.0, 5.0),
+                (120.0, 120.0),
+                (70.0, 120.0),
+                (70.0, 60.0),
+                (5.0, 60.0),
+            ];
+            let order: Vec<(f32, f32)> = if clockwise {
+                pts.to_vec()
+            } else {
+                pts.iter().rev().copied().collect()
+            };
+            p.move_to(order[0].0, order[0].1);
+            for &(x, y) in &order[1..] {
+                p.line_to(x, y);
+            }
+            p.close();
+            let mut white = Paint::color(Color::white());
+            white.set_fill_rule(FillRule::EvenOdd);
+            canvas.fill_path(&p, &white);
+            canvas.fill_path(&l_shape(), &Paint::color(Color::rgb(0, 160, 0)));
+        });
+        assert_l_only(&out, if clockwise { "clockwise" } else { "counter-clockwise" });
+    }
+}


### PR DESCRIPTION
Found while sweeping a 26-file corpus of Firefox-ecosystem SVGs against Chromium 149: DuckDuckGo's search-engine icon (`duckduckgo-com@2x.svg`, [file](https://raw.githubusercontent.com/rebeckerspecialties/femtovg/demo-assets/duckduckgo-com_2x.svg)) grew a dark-green block above its bow tie on the wgpu backend.

**Mechanism.** The concave fill's winding pass writes the full winding count into the stencil — overlapping subpaths hold 2, and a contour wound the other way wraps to 0xff. The even-odd cover pass correctly *reads* only the parity bit (`read_mask 0x1`), but it also *wrote* only bit 0 (`write_mask 0x1`), so its Zero ops turned 2 into 2 and 0xff into 0xfe. The next nonzero fill's `NotEqual 0` cover test then saw those leftovers and painted its whole bounding quad over them. In the logo: the even-odd white body is followed by the nonzero dark-green bow, whose bounding box intersects the body's stale region — hence a block with a dead-straight top edge (the bow's bbox). The OpenGL backend clears with a 0xff stencil mask and was never affected.

Reduced to two fills (white even-odd predecessor, then the bow) the bug reproduces in isolation; both the overlap (winding 2) and the wrapped single-contour cases trigger it, a nonzero or concave predecessor does not:

![repro](https://raw.githubusercontent.com/rebeckerspecialties/femtovg/demo-assets/evenodd-stencil-repro.png)

**Fix.** The even-odd cover pass clears with `write_mask 0xff`, matching the nonzero pass and the GL backend; read masks are unchanged, so parity filling is untouched. No new state, pipelines, or passes.

**In the wild, before / after / Chromium 149** (2.1× zoom; bottom row is the bow tie at 3.3×):

![ddg](https://raw.githubusercontent.com/rebeckerspecialties/femtovg/demo-assets/evenodd-stencil-ddg-before-after.png)

Structural residual vs Chromium after 2-px erosion (which removes edge-AA ribbons): 0.065 / 0.400 / 0.696 % → **0.001 / 0.000 / 0.000 %** at 0.7× / 1.3× / 2.1×.

Tests: `tests/evenodd_stencil_wgpu.rs` pins both trigger shapes — an even-odd overlap and a single contour wound each way — followed by a concave nonzero L whose concavity must stay untouched.
