### PR TITLE
Run the GPU test suite in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,28 @@ jobs:
       - run: cargo build --verbose --examples --features wgpu
       - run: cargo build --target=wasm32-unknown-unknown --example demo
       - run: cargo test
+  # `cargo test` above never runs the GPU tests: every tests/*_wgpu.rs is gated
+  # behind the `wgpu` feature, which that command does not enable, so each of
+  # those executables is built and then reports "running 0 tests". This job
+  # runs them for real on a runner with a Metal adapter, once the cheap matrix
+  # has passed. FEMTOVG_REQUIRE_GPU makes a missing adapter a failure instead
+  # of a skip, so the job cannot go green without having exercised the GPU.
+  gpu-tests:
+    needs: [build, format]
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+          profile: minimal
+      - name: Run the GPU test suite
+        env:
+          FEMTOVG_REQUIRE_GPU: metal
+        run: cargo test --features wgpu --no-fail-fast -- --nocapture
   format:
     runs-on: ubuntu-latest
     steps:

--- a/tests/blit_scissor_wgpu.rs
+++ b/tests/blit_scissor_wgpu.rs
@@ -13,34 +13,14 @@
 
 use femtovg::{renderer::WGPURenderer, Canvas, Color, ImageFlags, Paint, Path, PixelFormat, RenderTarget};
 
+mod common;
+use common::headless_device;
+
 const W: u32 = 200;
 const H: u32 = 200;
 
 /// Lazily create a headless wgpu device/queue. Returns `None` when no adapter
 /// is available, so the caller can skip the test.
-fn headless_device() -> Option<(wgpu::Device, wgpu::Queue)> {
-    let instance = wgpu::Instance::default();
-
-    let adapter = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
-        power_preference: wgpu::PowerPreference::default(),
-        force_fallback_adapter: false,
-        compatible_surface: None,
-        ..Default::default()
-    }))
-    .ok()?;
-
-    let (device, queue) = pollster::block_on(adapter.request_device(&wgpu::DeviceDescriptor {
-        label: Some("femtovg blit scissor test device"),
-        required_features: wgpu::Features::empty(),
-        required_limits: wgpu::Limits::downlevel_defaults().using_resolution(adapter.limits()),
-        experimental_features: wgpu::ExperimentalFeatures::disabled(),
-        memory_hints: wgpu::MemoryHints::MemoryUsage,
-        trace: wgpu::Trace::default(),
-    }))
-    .ok()?;
-
-    Some((device, queue))
-}
 
 /// Clear the canvas white, set a rounded scissor of 100x100 at (50,50) with a
 /// 40px corner radius, and fill `fill_rect` with an untinted, non-antialiased

--- a/tests/color_matrix_wgpu.rs
+++ b/tests/color_matrix_wgpu.rs
@@ -7,29 +7,11 @@
 
 use femtovg::{renderer::WGPURenderer, Canvas, Color, ImageFilter, ImageFlags, Paint, Path, PixelFormat, RenderTarget};
 
+mod common;
+use common::headless_device;
+
 const W: u32 = 32;
 const H: u32 = 32;
-
-fn headless_device() -> Option<(wgpu::Device, wgpu::Queue)> {
-    let instance = wgpu::Instance::default();
-    let adapter = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
-        power_preference: wgpu::PowerPreference::default(),
-        force_fallback_adapter: false,
-        compatible_surface: None,
-        ..Default::default()
-    }))
-    .ok()?;
-    let (device, queue) = pollster::block_on(adapter.request_device(&wgpu::DeviceDescriptor {
-        label: Some("femtovg color matrix test device"),
-        required_features: wgpu::Features::empty(),
-        required_limits: wgpu::Limits::downlevel_defaults().using_resolution(adapter.limits()),
-        experimental_features: wgpu::ExperimentalFeatures::disabled(),
-        memory_hints: wgpu::MemoryHints::MemoryUsage,
-        trace: wgpu::Trace::default(),
-    }))
-    .ok()?;
-    Some((device, queue))
-}
 
 /// Fill a source image with `src`, apply `filter` into a target image, draw the
 /// target to the output, and return the centre pixel `[r,g,b,a]`.

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -4,24 +4,77 @@
 
 use femtovg::{renderer::WGPURenderer, Canvas, Color};
 
