### PR TITLE
Fill clockwise contours to the same edge as counter-clockwise ones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- Fixed filled paths landing a pixel too wide when the contour runs clockwise.
+  The antialiasing fringe is extruded along each point's miter vector, whose
+  direction follows the order the points are in, so a clockwise contour pushed
+  it outward instead of inward - `Path::rect()` and `Path::circle()` emit
+  counter-clockwise and were exact, while an SVG arc with `sweep = 1`, or any
+  imported path wound the other way, was a pixel fat all round. Fills now cover
+  the same pixels either way, and the authored winding still selects holes for
+  `FillRule::NonZero`. This also takes most of the over-inking out of thin
+  filled shapes, which were paying the same pixel on both edges.
 - Added `Canvas::filter_image_chain()`, which applies a list of image filters in
   one call the way a Canvas `ctx.filter` list (`"blur(5px) brightness(1.2)"`) or
   an SVG filter chain does. Consecutive color-matrix filters fold into a single

--- a/src/path/cache.rs
+++ b/src/path/cache.rs
@@ -62,6 +62,10 @@ pub struct Contour {
     closed: bool,
     bevel: usize,
     solidity: Option<Solidity>,
+    /// Set for the duration of a fill: this contour's points were flipped to
+    /// the orientation the fringe extrusion assumes, so the triangles built
+    /// from them have to be flipped back.
+    reversed: bool,
     pub(crate) fill: Vec<Vertex>,
     pub(crate) stroke: Vec<Vertex>,
     pub(crate) convexity: Convexity,
@@ -74,6 +78,7 @@ impl Default for Contour {
             closed: Default::default(),
             bevel: Default::default(),
             solidity: None,
+            reversed: false,
             fill: Vec::new(),
             stroke: Vec::new(),
             convexity: Convexity::default(),
@@ -101,6 +106,18 @@ impl Contour {
 
     fn point_count(&self) -> usize {
         self.point_range.end - self.point_range.start
+    }
+
+    /// Recomputes each point's direction and length to its successor. Every
+    /// point stores the edge that leaves it, so reversing a contour leaves all
+    /// of them pointing at what is now the previous point.
+    fn recompute_directions(points: &mut [Point]) {
+        for i in 0..points.len() {
+            let next = points[(i + 1) % points.len()].pos;
+            let p = &mut points[i];
+            p.dpos = next - p.pos;
+            p.len = p.dpos.normalize();
+        }
     }
 }
 
@@ -519,6 +536,29 @@ impl PathCache {
     pub(crate) fn expand_fill(&mut self, fringe_width: f32, line_join: LineJoin, miter_limit: f32) {
         let has_fringe = fringe_width > 0.0;
 
+        // Every offset below is taken along a point's miter vector, and that
+        // vector's direction follows the order the contour's points are in. A
+        // contour wound the other way extrudes its fringe outward instead of
+        // inward, so the fill lands a whole fringe too wide - the clockwise
+        // square in #308, a pixel bigger all round than the identical
+        // counter-clockwise one. nanovg never meets this because it normalizes
+        // every contour up front ("Enforce winding" in nvg__flattenPaths, with
+        // nvg__addPath defaulting each path to NVG_CCW). femtovg cannot just do
+        // that: unlike nanovg it lets the authored winding express holes, the
+        // way SVG and Canvas write them, and the stencil pass reads that
+        // winding back off these triangles. So normalize for the geometry, put
+        // the triangles back the way the caller wound them, and restore the
+        // points - a later stroke of the same cached path must still see its
+        // own direction, which decides dash phase and which end gets which cap.
+        for contour in &mut self.contours {
+            let points = &mut self.points[contour.point_range.clone()];
+            contour.reversed = points.len() > 2 && Contour::polygon_area(points) < 0.0;
+            if contour.reversed {
+                points.reverse();
+                Contour::recompute_directions(points);
+            }
+        }
+
         self.calculate_joins(fringe_width, line_join, miter_limit);
 
         // Calculate max vertex usage.
@@ -576,9 +616,20 @@ impl PathCache {
             if triangle_fan_fill.len() > 2 {
                 let center = triangle_fan_fill[0];
                 let tail = &triangle_fan_fill[1..];
+                // Only the stencil pass reads this winding back, to tell a hole
+                // from a solid. A convex path skips the stencil and is drawn
+                // directly, where flipped triangles would just face away.
+                let flip = contour.reversed && !convex;
                 contour.fill = tail
                     .windows(2)
-                    .flat_map(|vertices| IntoIterator::into_iter([center, vertices[0], vertices[1]]))
+                    .flat_map(|vertices| {
+                        let (a, b) = if flip {
+                            (vertices[1], vertices[0])
+                        } else {
+                            (vertices[0], vertices[1])
+                        };
+                        IntoIterator::into_iter([center, a, b])
+                    })
                     .collect();
             }
 
@@ -608,6 +659,16 @@ impl PathCache {
                 let p1 = contour.stroke[1];
                 contour.stroke.push(Vertex::new(p0.x, p0.y, lu, 1.0));
                 contour.stroke.push(Vertex::new(p1.x, p1.y, ru, 1.0));
+            }
+        }
+
+        // The cache outlives this call; a stroke of the same path reads these
+        // same points, so give them back exactly as they arrived.
+        for contour in &mut self.contours {
+            if contour.reversed {
+                let points = &mut self.points[contour.point_range.clone()];
+                points.reverse();
+                Contour::recompute_directions(points);
             }
         }
     }

--- a/tests/fill_winding_wgpu.rs
+++ b/tests/fill_winding_wgpu.rs
@@ -1,0 +1,216 @@
+//! Headless GPU tests: a filled contour must cover the same pixels whichever
+//! way round it was wound. The antialiasing fringe is extruded along each
+//! point's miter vector, whose direction follows the point order, so a
+//! clockwise contour used to extrude it outward and land a pixel wide all
+//! round (#308) - while `Path::rect()` and `Path::circle()`, which emit
+//! counter-clockwise, were exact. Winding still has to mean something, though:
+//! it is how a nonzero fill tells a hole from a solid, the way SVG and Canvas
+//! write them, so these pin both halves.
+#![cfg(feature = "wgpu")]
+
+use femtovg::{renderer::WGPURenderer, Canvas, Color, FillRule, LineCap, Paint, Path};
+
+mod common;
+use common::headless_device;
+
+const W: u32 = 256;
+const H: u32 = 256;
+
+fn fill(device: &wgpu::Device, queue: &wgpu::Queue, rule: FillRule, path: &Path) -> Vec<u8> {
+    common::render_rgba(
+        device,
+        queue,
+        W,
+        H,
+        Color::rgba(0, 0, 0, 0),
+        |canvas: &mut Canvas<WGPURenderer>| {
+            canvas.fill_path(
+                path,
+                &Paint::color(Color::rgb(0, 0, 0))
+                    .with_anti_alias(true)
+                    .with_fill_rule(rule),
+            );
+        },
+    )
+}
+
+/// Summed alpha, i.e. the area the fill actually covered, in pixels.
+fn covered(px: &[u8]) -> f64 {
+    px.chunks_exact(4).map(|c| c[3] as f64 / 255.0).sum()
+}
+
+fn alpha_at(px: &[u8], x: usize, y: usize) -> f64 {
+    px[(y * W as usize + x) * 4 + 3] as f64 / 255.0
+}
+
+fn square(x0: f32, y0: f32, x1: f32, y1: f32, clockwise: bool) -> Vec<(f32, f32)> {
+    if clockwise {
+        vec![(x0, y0), (x1, y0), (x1, y1), (x0, y1)]
+    } else {
+        vec![(x0, y0), (x0, y1), (x1, y1), (x1, y0)]
+    }
+}
+
+fn contour(path: &mut Path, points: &[(f32, f32)]) {
+    for (i, (x, y)) in points.iter().enumerate() {
+        if i == 0 {
+            path.move_to(*x, *y);
+        } else {
+            path.line_to(*x, *y);
+        }
+    }
+    path.close();
+}
+
+#[test]
+fn clockwise_and_counter_clockwise_fills_cover_the_same_area() {
+    let Some((device, queue)) = headless_device() else {
+        return;
+    };
+    // Edges on exact pixel boundaries, so the true coverage is a whole number
+    // and neither winding has any partial pixel to hide an error in.
+    for clockwise in [false, true] {
+        let mut path = Path::new();
+        contour(&mut path, &square(100.0, 100.0, 200.0, 200.0, clockwise));
+        let px = fill(&device, &queue, FillRule::NonZero, &path);
+        let how = if clockwise { "clockwise" } else { "counter-clockwise" };
+
+        assert!(
+            (covered(&px) - 10000.0).abs() < 1.0,
+            "{how} 100x100 fill covered {:.2}px, want 10000",
+            covered(&px)
+        );
+        // The left edge is at x=100, so pixel 99 is outside and 100 is inside.
+        assert_eq!(
+            alpha_at(&px, 99, 150),
+            0.0,
+            "{how} fill leaked into the pixel left of its edge"
+        );
+        assert_eq!(alpha_at(&px, 100, 150), 1.0, "{how} fill did not reach its own edge");
+    }
+}
+
+#[test]
+fn winding_still_decides_holes_under_nonzero() {
+    let Some((device, queue)) = headless_device() else {
+        return;
+    };
+    // Outer counter-clockwise; the inner contour's winding is what says whether
+    // the middle is a hole. Normalizing orientation for the fringe must not
+    // take that away.
+    let mut hole = Path::new();
+    contour(&mut hole, &square(60.0, 60.0, 196.0, 196.0, false));
+    contour(&mut hole, &square(100.0, 100.0, 156.0, 156.0, true));
+    let px = fill(&device, &queue, FillRule::NonZero, &hole);
+    assert_eq!(alpha_at(&px, 128, 128), 0.0, "opposite winding must punch a hole");
+    assert_eq!(alpha_at(&px, 80, 128), 1.0, "the ring around the hole must stay filled");
+
+    let mut solid = Path::new();
+    contour(&mut solid, &square(60.0, 60.0, 196.0, 196.0, false));
+    contour(&mut solid, &square(100.0, 100.0, 156.0, 156.0, false));
+    let px = fill(&device, &queue, FillRule::NonZero, &solid);
+    assert_eq!(
+        alpha_at(&px, 128, 128),
+        1.0,
+        "same winding must stay solid under nonzero"
+    );
+}
+
+#[test]
+fn even_odd_fills_match_whichever_way_the_hole_is_wound() {
+    let Some((device, queue)) = headless_device() else {
+        return;
+    };
+    // Even-odd ignores direction by definition, so both windings must produce
+    // not just the same hole but the same coverage down to the fringe.
+    let mut areas = Vec::new();
+    for inner_clockwise in [false, true] {
+        let mut path = Path::new();
+        contour(&mut path, &square(60.0, 60.0, 196.0, 196.0, false));
+        contour(&mut path, &square(100.0, 100.0, 156.0, 156.0, inner_clockwise));
+        let px = fill(&device, &queue, FillRule::EvenOdd, &path);
+        assert_eq!(alpha_at(&px, 128, 128), 0.0, "even-odd must punch the hole either way");
+        areas.push(covered(&px));
+    }
+    assert!(
+        (areas[0] - areas[1]).abs() < 1.0,
+        "even-odd coverage differed by winding: {:.2} vs {:.2}",
+        areas[0],
+        areas[1]
+    );
+}
+
+#[test]
+fn a_reversed_concave_contour_covers_its_own_area() {
+    let Some((device, queue)) = headless_device() else {
+        return;
+    };
+    // Concave, so it goes through the stencil rather than the convex fast path,
+    // and the fan's winding is what the stencil counts.
+    let l_shape = [
+        (100.0f32, 100.0f32),
+        (200.0, 100.0),
+        (200.0, 150.0),
+        (150.0, 150.0),
+        (150.0, 200.0),
+        (100.0, 200.0),
+    ];
+    for reversed in [false, true] {
+        let mut points = l_shape.to_vec();
+        if reversed {
+            points.reverse();
+        }
+        let mut path = Path::new();
+        contour(&mut path, &points);
+        let px = fill(&device, &queue, FillRule::NonZero, &path);
+        assert!(
+            (covered(&px) - 7500.0).abs() < 1.0,
+            "L shape ({}) covered {:.2}px, want 7500",
+            if reversed { "reversed" } else { "as authored" },
+            covered(&px)
+        );
+    }
+}
+
+#[test]
+fn a_stroke_after_a_fill_still_sees_the_path_as_written() {
+    let Some((device, queue)) = headless_device() else {
+        return;
+    };
+    // The fill normalizes orientation on the path cache that a later stroke of
+    // the same path reads, and a stroke's direction decides which end takes
+    // which cap. Stroking on its own and stroking after a fill must agree, for
+    // a closed contour and for an open one with different caps at each end.
+    let closed = || {
+        let mut path = Path::new();
+        contour(&mut path, &square(100.0, 100.0, 200.0, 200.0, true));
+        path
+    };
+    let open = || {
+        let mut path = Path::new();
+        path.move_to(80.0, 80.0);
+        path.line_to(200.0, 90.0);
+        path.line_to(190.0, 200.0);
+        path
+    };
+
+    for (what, make) in [
+        ("closed clockwise square", Box::new(closed) as Box<dyn Fn() -> Path>),
+        ("open clockwise polyline", Box::new(open)),
+    ] {
+        let stroke = |canvas: &mut Canvas<WGPURenderer>| {
+            let mut paint = Paint::color(Color::rgb(0, 0, 0))
+                .with_line_width(11.0)
+                .with_anti_alias(true);
+            paint.set_line_cap_start(LineCap::Round);
+            paint.set_line_cap_end(LineCap::Square);
+            canvas.stroke_path(&make(), &paint);
+        };
+        let alone = common::render_rgba(&device, &queue, W, H, Color::rgba(0, 0, 0, 0), |canvas| stroke(canvas));
+        let after_fill = common::render_rgba(&device, &queue, W, H, Color::rgba(0, 0, 0, 0), |canvas| {
+            canvas.fill_path(&make(), &Paint::color(Color::rgba(0, 0, 0, 0)).with_anti_alias(true));
+            stroke(canvas);
+        });
+        assert_eq!(alone, after_fill, "filling first changed the stroke of a {what}");
+    }
+}


### PR DESCRIPTION
Fixes #308: a filled contour covered a different set of pixels depending on which way round it was wound. The antialiasing fringe is extruded along each point's miter vector, whose direction follows the point order, so a clockwise contour pushed the fringe outward and landed a whole fringe wide on every side: a 100×100 square covered 10,353 px clockwise against 10,000 counter-clockwise. `Path::rect()` and `Path::circle()` emit counter-clockwise and were exact, which is why it survived; `svg_arc_to()` follows the sweep flag, and imported paths are wound however their author wound them — usvg emits every `<circle>` clockwise.

![winding edge](https://raw.githubusercontent.com/rebeckerspecialties/femtovg/pixel-comparisons/comparisons/fill-winding-edge-fixed.png)

### Fix

nanovg avoids this by normalizing every contour up front (`nvg__flattenPaths`, "Enforce winding"). femtovg cannot copy that directly: it lets the authored winding express holes for `FillRule::NonZero`, and the stencil pass reads that winding back. So orientation is normalized for the geometry only — the points are flipped before the joins are computed, the fill triangles are emitted in the caller's orientation, and the points are handed back, since a later stroke of the same cached path must still see its own direction (dash phase, which end takes which cap).

A hole's boundary needs the opposite orientation from a solid contour's: with the fill on the far side of its edge, normalizing it like a solid lands its half-pixel inset and fringe inside the hole, and the fill around it reads exactly one pixel too wide on that edge. Each contour is therefore judged by the other contours' winding at the midpoint of its first edge under the fill rule, and holes are oriented the other way — nanovg's `NVG_SOLID` / `NVG_HOLE`, derived from the authored winding instead of declared. The sides are computed once per path cache (per transform), walking only the contours whose bounding box contains the sample point, so a path of many disjoint contours costs about one pass over its points.

### Result

Analytic ground truth, summed alpha against exact area:

| shape | master | this PR | exact |
|---|---|---|---|
| 100×100 square, clockwise | 10353.00 | **10000.00** | 10000 |
| 100×100 square, counter-clockwise | 10000.00 | 10000.00 | 10000 |
| 240×240 square rotated 45° | 58539.67 | **57660.00** | 57600 |
| concave L, clockwise | 7853.00 | **7500.00** | 7500 |
| 136×136 ring with a 56×56 hole, either winding, either rule | +224 | **15360.00** | 15360 |

**SVGenius** (100 icons, `hard/process`, rendered at their reference PNGs' own 625 px; the PNGs are CairoSVG renders that agree with Chromium 131 to 113 px on the chair): pixels differing by more than 32/255 fall from **1.33 % to 0.03 %** of the frame, 69 files above 0.5 % → 0, and 0.73 % → 0.11 % against Chromium over the 93 files the reference page frames the same way. The thick black outlines in this corpus are filled rings, and 75 of the 100 files carry holes: the winding fix alone left them a pixel wide on every hole edge (chair 6,517 px, phone 6,973 px) and 25 of those files worse than master; the hole orientation takes chair to 164 px and phone to 260.

![corpus accuracy](https://raw.githubusercontent.com/rebeckerspecialties/femtovg/pixel-comparisons/comparisons/fill-winding-corpus-accuracy-holes.png)

**The #308 logos** at 100 % and across a zoom ladder, rendered natively at each size:

![logos at 100%](https://raw.githubusercontent.com/rebeckerspecialties/femtovg/pixel-comparisons/comparisons/fill-winding-logos-static.png)

![zoom ladder](https://raw.githubusercontent.com/rebeckerspecialties/femtovg/pixel-comparisons/comparisons/fill-winding-zoom-ladder.png)

**BuseyBench** (27 AI-generated portraits): the eyes matched both browsers at 4× and not at 1×, because every catchlight, pupil and rim is a clockwise `<circle>` that gained a pixel of radius — a 0.5 px disc drew 9.6× its ink. On top of the layer stack and #338, this PR takes the corpus mean pixel difference against Chromium from 2.33 % to 0.93 % and the structural difference from 0.053 % to 0.027 % (Firefox 2.28 % → 0.84 %, 0.051 % → 0.026 %); #339 covers the sub-pixel strokes in the same eyes.

![eyes at 1x across builds, and the sub-pixel probe](https://raw.githubusercontent.com/rebeckerspecialties/femtovg/demo-assets/busey-eyes-subpixel.png)

**Thin fills** (the fill half of #327) were paying that pixel on both edges. Ink against true area for a 45° bar: 0.5 px 5.27× → 1.45×, 1 px 2.99× → 1.12×, 2 px 2.06× → 0.98×, 4 px 1.49× → 1.02×. Everything at or above 2 px is now exact; below about a pixel the ramps from opposite edges still overlap and blend `src-over` rather than combining as coverage, which needs coverage-based antialiasing and is untouched here.

### Tests

`tests/fill_winding_wgpu.rs`: both windings cover the same area and reach the same edge; winding still decides holes under `NonZero`; even-odd is winding-independent down to the fringe; a reversed concave contour covers its own area; a stroke after a fill still sees the path as written; a ring keeps its exact area and a clean first pixel inside the hole under both rules and either outer orientation (a pixel per hole edge adds 224 px); two solid squares and a solid island inside a hole keep their exact areas. Four of the first five fail on master; the two hole tests fail on the winding fix alone. 255 GPU tests and the default suite green; fmt and clippy clean.
