### PR TITLE
Pad multi-stop gradient ramps past the last stop

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,27 @@ jobs:
       - run: cargo build --verbose --examples --features wgpu
       - run: cargo build --target=wasm32-unknown-unknown --example demo
       - run: cargo test
+  # The *_wgpu integration tests are gated behind the `wgpu` feature, so the
+  # plain `cargo test` above compiles each of them to an executable that runs
+  # zero tests. This job runs the GPU regression test for real, on a runner
+  # with a Metal adapter, once the cheap matrix has passed.
+  gpu-regression:
+    needs: [build, format]
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+          profile: minimal
+      - name: Gradient tail pad (Metal)
+        env:
+          # Fail instead of skipping when no adapter is found, and insist on Metal.
+          FEMTOVG_REQUIRE_GPU: metal
+        run: cargo test --features wgpu --test gradient_tail_pad_wgpu -- --nocapture
   format:
     runs-on: ubuntu-latest
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+- Fixed multi-stop gradients whose last stop ends before 1.0: the rest of the
+  ramp was left transparent (or holding stale texture data) instead of the last
+  stop's color, as SVG's default `spreadMethod="pad"` and Canvas gradients
+  render it. Showed as a wedge cut out of the Firefox logo's flame.
+
 ## [0.27.0] - 2026-08-31
 
 - Added text decoration for `fill_text()` and `stroke_text()`: underline,

--- a/src/gradient_store.rs
+++ b/src/gradient_store.rs
@@ -142,5 +142,66 @@ fn linear_gradient_stops(gradient: &MultiStopGradient) -> imgref::Img<Vec<rgb::R
             break;
         }
     }
+
+    // Pad from the last stop to the end of the ramp, mirroring the head pad
+    // above: SVG `spreadMethod="pad"` and Canvas gradients clamp to the last
+    // stop's color. Without this the texels past a last stop below 1.0 were
+    // never written - transparent on a fresh texture, stale on a recycled one.
+    let last_stop = gradient.get(gradient.len() - 1);
+    if last_stop.0 < 1.0 {
+        gradient_span(&mut dest, last_stop.1, last_stop.1, last_stop.0, 1.0);
+    }
     imgref::Img::new(dest.to_vec(), 256, 1)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::paint::GradientColors;
+
+    fn lut(stops: Vec<(f32, Color)>) -> Vec<rgb::RGBA8> {
+        match GradientColors::from_stops(stops) {
+            GradientColors::MultiStop { stops } => linear_gradient_stops(&stops).buf().to_vec(),
+            GradientColors::TwoStop { .. } => panic!("expected a multi-stop gradient"),
+        }
+    }
+
+    /// SVG `spreadMethod="pad"` / Canvas semantics: past the last stop the
+    /// ramp holds the last stop's color. Regression for the Firefox logo
+    /// (splash-logo.svg, mr-settodefault.svg), whose 4-stop flame gradient
+    /// ends at offset 0.70 and rendered its last 30% unwritten.
+    #[test]
+    fn ramp_pads_past_the_last_stop() {
+        let last = Color::rgb(227, 21, 135);
+        let texels = lut(vec![
+            (0.05, Color::rgb(255, 244, 79)),
+            (0.37, Color::rgb(255, 152, 14)),
+            (0.53, Color::rgb(255, 54, 71)),
+            (0.70, last),
+        ]);
+        for i in [180usize, 200, 230, 255] {
+            let t = texels[i];
+            assert_eq!(
+                (t.r, t.g, t.b, t.a),
+                (227, 21, 135, 255),
+                "texel {i} must hold the last stop's color"
+            );
+        }
+        // The head pad keeps working too.
+        let head = texels[0];
+        assert_eq!((head.r, head.g, head.b, head.a), (255, 244, 79, 255));
+    }
+
+    /// A transparent last stop pads transparent (premultiplied zero), not
+    /// black.
+    #[test]
+    fn transparent_last_stop_pads_transparent() {
+        let texels = lut(vec![
+            (0.0, Color::rgb(255, 0, 0)),
+            (0.4, Color::rgb(0, 255, 0)),
+            (0.6, Color::rgba(0, 0, 255, 0)),
+        ]);
+        let t = texels[255];
+        assert_eq!((t.r, t.g, t.b, t.a), (0, 0, 0, 0));
+    }
 }