+/// Set `FEMTOVG_REQUIRE_GPU` to turn "no adapter" from a skip into a failure:
+/// any value (`1`, `true`, `any`) requires that some adapter was found, and a
+/// backend name (`metal`, `vulkan`, `dx12`, `gl`) additionally requires that
+/// backend. CI's GPU job sets it, so the job cannot report success by quietly
+/// skipping every test on a runner where adapter creation failed.
+fn gpu_requirement() -> Option<String> {
+    std::env::var("FEMTOVG_REQUIRE_GPU")
+        .ok()
+        .map(|value| value.trim().to_ascii_lowercase())
+        .filter(|value| !value.is_empty())
+}
+
 pub fn headless_device() -> Option<(wgpu::Device, wgpu::Queue)> {
+    let require = gpu_requirement();
     let instance = wgpu::Instance::default();
-    let adapter = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
+    let adapter = match pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
         power_preference: wgpu::PowerPreference::default(),
         force_fallback_adapter: false,
         compatible_surface: None,
         ..Default::default()
-    }))
-    .ok()?;
-    let (device, queue) = pollster::block_on(adapter.request_device(&wgpu::DeviceDescriptor {
+    })) {
+        Ok(adapter) => adapter,
+        Err(err) => {
+            assert!(
+                require.is_none(),
+                "FEMTOVG_REQUIRE_GPU is set but no wgpu adapter was found: {err}"
+            );
+            eprintln!("skipping: no wgpu adapter available ({err})");
+            return None;
+        }
+    };
+
+    // Which GPU ran the suite is the first thing anyone reading a CI failure
+    // needs; print it once per test binary rather than once per test.
+    let info = adapter.get_info();
+    static ANNOUNCE: std::sync::Once = std::sync::Once::new();
+    ANNOUNCE.call_once(|| {
+        eprintln!(
+            "wgpu adapter: {} | backend {:?} | type {:?} | driver {} {}",
+            info.name, info.backend, info.device_type, info.driver, info.driver_info
+        );
+    });
+    if let Some(required) = require.as_deref() {
+        let backend = format!("{:?}", info.backend).to_ascii_lowercase();
+        assert!(
+            matches!(required, "1" | "true" | "any") || required == backend,
+            "FEMTOVG_REQUIRE_GPU={required} but the adapter's backend is {backend}"
+        );
+    }
+
+    let (device, queue) = match pollster::block_on(adapter.request_device(&wgpu::DeviceDescriptor {
         label: Some("femtovg test device"),
         required_features: wgpu::Features::empty(),
         required_limits: wgpu::Limits::downlevel_defaults().using_resolution(adapter.limits()),
         experimental_features: wgpu::ExperimentalFeatures::disabled(),
         memory_hints: wgpu::MemoryHints::MemoryUsage,
         trace: wgpu::Trace::default(),
-    }))
-    .ok()?;
+    })) {
+        Ok(pair) => pair,
+        Err(err) => {
+            assert!(
+                require.is_none(),
+                "FEMTOVG_REQUIRE_GPU is set but the device request failed: {err}"
+            );
+            eprintln!("skipping: wgpu device request failed ({err})");
+            return None;
+        }
+    };
+    // A validation error must fail the test that provoked it, not scroll past
+    // in the log while the test reads back plausible-looking pixels.
+    device.on_uncaptured_error(std::sync::Arc::new(|err| panic!("wgpu uncaptured error: {err}")));
     Some((device, queue))
 }
 
