### PR TITLE
Mark CompositeOperation and BlendFactor non_exhaustive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- `CompositeOperation` and `BlendFactor` are now `#[non_exhaustive]`. Both
+  describe an open-ended capability space - the separable blend modes
+  (`multiply`, `screen`, `color-burn`, ...) belong in `CompositeOperation`, and
+  `BlendFactor` is a subset of what the backends expose - so adding to either
+  should not be a breaking change. Downstream `match`es on them now need a
+  wildcard arm.
 - Fixed multi-stop gradients whose last stop ends before 1.0: the rest of the
   ramp was left transparent (or holding stale texture data) instead of the last
   stop's color, as SVG's default `spreadMethod="pad"` and Canvas gradients

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,7 +87,11 @@ pub enum FillRule {
 }
 
 /// Blend factors.
+///
+/// Non-exhaustive: this mirrors the blend factors the backends expose and is
+/// currently a subset of them, so matching on it must carry a wildcard arm.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Hash)]
+#[non_exhaustive]
 pub enum BlendFactor {
     /// Not all
     Zero,
@@ -114,7 +118,14 @@ pub enum BlendFactor {
 }
 
 /// Predefined composite oprations.
+///
+/// Non-exhaustive: the separable blend modes that Canvas 2D's
+/// `globalCompositeOperation` and CSS/SVG's `mix-blend-mode` also carry
+/// (`multiply`, `screen`, `overlay`, `color-burn` and the rest) belong in this
+/// enum and are not implemented yet, so matching on it must carry a wildcard
+/// arm.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Hash)]
+#[non_exhaustive]
 pub enum CompositeOperation {
     /// Displays the source over the destination.
     SourceOver,


### PR DESCRIPTION
Groundwork for #332, and worth doing on its own.

`CompositeOperation` and `BlendFactor` are public enums that downstream code can `match` on exhaustively, and both describe an open-ended space:

- **`CompositeOperation`** holds the Porter-Duff operators plus `Lighter`, `Copy` and `Xor`. The separable blend modes that Canvas 2D's `globalCompositeOperation` and CSS/SVG's `mix-blend-mode` also carry — `multiply`, `screen`, `overlay`, `color-burn` and the rest — are the subject of #332 and belong in this same enum. Adding them to an exhaustive enum breaks every downstream exhaustive match.
- **`BlendFactor`** mirrors the backends' blend factors and is currently a strict subset of what both GL and wgpu expose (no constant factors, no dual-source), so it is likely to grow for the same reason.

Marking an enum `#[non_exhaustive]` is itself one break for exhaustive matches, so this is not about avoiding a break but about *when* to spend it: once now, in a change that is trivial to review and to absorb, rather than later bundled with new variants and a renderer change. Downstream `match`es gain a wildcard arm and are then insulated from every future addition.

**Deliberately not included:** `CompositeOperationState`. Its fields are already private, so it cannot be constructed or destructured outside the crate and the attribute would add nothing.

**Blast radius checked, not assumed:** nothing in the crate's examples, integration tests or doc-tests matches either enum exhaustively. Examples, doc-tests and the full GPU suite (198 tests, Metal) build and pass unchanged; doc-tests and examples are external crates, so they would have caught a break. Changelog entry included since this is a public API change.