--- a/src/paint.rs
+++ b/src/paint.rs
@@ -158,6 +158,10 @@ impl MultiStopGradient {
         stop
     }
 
+    pub(crate) fn len(&self) -> usize {
+        self.shared_stops.len()
+    }
+
     pub(crate) fn pairs(&self) -> impl Iterator<Item = [GradientStop; 2]> + '_ {
         self.shared_stops.as_ref().windows(2).map(move |pair| {
             let mut stops = [pair[0], pair[1]];
@@ -207,7 +211,7 @@ impl GradientColors {
             }
         }
     }
-    fn from_stops<Stops>(stops: Stops) -> Self
+    pub(crate) fn from_stops<Stops>(stops: Stops) -> Self
     where
         Stops: IntoIterator<Item = (f32, Color)>,
     {

--- a/tests/gradient_stop_interpolation_wgpu.rs
+++ b/tests/gradient_stop_interpolation_wgpu.rs
@@ -10,29 +10,11 @@
 
 use femtovg::{renderer::WGPURenderer, Canvas, Color, Paint, Path};
 
+mod common;
+use common::headless_device;
+
 const W: u32 = 256;
 const H: u32 = 64;
-
-fn headless_device() -> Option<(wgpu::Device, wgpu::Queue)> {
-    let instance = wgpu::Instance::default();
-    let adapter = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
-        power_preference: wgpu::PowerPreference::default(),
-        force_fallback_adapter: false,
-        compatible_surface: None,
-        ..Default::default()
-    }))
-    .ok()?;
-    let (device, queue) = pollster::block_on(adapter.request_device(&wgpu::DeviceDescriptor {
-        label: Some("femtovg gradient interpolation test device"),
-        required_features: wgpu::Features::empty(),
-        required_limits: wgpu::Limits::downlevel_defaults().using_resolution(adapter.limits()),
-        experimental_features: wgpu::ExperimentalFeatures::disabled(),
-        memory_hints: wgpu::MemoryHints::MemoryUsage,
-        trace: wgpu::Trace::default(),
-    }))
-    .ok()?;
-    Some((device, queue))
-}
 
 fn render(device: &wgpu::Device, queue: &wgpu::Queue, draw: impl FnOnce(&mut Canvas<WGPURenderer>)) -> Vec<u8> {
     let target = device.create_texture(&wgpu::TextureDescriptor {

--- a/tests/gradient_tail_pad_wgpu.rs
+++ b/tests/gradient_tail_pad_wgpu.rs
@@ -1,0 +1,117 @@
+//! Headless GPU test: a multi-stop gradient whose last stop sits below 1.0
+//! clamps to that stop's color for the rest of the ramp (SVG pad / Canvas
+//! semantics). The LUT texels past the last stop used to be left unwritten -
+//! transparent on a fresh texture, stale on a recycled one - which cut a wedge
+//! out of the Firefox logo's flame (splash-logo.svg, mr-settodefault.svg).
+#![cfg(feature = "wgpu")]
+
+use femtovg::{renderer::WGPURenderer, Canvas, Color, Paint, Path};
+
+const W: u32 = 220;
+const H: u32 = 64;
+
+fn headless_device() -> Option<(wgpu::Device, wgpu::Queue)> {
+    let instance = wgpu::Instance::default();
+    let adapter = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
+        power_preference: wgpu::PowerPreference::default(),
+        force_fallback_adapter: false,
+        compatible_surface: None,
+        ..Default::default()
+    }))
+    .ok()?;
+    let (device, queue) = pollster::block_on(adapter.request_device(&wgpu::DeviceDescriptor {
+        label: Some("femtovg gradient dither test device"),
+        required_features: wgpu::Features::empty(),
+        required_limits: wgpu::Limits::downlevel_defaults().using_resolution(adapter.limits()),
+        experimental_features: wgpu::ExperimentalFeatures::disabled(),
+        memory_hints: wgpu::MemoryHints::MemoryUsage,
+        trace: wgpu::Trace::default(),
+    }))
+    .ok()?;
+    Some((device, queue))
+}
+
+#[test]
+fn multi_stop_gradient_pads_past_last_stop() {
+    let Some((device, queue)) = headless_device() else {
+        eprintln!("skipping: no wgpu adapter available");
+        return;
+    };
+    let target = device.create_texture(&wgpu::TextureDescriptor {
+        label: Some("tail pad out"),
+        size: wgpu::Extent3d {
+            width: W,
+            height: H,
+            depth_or_array_layers: 1,
+        },
+        mip_level_count: 1,
+        sample_count: 1,
+        dimension: wgpu::TextureDimension::D2,
+        format: wgpu::TextureFormat::Rgba8Unorm,
+        usage: wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::COPY_SRC,
+        view_formats: &[],
+    });
+    let renderer = WGPURenderer::new(device.clone(), queue.clone());
+    let mut canvas = Canvas::new(renderer).expect("canvas");
+    canvas.set_size(W, H, 1.0);
+    canvas.clear_rect(0, 0, W, H, Color::white());
+    // Three stops ending at 0.6 across the width; the right 40% must be blue.
+    let stops = vec![
+        (0.0, Color::rgb(220, 40, 40)),
+        (0.3, Color::rgb(40, 200, 40)),
+        (0.6, Color::rgb(40, 80, 220)),
+    ];
+    let paint = Paint::linear_gradient_stops(0.0, 0.0, W as f32, 0.0, stops);
+    let mut p = Path::new();
+    p.rect(0.0, 0.0, W as f32, H as f32);
+    canvas.fill_path(&p, &paint);
+    let commands = canvas.flush_to_output(&target);
+    queue.submit(commands);
+
+    let unpadded = W * 4;
+    let padded = unpadded.div_ceil(wgpu::COPY_BYTES_PER_ROW_ALIGNMENT) * wgpu::COPY_BYTES_PER_ROW_ALIGNMENT;
+    let readback = device.create_buffer(&wgpu::BufferDescriptor {
+        label: None,
+        size: (padded * H) as u64,
+        usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
+        mapped_at_creation: false,
+    });
+    let mut enc = device.create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
+    enc.copy_texture_to_buffer(
+        wgpu::TexelCopyTextureInfo {
+            texture: &target,
+            mip_level: 0,
+            origin: wgpu::Origin3d::ZERO,
+            aspect: wgpu::TextureAspect::All,
+        },
+        wgpu::TexelCopyBufferInfo {
+            buffer: &readback,
+            layout: wgpu::TexelCopyBufferLayout {
+                offset: 0,
+                bytes_per_row: Some(padded),
+                rows_per_image: Some(H),
+            },
+        },
+        wgpu::Extent3d {
+            width: W,
+            height: H,
+            depth_or_array_layers: 1,
+        },
+    );
+    queue.submit(Some(enc.finish()));
+    let slice = readback.slice(..);
+    slice.map_async(wgpu::MapMode::Read, |_| {});
+    device.poll(wgpu::PollType::wait_indefinitely()).unwrap();
+    let mapped = slice.get_mapped_range().expect("readback");
+    let px = |x: usize| {
+        let i = (H as usize / 2) * padded as usize + x * 4;
+        [mapped[i] as i32, mapped[i + 1] as i32, mapped[i + 2] as i32]
+    };
+    for x in [150usize, 180, 210, 219] {
+        let p = px(x);
+        assert!(
+            (p[0] - 40).abs() <= 2 && (p[1] - 80).abs() <= 2 && (p[2] - 220).abs() <= 2,
+            "x={x} past the last stop must clamp to blue, got {p:?}"
+        );
+    }
+}