@@ -54,8 +107,11 @@ pub fn render_rgba(
     canvas.set_size(width, height, 1.0);
     canvas.clear_rect(0, 0, width, height, clear);
     draw(&mut canvas);
-    let commands = canvas.flush_to_output(&target);
-    queue.submit(commands);
+    // The render and the copy that reads it back go to the queue together, so
+    // the pixels cannot depend on the ordering of two separate submissions.
+    let commands = canvas
+        .flush_to_output(&target)
+        .expect("flush_to_output produced no command buffer for a frame with draws");
 
     let unpadded = width * 4;
     let padded = unpadded.div_ceil(wgpu::COPY_BYTES_PER_ROW_ALIGNMENT) * wgpu::COPY_BYTES_PER_ROW_ALIGNMENT;
@@ -87,10 +143,19 @@ pub fn render_rgba(
             depth_or_array_layers: 1,
         },
     );
-    queue.submit(Some(enc.finish()));
+    queue.submit([commands, enc.finish()]);
     let slice = readback.slice(..);
-    slice.map_async(wgpu::MapMode::Read, |_| {});
-    device.poll(wgpu::PollType::wait_indefinitely()).unwrap();
+    let (sender, receiver) = std::sync::mpsc::channel();
+    slice.map_async(wgpu::MapMode::Read, move |result| {
+        sender.send(result).expect("map result receiver dropped");
+    });
+    device
+        .poll(wgpu::PollType::wait_indefinitely())
+        .expect("device poll failed while waiting for the readback");
+    receiver
+        .recv()
+        .expect("map_async callback never ran")
+        .expect("readback buffer map failed");
     let mapped = slice.get_mapped_range().expect("readback");
     let mut pixels = vec![0u8; (unpadded * height) as usize];
     for row in 0..height as usize {

--- a/tests/conic_scissor_wgpu.rs
+++ b/tests/conic_scissor_wgpu.rs
@@ -13,29 +13,11 @@
 
 use femtovg::{renderer::WGPURenderer, Canvas, Color, Paint, Path};
 
+mod common;
+use common::headless_device;
+
 const W: u32 = 200;
 const H: u32 = 200;
-
-fn headless_device() -> Option<(wgpu::Device, wgpu::Queue)> {
-    let instance = wgpu::Instance::default();
-    let adapter = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
-        power_preference: wgpu::PowerPreference::default(),
-        force_fallback_adapter: false,
-        compatible_surface: None,
-        ..Default::default()
-    }))
-    .ok()?;
-    let (device, queue) = pollster::block_on(adapter.request_device(&wgpu::DeviceDescriptor {
-        label: Some("femtovg conic scissor test device"),
-        required_features: wgpu::Features::empty(),
-        required_limits: wgpu::Limits::downlevel_defaults().using_resolution(adapter.limits()),
-        experimental_features: wgpu::ExperimentalFeatures::disabled(),
-        memory_hints: wgpu::MemoryHints::MemoryUsage,
-        trace: wgpu::Trace::default(),
-    }))
-    .ok()?;
-    Some((device, queue))
-}
 
 /// Clear white, set a 100x100 rounded scissor at (50,50) with a 40px radius, and
 /// fill that rect with a conic gradient centred in it. Returns row-major

--- a/tests/evenodd_stencil_wgpu.rs
+++ b/tests/evenodd_stencil_wgpu.rs
@@ -8,29 +8,11 @@
 
 use femtovg::{renderer::WGPURenderer, Canvas, Color, FillRule, Paint, Path};
 
+mod common;
+use common::headless_device;
+
 const W: u32 = 128;
 const H: u32 = 128;
