### PR TITLE
Zero-initialize GL textures at creation

### DIFF
--- a/src/renderer/opengl/gl_texture.rs
+++ b/src/renderer/opengl/gl_texture.rs
@@ -47,6 +47,20 @@ impl GlTexture {
             external: false,
         };
 
+        // Upload a zeroed buffer instead of NULL so the texture's contents are
+        // defined from creation: glTexImage2D with NULL leaves them undefined,
+        // and embedded GL drivers hand back recycled, unscrubbed memory that
+        // edge-of-quad NEAREST lookups can pick up as stray pixels (#310).
+        // Desktop drivers zero pages in practice, which is why this went
+        // unnoticed; the wgpu backend guarantees zero-initialized textures, so
+        // this also aligns the two backends.
+        let bytes_per_pixel = match info.format() {
+            PixelFormat::Gray8 => 1,
+            PixelFormat::Rgb8 => 3,
+            PixelFormat::Rgba8 => 4,
+        };
+        let zeroed = vec![0u8; info.width() * info.height() * bytes_per_pixel];
+
         match info.format() {
             PixelFormat::Gray8 => unsafe {
                 let internal_format = if opengles_2_0 { glow::LUMINANCE } else { glow::R8 };
@@ -61,7 +75,7 @@ impl GlTexture {
                     0,
                     format,
                     glow::UNSIGNED_BYTE,
-                    glow::PixelUnpackData::Slice(None), //data.buf().as_ptr() as *const GLvoid
+                    glow::PixelUnpackData::Slice(Some(&zeroed)),
                 );
             },
             PixelFormat::Rgb8 => unsafe {
@@ -74,8 +88,7 @@ impl GlTexture {
                     0,
                     glow::RGB,
                     glow::UNSIGNED_BYTE,
-                    glow::PixelUnpackData::Slice(None),
-                    //data.buf().as_ptr() as *const GLvoid
+                    glow::PixelUnpackData::Slice(Some(&zeroed)),
                 );
             },
             PixelFormat::Rgba8 => unsafe {
@@ -88,8 +101,7 @@ impl GlTexture {
                     0,
                     glow::RGBA,
                     glow::UNSIGNED_BYTE,
-                    glow::PixelUnpackData::Slice(None),
-                    //data.buf().as_ptr() as *const GLvoid
+                    glow::PixelUnpackData::Slice(Some(&zeroed)),
                 );
             },
         }

--- a/src/text.rs
+++ b/src/text.rs
@@ -26,10 +26,12 @@ pub use textlayout::*;
 // This padding is an empty border around the glyph’s pixels but inside the
 // sampled area (texture coordinates) for the quad in render_atlas().
 const GLYPH_PADDING: u32 = 1;
-// We add an additional margin of 1 pixel outside of the sampled area,
-// to deal with the linear interpolation of texels at the edge of that area
-// which mixes in the texels just outside of the edge.
-// This manifests as noise around the glyph, outside of the padding.
+// We add an additional margin of 1 texel outside of the sampled area.
+// The atlas is NEAREST-sampled (since 62e5be6), so no filter tap blends
+// across the boundary; the margin is a guard band for GPUs whose
+// interpolated texture coordinates drift at quad edges and select a
+// neighbouring texel instead (issues #22, #310). Atlas textures start
+// zero-initialized on both backends, so margin texels are blank.
 const GLYPH_MARGIN: u32 = 1;
 
 const TEXTURE_SIZE: usize = 512;
@@ -788,8 +790,8 @@ impl GlyphAtlas {
 
         let is_color = image.content == swash::scale::image::Content::Color;
 
-        // Create a padded image with zeroed borders to avoid sampling undefined
-        // texture data at glyph edges (the atlas texture is not zero-initialized).
+        // Create a padded image with zeroed borders so the sampled rect's edge
+        // texels are blank (the texture itself starts zero-initialized).
         let padded_width = (glyph_width + 2 * GLYPH_PADDING) as usize;
         let padded_height = (glyph_height + 2 * GLYPH_PADDING) as usize;
         let mut pixels = vec![rgb::RGBA8::new(0, 0, 0, 0); padded_width * padded_height];


### PR DESCRIPTION
Replaces #330 with the approach from its review discussion: zero-initialize GL textures at creation, and we're done.

`glTexImage2D` with NULL data leaves contents undefined. Desktop drivers zero pages in practice, but embedded GL drivers hand back recycled, unscrubbed memory — and the glyph atlas `GLYPH_MARGIN` ring is never written by the swash upload path, so edge-of-quad NEAREST lookups on GPUs with imprecise texture-coordinate interpolation (Mesa [#4359](https://gitlab.freedesktop.org/mesa/mesa/-/issues/4359) documents one-texel over-reads on vc4) could pick up whatever that memory held. Candidate mechanism for #310's finding 1, and the same defect class #22 fixed for the bilinear era.

The fix passes a zeroed heap vec to `glTexImage2D` for all three formats at creation. The wgpu backend already guarantees zero-initialized textures per spec, so this aligns the backends; every texture now has defined contents from birth on both. Cost: one transient allocation and a one-time upload per texture creation (~1MB for a 512² atlas texture), which also makes driver allocation eager rather than lazy.

Carries over #330's comment fixes: the stale `GLYPH_MARGIN` comment (flagged in #310 — it described bilinear bleed, but the atlas has been NEAREST-sampled since 62e5be6) and the swash upload comment's now-false "not zero-initialized" parenthetical.

I've asked the #310 reporter to run their VC4 A/B against this branch at stock constants.