--- a/tests/gradient_tail_pad_wgpu.rs
+++ b/tests/gradient_tail_pad_wgpu.rs
@@ -1,8 +1,22 @@
-//! Headless GPU test: a multi-stop gradient whose last stop sits below 1.0
-//! clamps to that stop's color for the rest of the ramp (SVG pad / Canvas
-//! semantics). The LUT texels past the last stop used to be left unwritten -
-//! transparent on a fresh texture, stale on a recycled one - which cut a wedge
-//! out of the Firefox logo's flame (splash-logo.svg, mr-settodefault.svg).
+//! Headless GPU regression test: a multi-stop gradient whose last stop sits
+//! below 1.0 clamps to that stop's color for the rest of the ramp (SVG pad /
+//! Canvas semantics). The LUT texels past the last stop used to be left
+//! unwritten - transparent on a fresh texture, stale on a recycled one - which
+//! cut a wedge out of the Firefox logo's flame (splash-logo.svg,
+//! mr-settodefault.svg).
+//!
+//! The tail pixels alone cannot tell "unpadded LUT" from "the draw never
+//! landed" or "the wrong texture was read": all three come back as the clear
+//! color. So the frame carries controls that pin each of those down before
+//! the tail is judged: a white gap proves the clear and the readback row
+//! mapping, a solid magenta strip proves draws land in the target, and
+//! samples inside the ramp prove the LUT is the one being sampled and holds
+//! the right colors. Render and readback go to the queue in one submission.
+//!
+//! Set `FEMTOVG_REQUIRE_GPU=1` to fail instead of skip when no adapter is
+//! found, or `FEMTOVG_REQUIRE_GPU=metal` (or another backend name) to also
+//! insist on that backend; CI's Mac job sets `metal` so the test cannot pass
+//! by not running.
 #![cfg(feature = "wgpu")]
 
 use femtovg::{renderer::WGPURenderer, Canvas, Color, Paint, Path};