-
-fn headless_device() -> Option<(wgpu::Device, wgpu::Queue)> {
-    let instance = wgpu::Instance::default();
-    let adapter = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
-        power_preference: wgpu::PowerPreference::default(),
-        force_fallback_adapter: false,
-        compatible_surface: None,
-        ..Default::default()
-    }))
-    .ok()?;
-    let (device, queue) = pollster::block_on(adapter.request_device(&wgpu::DeviceDescriptor {
-        label: Some("femtovg gradient dither test device"),
-        required_features: wgpu::Features::empty(),
-        required_limits: wgpu::Limits::downlevel_defaults().using_resolution(adapter.limits()),
-        experimental_features: wgpu::ExperimentalFeatures::disabled(),
-        memory_hints: wgpu::MemoryHints::MemoryUsage,
-        trace: wgpu::Trace::default(),
-    }))
-    .ok()?;
-    Some((device, queue))
-}
 
 fn render(device: &wgpu::Device, queue: &wgpu::Queue, draw: impl FnOnce(&mut Canvas<WGPURenderer>)) -> Vec<u8> {
     let target = device.create_texture(&wgpu::TextureDescriptor {

--- a/tests/gradient_dither_wgpu.rs
+++ b/tests/gradient_dither_wgpu.rs
@@ -8,29 +8,11 @@
 
 use femtovg::{renderer::WGPURenderer, Canvas, Color, Paint, Path};
 
+mod common;
+use common::headless_device;
+
 const W: u32 = 220;
 const H: u32 = 64;
-
-fn headless_device() -> Option<(wgpu::Device, wgpu::Queue)> {
-    let instance = wgpu::Instance::default();
-    let adapter = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
-        power_preference: wgpu::PowerPreference::default(),
-        force_fallback_adapter: false,
-        compatible_surface: None,
-        ..Default::default()
-    }))
-    .ok()?;
-    let (device, queue) = pollster::block_on(adapter.request_device(&wgpu::DeviceDescriptor {
-        label: Some("femtovg gradient dither test device"),
-        required_features: wgpu::Features::empty(),
-        required_limits: wgpu::Limits::downlevel_defaults().using_resolution(adapter.limits()),
-        experimental_features: wgpu::ExperimentalFeatures::disabled(),
-        memory_hints: wgpu::MemoryHints::MemoryUsage,
-        trace: wgpu::Trace::default(),
-    }))
-    .ok()?;
-    Some((device, queue))
-}
 
 #[test]
 fn gradients_are_dithered_to_break_banding() {

--- a/tests/gradient_stress_wgpu.rs
+++ b/tests/gradient_stress_wgpu.rs
@@ -6,29 +6,11 @@
 
 use femtovg::{renderer::WGPURenderer, Canvas, Color, Paint, Path};
 
+mod common;
+use common::headless_device;
+
 const W: u32 = 200;
 const H: u32 = 200;
-
-fn headless_device() -> Option<(wgpu::Device, wgpu::Queue)> {
-    let instance = wgpu::Instance::default();
-    let adapter = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
-        power_preference: wgpu::PowerPreference::default(),
-        force_fallback_adapter: false,
-        compatible_surface: None,
-        ..Default::default()
-    }))
-    .ok()?;
-    let (device, queue) = pollster::block_on(adapter.request_device(&wgpu::DeviceDescriptor {
-        label: Some("femtovg gradient stress test device"),
-        required_features: wgpu::Features::empty(),
-        required_limits: wgpu::Limits::downlevel_defaults().using_resolution(adapter.limits()),
-        experimental_features: wgpu::ExperimentalFeatures::disabled(),
-        memory_hints: wgpu::MemoryHints::MemoryUsage,
-        trace: wgpu::Trace::default(),
-    }))
-    .ok()?;
-    Some((device, queue))
-}
 
 fn render_scene(device: &wgpu::Device, queue: &wgpu::Queue, draw: impl FnOnce(&mut Canvas<WGPURenderer>)) -> Vec<u8> {
     let target = device.create_texture(&wgpu::TextureDescriptor {

--- a/tests/image_update_bounds_wgpu.rs
+++ b/tests/image_update_bounds_wgpu.rs
@@ -10,26 +10,8 @@ use femtovg::{renderer::WGPURenderer, Canvas, ErrorKind, ImageFlags};
 use imgref::Img;
 use rgb::{alt::Gray, RGBA8};
 
-fn headless_device() -> Option<(wgpu::Device, wgpu::Queue)> {
-    let instance = wgpu::Instance::default();
-    let adapter = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
-        power_preference: wgpu::PowerPreference::default(),
-        force_fallback_adapter: false,
-        compatible_surface: None,
-        ..Default::default()
-    }))
-    .ok()?;
-    let (device, queue) = pollster::block_on(adapter.request_device(&wgpu::DeviceDescriptor {
-        label: Some("femtovg image update bounds test device"),
-        required_features: wgpu::Features::empty(),
-        required_limits: wgpu::Limits::downlevel_defaults().using_resolution(adapter.limits()),
-        experimental_features: wgpu::ExperimentalFeatures::disabled(),
-        memory_hints: wgpu::MemoryHints::MemoryUsage,
-        trace: wgpu::Trace::default(),
-    }))
-    .ok()?;
-    Some((device, queue))
-}
+mod common;
+use common::headless_device;
 
 fn canvas() -> Option<Canvas<WGPURenderer>> {
     let (device, queue) = headless_device()?;

--- a/tests/shadow_wgpu.rs
+++ b/tests/shadow_wgpu.rs
@@ -11,34 +11,14 @@
 
 use femtovg::{renderer::WGPURenderer, Canvas, Color, Paint, Path, RenderTarget};
 
+mod common;
+use common::headless_device;
+
 const W: u32 = 120;
 const H: u32 = 120;
 
 /// Lazily create a headless wgpu device/queue. Returns `None` when no adapter is
 /// available (e.g. backend-less CI), so the caller can skip the test.
-fn headless_device() -> Option<(wgpu::Device, wgpu::Queue)> {
-    let instance = wgpu::Instance::default();
-
-    let adapter = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
-        power_preference: wgpu::PowerPreference::default(),
-        force_fallback_adapter: false,
-        compatible_surface: None,
-        ..Default::default()
-    }))
-    .ok()?;
-
-    let (device, queue) = pollster::block_on(adapter.request_device(&wgpu::DeviceDescriptor {
-        label: Some("femtovg shadow test device"),
-        required_features: wgpu::Features::empty(),
-        required_limits: wgpu::Limits::downlevel_defaults().using_resolution(adapter.limits()),
-        experimental_features: wgpu::ExperimentalFeatures::disabled(),
-        memory_hints: wgpu::MemoryHints::MemoryUsage,
-        trace: wgpu::Trace::default(),
-    }))
-    .ok()?;
-
-    Some((device, queue))
-}
 
 /// Render `draw` into an offscreen RGBA8 texture and read the pixels back.
 /// Returns a row-major buffer of `[r, g, b, a]` per pixel.

--- a/tests/text_scale_position_wgpu.rs
+++ b/tests/text_scale_position_wgpu.rs
@@ -19,6 +19,9 @@
 
 use femtovg::{renderer::WGPURenderer, Canvas, Color, Paint, Path};
 
+mod common;
+use common::headless_device;
+
 const W: u32 = 640;
 const H: u32 = 400;
 const FONT: &[u8] = include_bytes!("../examples/assets/RobotoFlex-VariableFont.ttf");
@@ -30,27 +33,6 @@ const ZS: [f32; 7] = [1.40, 1.42, 1.44, 1.46, 1.48, 1.50, 1.52];
 // by under a pixel per step. 6 px cleanly separates the two while tolerating
 // antialiasing and centroid noise.
 const MAX_STEP: f32 = 6.0;
-
-fn headless_device() -> Option<(wgpu::Device, wgpu::Queue)> {
-    let instance = wgpu::Instance::default();
-    let adapter = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
-        power_preference: wgpu::PowerPreference::default(),
-        force_fallback_adapter: false,
-        compatible_surface: None,
-        ..Default::default()
-    }))
-    .ok()?;
-    let (device, queue) = pollster::block_on(adapter.request_device(&wgpu::DeviceDescriptor {
-        label: Some("femtovg text scale position test device"),
-        required_features: wgpu::Features::empty(),
-        required_limits: wgpu::Limits::downlevel_defaults().using_resolution(adapter.limits()),
-        experimental_features: wgpu::ExperimentalFeatures::disabled(),
-        memory_hints: wgpu::MemoryHints::MemoryUsage,
-        trace: wgpu::Trace::default(),
-    }))
-    .ok()?;
-    Some((device, queue))
-}
 
 /// Render a scene under a zoom of `z` around `pivot`. Returns row-major
 /// `[r,g,b,a]` pixels.