@@ -10,31 +24,174 @@ use femtovg::{renderer::WGPURenderer, Canvas, Color, Paint, Path};
 const W: u32 = 220;
 const H: u32 = 64;
 
+/// The gradient fills rows 0..40; row 20 is sampled.
+const RAMP_BOTTOM: f32 = 40.0;
+const RAMP_ROW: u32 = 20;
+/// Rows 40..48 stay at the clear color; row 44 is sampled.
+const GAP_ROW: u32 = 44;
+/// A solid strip fills rows 48..64; row 56 is sampled.
+const STRIP_TOP: f32 = 48.0;
+const STRIP_ROW: u32 = 56;
+
+const RED: [u8; 3] = [220, 40, 40];
+const GREEN: [u8; 3] = [40, 200, 40];
+const BLUE: [u8; 3] = [40, 80, 220];
+const WHITE: [u8; 3] = [255, 255, 255];
+/// Unlike anything in the ramp or the clear, so a strip pixel cannot be
+/// mistaken for either.
+const MAGENTA: [u8; 3] = [200, 0, 200];
+
+fn gpu_requirement() -> Option<String> {
+    std::env::var("FEMTOVG_REQUIRE_GPU")
+        .ok()
+        .map(|v| v.trim().to_ascii_lowercase())
+        .filter(|v| !v.is_empty())
+}
+
 fn headless_device() -> Option<(wgpu::Device, wgpu::Queue)> {
+    let require = gpu_requirement();
     let instance = wgpu::Instance::default();
-    let adapter = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
+    let adapter = match pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
         power_preference: wgpu::PowerPreference::default(),
         force_fallback_adapter: false,
         compatible_surface: None,
         ..Default::default()
-    }))
-    .ok()?;
-    let (device, queue) = pollster::block_on(adapter.request_device(&wgpu::DeviceDescriptor {
-        label: Some("femtovg gradient dither test device"),
+    })) {
+        Ok(adapter) => adapter,
+        Err(err) => {
+            if require.is_some() {
+                panic!("FEMTOVG_REQUIRE_GPU is set but no wgpu adapter was found: {err}");
+            }
+            eprintln!("skipping: no wgpu adapter available ({err})");
+            return None;
+        }
+    };
+    let info = adapter.get_info();
+    eprintln!(
+        "wgpu adapter: {} | backend {:?} | type {:?} | driver {} {}",
+        info.name, info.backend, info.device_type, info.driver, info.driver_info
+    );
+    if let Some(required) = require.as_deref() {
+        let backend = format!("{:?}", info.backend).to_ascii_lowercase();
+        if !matches!(required, "1" | "true" | "any") && required != backend {
+            panic!("FEMTOVG_REQUIRE_GPU={required} but the adapter's backend is {backend}");
+        }
+    }
+    let (device, queue) = match pollster::block_on(adapter.request_device(&wgpu::DeviceDescriptor {
+        label: Some("femtovg gradient tail pad test device"),
         required_features: wgpu::Features::empty(),
         required_limits: wgpu::Limits::downlevel_defaults().using_resolution(adapter.limits()),
         experimental_features: wgpu::ExperimentalFeatures::disabled(),
         memory_hints: wgpu::MemoryHints::MemoryUsage,
         trace: wgpu::Trace::default(),
-    }))
-    .ok()?;
+    })) {
+        Ok(pair) => pair,
+        Err(err) => {
+            if require.is_some() {
+                panic!("FEMTOVG_REQUIRE_GPU is set but the device request failed: {err}");
+            }
+            eprintln!("skipping: wgpu device request failed ({err})");
+            return None;
+        }
+    };
+    // Validation errors are failures, not log lines.
+    device.on_uncaptured_error(std::sync::Arc::new(|err| panic!("wgpu uncaptured error: {err}")));
     Some((device, queue))