--- a/tests/uniform_slots_wgpu.rs
+++ b/tests/uniform_slots_wgpu.rs
@@ -9,30 +9,12 @@
 
 use femtovg::{renderer::WGPURenderer, Canvas, Color, FillRule, Paint, Path};
 
+mod common;
+use common::headless_device;
+
 const W: u32 = 256;
 const H: u32 = 256;
 const SHAPES: usize = 300;
-
-fn headless_device() -> Option<(wgpu::Device, wgpu::Queue)> {
-    let instance = wgpu::Instance::default();
-    let adapter = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
-        power_preference: wgpu::PowerPreference::default(),
-        force_fallback_adapter: false,
-        compatible_surface: None,
-        ..Default::default()
-    }))
-    .ok()?;
-    let (device, queue) = pollster::block_on(adapter.request_device(&wgpu::DeviceDescriptor {
-        label: Some("femtovg uniform slot test device"),
-        required_features: wgpu::Features::empty(),
-        required_limits: wgpu::Limits::downlevel_defaults().using_resolution(adapter.limits()),
-        experimental_features: wgpu::ExperimentalFeatures::disabled(),
-        memory_hints: wgpu::MemoryHints::MemoryUsage,
-        trace: wgpu::Trace::default(),
-    }))
-    .ok()?;
-    Some((device, queue))
-}
 
 /// A bowtie: the two triangles overlap, so the fill goes through the stencil path.
 fn bowtie(x: f32, y: f32) -> Path {

--- a/tests/zoom_invariance_wgpu.rs
+++ b/tests/zoom_invariance_wgpu.rs
@@ -10,30 +10,12 @@
 
 use femtovg::{renderer::WGPURenderer, Canvas, Color, Paint, Path};
 
+mod common;
+use common::headless_device;
+
 const W: u32 = 1000;
 const H: u32 = 400;
 const FONT: &[u8] = include_bytes!("../examples/assets/RobotoFlex-VariableFont.ttf");
-
-fn headless_device() -> Option<(wgpu::Device, wgpu::Queue)> {
-    let instance = wgpu::Instance::default();
-    let adapter = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
-        power_preference: wgpu::PowerPreference::default(),
-        force_fallback_adapter: false,
-        compatible_surface: None,
-        ..Default::default()
-    }))
-    .ok()?;
-    let (device, queue) = pollster::block_on(adapter.request_device(&wgpu::DeviceDescriptor {
-        label: Some("femtovg zoom invariance test device"),
-        required_features: wgpu::Features::empty(),
-        required_limits: wgpu::Limits::downlevel_defaults().using_resolution(adapter.limits()),
-        experimental_features: wgpu::ExperimentalFeatures::disabled(),
-        memory_hints: wgpu::MemoryHints::MemoryUsage,
-        trace: wgpu::Trace::default(),
-    }))
-    .ok()?;
-    Some((device, queue))
-}
 
 fn render(device: &wgpu::Device, queue: &wgpu::Queue, draw: impl FnOnce(&mut Canvas<WGPURenderer>)) -> Vec<u8> {
     let target = device.create_texture(&wgpu::TextureDescriptor {


### PR DESCRIPTION
## The GPU tests have never run in CI

CI runs `cargo test`, which does not enable the `wgpu` feature. Every `tests/*_wgpu.rs` starts with `#![cfg(feature = "wgpu")]`, so all twelve of those executables are compiled and then report `running 0 tests`. That is 50 headless GPU tests that have never executed on any CI run, across all nine matrix cells.

From the last green run on master ([33681008517](https://github.com/femtovg/femtovg/actions/runs/33681008517)):

```
Running tests\blit_scissor_wgpu.rs (target\debug\deps\blit_scissor_wgpu-6c009401d49499d7.exe)
running 0 tests
Running tests\color_matrix_wgpu.rs (target\debug\deps\color_matrix_wgpu-9e4fd36e7b2c2471.exe)
running 0 tests
Running tests\conic_scissor_wgpu.rs (target\debug\deps\conic_scissor_wgpu-0f82715d41c3fecc.exe)
running 0 tests
```

Every renderer regression those tests pin - stencil clearing, scissor blits, dithering, gradient conformance, shadows, glyph positioning - has been resting on contributors running the suite by hand.

## What this adds

A `gpu-tests` job on `macos-latest`, gated behind `needs: [build, format]` so it only spends a Mac runner once the cheap matrix is green. It runs the suite with `--no-fail-fast`, so a bad day reports the complete inventory rather than stopping at the first failing binary.

```yaml
  gpu-tests:
    needs: [build, format]
    runs-on: macos-latest
    ...
      - name: Run the GPU test suite
        env:
          FEMTOVG_REQUIRE_GPU: metal
        run: cargo test --features wgpu --no-fail-fast -- --nocapture
```

## Making the job impossible to silently pass

A GPU job can still go green by skipping every test: `headless_device()` returns `None` when no adapter is found and each test returns early. That is the right behavior on a contributor's machine and exactly the wrong behavior in the job that exists to exercise the GPU - it is the same class of failure as the one above, just one layer in.

`FEMTOVG_REQUIRE_GPU` turns the skip into a failure. Any value (`1`, `true`, `any`) requires that an adapter was found; a backend name additionally requires that backend, and CI sets `metal`. Unset, the skip behaves exactly as before, so nothing changes for anyone running the suite locally without a GPU.

Verified by construction, not by assumption:

| Condition | Result |
|---|---|
| `FEMTOVG_REQUIRE_GPU=vulkan` on a Metal machine | fails: `FEMTOVG_REQUIRE_GPU=vulkan but the adapter's backend is metal` |
| adapter lookup forced to fail, gate on | fails: `FEMTOVG_REQUIRE_GPU is set but no wgpu adapter was found` |
| adapter lookup forced to fail, gate off | skips, as today |
| plain `cargo test` (no feature) | `running 0 tests`, cheap matrix unchanged |

The adapter's identity is printed once per test binary, so a CI failure records which GPU produced it rather than leaving it to be guessed.

## Consolidating the device helper

`headless_device()` had been copied into eleven test files, byte-identical apart from its debug label. This moves it to `tests/common/mod.rs`, where `gradient_paint_conformance_wgpu.rs` already kept its copy, so the gate and the adapter print land in one place instead of twelve. Net -115 lines.

The shared `render_rgba()` also submitted the render and the readback copy as two separate submissions, discarded the `map_async` result, and let uncaptured validation errors pass by. Any of those can turn a real failure into plausible-looking pixels, which is worth closing in the change that makes the suite load-bearing: render and copy now go to the queue together, and a missing command buffer, a failed map or a validation error is a failure.

## Result

All 50 GPU tests pass locally on Metal (Apple M4 Max), zero skipped:

```
wgpu adapter: Apple M4 Max | backend Metal | type IntegratedGpu
tests/blit_scissor_wgpu.rs               ok. 2 passed
tests/color_matrix_wgpu.rs               ok. 2 passed
tests/conic_scissor_wgpu.rs              ok. 1 passed
tests/evenodd_stencil_wgpu.rs            ok. 2 passed
tests/gradient_dither_wgpu.rs            ok. 1 passed
tests/gradient_paint_conformance_wgpu.rs ok. 18 passed
tests/gradient_stress_wgpu.rs            ok. 2 passed
tests/image_update_bounds_wgpu.rs        ok. 4 passed
tests/shadow_wgpu.rs                     ok. 11 passed
tests/text_scale_position_wgpu.rs        ok. 3 passed
tests/uniform_slots_wgpu.rs              ok. 1 passed
tests/zoom_invariance_wgpu.rs            ok. 3 passed
```

The open question this PR answers is whether they also pass on the runner's GPU, which is a paravirtualized Apple device rather than bare metal - the CI run on this PR is the first look at that.

Deliberately left for a follow-up: Linux and Windows GPU jobs. Those runners have software adapters (lavapipe, WARP) whose rasterization differs from hardware, so they need their own tolerance review and would muddy this PR's signal.