+}
+
+/// Flushes the canvas into `target` and reads the target back. The render
+/// command buffer and the copy are submitted together, in that order, so the
+/// result cannot depend on the ordering of two separate submissions, and a
+/// failed map is an error rather than silence.
+fn render_and_read(
+    device: &wgpu::Device,
+    queue: &wgpu::Queue,
+    canvas: &mut Canvas<WGPURenderer>,
+    target: &wgpu::Texture,
+) -> Vec<u8> {
+    // A frame with nothing to draw yields no command buffer; here that would
+    // itself be the bug, so it is an error rather than a quiet empty submit.
+    let render = canvas
+        .flush_to_output(target)
+        .expect("flush_to_output produced no command buffer for a frame with draws");
+
+    let unpadded = W * 4;
+    let padded = unpadded.div_ceil(wgpu::COPY_BYTES_PER_ROW_ALIGNMENT) * wgpu::COPY_BYTES_PER_ROW_ALIGNMENT;
+    let readback = device.create_buffer(&wgpu::BufferDescriptor {
+        label: Some("tail pad readback"),
+        size: (padded * H) as u64,
+        usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
+        mapped_at_creation: false,
+    });
+    let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+        label: Some("tail pad readback copy"),
+    });
+    encoder.copy_texture_to_buffer(
+        wgpu::TexelCopyTextureInfo {
+            texture: target,
+            mip_level: 0,
+            origin: wgpu::Origin3d::ZERO,
+            aspect: wgpu::TextureAspect::All,
+        },
+        wgpu::TexelCopyBufferInfo {
+            buffer: &readback,
+            layout: wgpu::TexelCopyBufferLayout {
+                offset: 0,
+                bytes_per_row: Some(padded),
+                rows_per_image: Some(H),
+            },
+        },
+        wgpu::Extent3d {
+            width: W,
+            height: H,
+            depth_or_array_layers: 1,
+        },
+    );
+    queue.submit([render, encoder.finish()]);
+
+    let slice = readback.slice(..);
+    let (sender, receiver) = std::sync::mpsc::channel();
+    slice.map_async(wgpu::MapMode::Read, move |result| {
+        sender.send(result).expect("map result receiver dropped");
+    });
+    device
+        .poll(wgpu::PollType::wait_indefinitely())
+        .expect("device poll failed while waiting for the readback");
+    receiver
+        .recv()
+        .expect("map_async callback never ran")
+        .expect("readback buffer map failed");
+    let mapped = slice.get_mapped_range().expect("mapped range");
+    let mut pixels = vec![0u8; (W * H * 4) as usize];
+    for row in 0..H as usize {
+        let src = row * padded as usize;
+        let dst = row * unpadded as usize;
+        pixels[dst..dst + unpadded as usize].copy_from_slice(&mapped[src..src + unpadded as usize]);
+    }
+    pixels
+}
+
+fn pixel(pixels: &[u8], x: u32, y: u32) -> [u8; 3] {
+    let i = ((y * W + x) * 4) as usize;
+    [pixels[i], pixels[i + 1], pixels[i + 2]]
+}
+
+/// Linear mix of two ramp colors at `s` in 0..=1, in the un-premultiplied
+/// 8-bit space the ramp is built in.
+fn mix(a: [u8; 3], b: [u8; 3], s: f32) -> [u8; 3] {
+    let lerp = |p: u8, q: u8| (p as f32 + (q as f32 - p as f32) * s).round() as u8;
+    [lerp(a[0], b[0]), lerp(a[1], b[1]), lerp(a[2], b[2])]
+}
+
+fn within(got: [u8; 3], want: [u8; 3], tolerance: i32) -> bool {
+    got.iter()
+        .zip(want.iter())
+        .all(|(g, w)| (*g as i32 - *w as i32).abs() <= tolerance)
 }
 
 #[test]
 fn multi_stop_gradient_pads_past_last_stop() {
     let Some((device, queue)) = headless_device() else {
-        eprintln!("skipping: no wgpu adapter available");
         return;
     };
     let target = device.create_texture(&wgpu::TextureDescriptor {
@@ -55,63 +212,89 @@ fn multi_stop_gradient_pads_past_last_stop() {
     let mut canvas = Canvas::new(renderer).expect("canvas");
     canvas.set_size(W, H, 1.0);
     canvas.clear_rect(0, 0, W, H, Color::white());
-    // Three stops ending at 0.6 across the width; the right 40% must be blue.
-    let stops = vec![
-        (0.0, Color::rgb(220, 40, 40)),
-        (0.3, Color::rgb(40, 200, 40)),
-        (0.6, Color::rgb(40, 80, 220)),
-    ];
-    let paint = Paint::linear_gradient_stops(0.0, 0.0, W as f32, 0.0, stops);
-    let mut p = Path::new();
-    p.rect(0.0, 0.0, W as f32, H as f32);
-    canvas.fill_path(&p, &paint);
-    let commands = canvas.flush_to_output(&target);
-    queue.submit(commands);
 
-    let unpadded = W * 4;
-    let padded = unpadded.div_ceil(wgpu::COPY_BYTES_PER_ROW_ALIGNMENT) * wgpu::COPY_BYTES_PER_ROW_ALIGNMENT;
-    let readback = device.create_buffer(&wgpu::BufferDescriptor {
-        label: None,
-        size: (padded * H) as u64,
-        usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
-        mapped_at_creation: false,
-    });
-    let mut enc = device.create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
-    enc.copy_texture_to_buffer(
-        wgpu::TexelCopyTextureInfo {
-            texture: &target,
-            mip_level: 0,
-            origin: wgpu::Origin3d::ZERO,
-            aspect: wgpu::TextureAspect::All,
-        },
-        wgpu::TexelCopyBufferInfo {
-            buffer: &readback,
-            layout: wgpu::TexelCopyBufferLayout {
-                offset: 0,
-                bytes_per_row: Some(padded),
-                rows_per_image: Some(H),
-            },
-        },
-        wgpu::Extent3d {
-            width: W,
-            height: H,
-            depth_or_array_layers: 1,
-        },
-    );
-    queue.submit(Some(enc.finish()));
-    let slice = readback.slice(..);
-    slice.map_async(wgpu::MapMode::Read, |_| {});
-    device.poll(wgpu::PollType::wait_indefinitely()).unwrap();
-    let mapped = slice.get_mapped_range().expect("readback");
-    let px = |x: usize| {
-        let i = (H as usize / 2) * padded as usize + x * 4;
-        [mapped[i] as i32, mapped[i + 1] as i32, mapped[i + 2] as i32]
+    // Three stops ending at 0.6 across the width; the right 40% must be blue.
+    let color = |c: [u8; 3]| Color::rgb(c[0], c[1], c[2]);
+    let stops = [(0.0, color(RED)), (0.3, color(GREEN)), (0.6, color(BLUE))];
+    let paint = Paint::linear_gradient_stops(0.0, 0.0, W as f32, 0.0, stops);
+    let mut ramp = Path::new();
+    ramp.rect(0.0, 0.0, W as f32, RAMP_BOTTOM);
+    canvas.fill_path(&ramp, &paint);
+
+    // Solid control strip, drawn after the gradient through the ordinary fill
+    // path with a plain color paint.
+    let mut strip = Path::new();
+    strip.rect(0.0, STRIP_TOP, W as f32, H as f32 - STRIP_TOP);
+    canvas.fill_path(&strip, &Paint::color(color(MAGENTA)));
+
+    let pixels = render_and_read(&device, &queue, &mut canvas, &target);
+
+    let mut failures = Vec::new();
+    let mut check = |x: u32, y: u32, want: [u8; 3], tolerance: i32, what: &str| {
+        let got = pixel(&pixels, x, y);
+        if !within(got, want, tolerance) {
+            failures.push(format!("{what}: ({x},{y}) expected {want:?} ±{tolerance}, got {got:?}"));
+        }
     };
-    for x in [150usize, 180, 210, 219] {
-        let p = px(x);
-        assert!(
-            (p[0] - 40).abs() <= 2 && (p[1] - 80).abs() <= 2 && (p[2] - 220).abs() <= 2,
-            "x={x} past the last stop must clamp to blue, got {p:?}"
+
+    // Controls first: each one rules out a way the tail could be white for a
+    // reason that has nothing to do with the ramp.
+    for x in [5, 110, 214] {
+        check(
+            x,
+            GAP_ROW,
+            WHITE,
+            1,
+            "clear color in the untouched gap (clear + row mapping)",
         );
+        check(x, STRIP_ROW, MAGENTA, 1, "solid strip (draws land in the target)");
+    }
+    // Inside the ramp: the LUT is being sampled, and holds the stops. The
+    // ramp is quantized to 256 texels and sampled with filtering, hence the
+    // tolerance; a stale or foreign texture is nowhere near it.
+    let t = |x: u32| x as f32 / W as f32;
+    check(1, RAMP_ROW, RED, 8, "first stop (ramp start)");
+    check(
+        33,
+        RAMP_ROW,
+        mix(RED, GREEN, t(33) / 0.3),
+        8,
+        "red-green interior of the ramp",
+    );
+    check(
+        99,
+        RAMP_ROW,
+        mix(GREEN, BLUE, (t(99) - 0.3) / 0.3),
+        8,
+        "green-blue interior of the ramp",
+    );
+    check(
+        126,
+        RAMP_ROW,
+        mix(GREEN, BLUE, (t(126) - 0.3) / 0.3),
+        8,
+        "approach to the last stop",
+    );
+
+    // The regression: past the last stop (t > 0.6, x > 132) the ramp must hold
+    // the last stop's color, not the unwritten-texel transparent that shows
+    // as the clear color.
+    for x in [140, 150, 180, 210, 219] {
+        check(
+            x,
+            RAMP_ROW,
+            BLUE,
+            2,
+            "tail past the last stop must clamp to the last stop",
+        );
+    }
+
+    if !failures.is_empty() {
+        let row: Vec<String> = (0..W)
+            .step_by(10)
+            .map(|x| format!("{x}:{:?}", pixel(&pixels, x, RAMP_ROW)))
+            .collect();
+        eprintln!("ramp row {RAMP_ROW}: {}", row.join(" "));
+        panic!("{} check(s) failed:\n  {}", failures.len(), failures.join("\n  "));
     }
 }

--- a/tests/gradient_tail_pad_wgpu.rs
+++ b/tests/gradient_tail_pad_wgpu.rs
@@ -21,6 +21,9 @@
 
 use femtovg::{renderer::WGPURenderer, Canvas, Color, Paint, Path};
 
+mod common;
+use common::headless_device;
+
 const W: u32 = 220;
 const H: u32 = 64;
 
@@ -40,64 +43,6 @@ const WHITE: [u8; 3] = [255, 255, 255];
 /// Unlike anything in the ramp or the clear, so a strip pixel cannot be
 /// mistaken for either.
 const MAGENTA: [u8; 3] = [200, 0, 200];
-
-fn gpu_requirement() -> Option<String> {
-    std::env::var("FEMTOVG_REQUIRE_GPU")
-        .ok()
-        .map(|v| v.trim().to_ascii_lowercase())
-        .filter(|v| !v.is_empty())
-}
-
-fn headless_device() -> Option<(wgpu::Device, wgpu::Queue)> {
-    let require = gpu_requirement();
-    let instance = wgpu::Instance::default();
-    let adapter = match pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
-        power_preference: wgpu::PowerPreference::default(),
-        force_fallback_adapter: false,
-        compatible_surface: None,
-        ..Default::default()
-    })) {
-        Ok(adapter) => adapter,
-        Err(err) => {
-            if require.is_some() {
-                panic!("FEMTOVG_REQUIRE_GPU is set but no wgpu adapter was found: {err}");
-            }
-            eprintln!("skipping: no wgpu adapter available ({err})");
-            return None;
-        }
-    };
-    let info = adapter.get_info();
-    eprintln!(
-        "wgpu adapter: {} | backend {:?} | type {:?} | driver {} {}",
-        info.name, info.backend, info.device_type, info.driver, info.driver_info
-    );
-    if let Some(required) = require.as_deref() {
-        let backend = format!("{:?}", info.backend).to_ascii_lowercase();
-        if !matches!(required, "1" | "true" | "any") && required != backend {
-            panic!("FEMTOVG_REQUIRE_GPU={required} but the adapter's backend is {backend}");
-        }
-    }
-    let (device, queue) = match pollster::block_on(adapter.request_device(&wgpu::DeviceDescriptor {
-        label: Some("femtovg gradient tail pad test device"),
-        required_features: wgpu::Features::empty(),
-        required_limits: wgpu::Limits::downlevel_defaults().using_resolution(adapter.limits()),
-        experimental_features: wgpu::ExperimentalFeatures::disabled(),
-        memory_hints: wgpu::MemoryHints::MemoryUsage,
-        trace: wgpu::Trace::default(),
-    })) {
-        Ok(pair) => pair,
-        Err(err) => {
-            if require.is_some() {
-                panic!("FEMTOVG_REQUIRE_GPU is set but the device request failed: {err}");
-            }
-            eprintln!("skipping: wgpu device request failed ({err})");
-            return None;
-        }
-    };
-    // Validation errors are failures, not log lines.
-    device.on_uncaptured_error(std::sync::Arc::new(|err| panic!("wgpu uncaptured error: {err}")));
-    Some((device, queue))
-}
 
 /// Flushes the canvas into `target` and reads the target back. The render
 /// command buffer and the copy are submitted together, in that order, so the


### PR DESCRIPTION
Found while sweeping a 26-file corpus of Firefox-ecosystem SVGs against Chromium 149: Mozilla's Firefox logo art — `splash-logo.svg` ([file](https://raw.githubusercontent.com/rebeckerspecialties/femtovg/demo-assets/splash-logo.svg)) and `mr-settodefault.svg` ([file](https://raw.githubusercontent.com/rebeckerspecialties/femtovg/demo-assets/mr-settodefault.svg)) — lost a wedge of its flame.

**Mechanism.** The gradient LUT builder pads the ramp *before* the first stop, but never *after* the last one: the pair loop only sees the authored stops, and the sentinel stop > 1.0 that its comment describes is never appended by `GradientColors::from_stops`. Every texel past a last stop below 1.0 stays unwritten — transparent black on a fresh texture, and whatever a recycled texture held on reuse (in a probe, the tail of one gradient rendered in the colors of the *other* gradient in the frame). SVG `spreadMethod="pad"` (the default) and Canvas gradients clamp to the last stop's color there.

The Firefox flame is a 4-stop linear gradient ending at offset 0.70, so its last 30% of ramp — the lower-left cap of the disc — rendered as a hole. The isolated flame path (right column) shows it plainly; in context the wedge lets the background through:

![before / after / Chromium](https://raw.githubusercontent.com/rebeckerspecialties/femtovg/demo-assets/gradient-tail-pad-before-after.png)

| file | zoom | before (structural) | after (structural) |
|------|------|---------------------|--------------------|
| splash-logo | 0.7× / 1.3× / 2.1× | 0.74 (0.23) / 2.36 (1.30) / 5.55 (3.75) % | 0.21 (0.00) / 0.33 (0.00) / 0.57 (0.00) % |
| mr-settodefault | 0.7× / 1.3× / 2.1× | 1.07 (0.05) / 2.09 (0.35) / 3.65 (1.31) % | 0.84 (0.00) / 1.11 (0.00) / 1.19 (0.00) % |

(pixels >20/255 from Chromium 149; "structural" = after a 2-px erosion that removes edge-AA ribbons.) The isolated mr flame path goes from 8.30% to 0.14%.

**Fix.** Pad from the last stop to the end of the ramp, mirroring the head pad. No shader or allocation change. Tests: LUT texels past an opaque and a transparent last stop, and a GPU test pinning the rendered clamp on a 3-stop gradient ending at 0.6.


---

## Test plumbing, after merging #333

#333 added the CI job that actually runs the wgpu suite, with `FEMTOVG_REQUIRE_GPU` so that a runner which fails to create an adapter fails the job instead of skipping every test, and it consolidated the copied-around `headless_device()` into `tests/common/mod.rs`. Two consequences land here:

- The `gpu-regression` job this branch had added, which ran only the tail-pad test, is gone. #333's `gpu-tests` job runs the whole suite, this test included, so the narrower job has nothing left to do.
- `tests/gradient_stop_interpolation_wgpu.rs` still defined its own `headless_device()`. It came in with #326, which landed just after #333 consolidated the others, so it was the last GPU test file carrying a private copy. A private copy does not honor the require-gate, which means that on a runner where adapter creation failed, that suite would quietly skip while CI reported success — the exact hole #333 exists to close. It now uses the shared helper, as the new tail-pad test does.

Verified with the command CI runs, `FEMTOVG_REQUIRE_GPU=metal cargo test --features wgpu --no-fail-fast`: 198 passed, 0 failed, 0 skipped, on an Apple M4 Max via Metal.
