### PR TITLE
Add feTurbulence and the sRGB transfer curve as image filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- Added `ImageFilter::Turbulence`, the SVG `feTurbulence` primitive, generated on
+  the GPU from the SVG 1.1 reference algorithm - the same Park-Miller generator
+  and Perlin lattice Chromium and Firefox run, so a seed gives a browser's noise.
+  The lattice is uploaded once per seed as a 512 KB texture with the spec's two
+  dependent permutation lookups pre-composed, so every fetch is addressed
+  straight from the pixel (the shape tile-based mobile GPUs pipeline) at eight
+  fetches per octave for all four channels; the last four seeds stay cached. A
+  `transform` maps noise space onto the output so the pattern scales with the
+  content, and `stitchTiles` is supported. Added `ImageFilter::LinearRgbToSrgb`
+  and `SrgbToLinearRgb`, the sRGB transfer curve as a pass, so a chain can run
+  in linearRGB the way SVG filters do by default and hand back what a browser
+  displays; an adjacent pair folds away.
 - Added `Canvas::filter_image_chain()`, which applies a list of image filters in
   one call the way a Canvas `ctx.filter` list (`"blur(5px) brightness(1.2)"`) or
   an SVG filter chain does. Consecutive color-matrix filters fold into a single

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Run with `cargo run --example text`
 * [x] Fill rules - EvenOdd/NonZero
 * [x] Rectangle scissoring
 * [x] Composition modes (SourceOver, SourceIn, SourceOut, Atop, etc..)
-* [x] Image filters - gaussian blur and color matrices (the CSS filter functions), chained in a single call
+* [x] Image filters - gaussian blur, color matrices (the CSS filter functions), Perlin turbulence (SVG `feTurbulence`) and the sRGB transfer curve, chained in a single call
 * [x] Global alpha
 * [x] Text filling and stroking
 * [x] Text shaping

--- a/src/image.rs
+++ b/src/image.rs
@@ -4,6 +4,9 @@ use rgb::alt::Gray;
 use rgb::*;
 use slotmap::{DefaultKey, SlotMap};
 
+use crate::geometry::Transform2D;
+use crate::renderer::ShaderType;
+
 #[cfg(feature = "image-loading")]
 use ::image::DynamicImage;
 
@@ -357,6 +360,74 @@ pub enum ImageFilter {
         /// Row-major 4x5 color matrix.
         matrix: [f32; 20],
     },
+    /// Perlin turbulence or fractal noise: the SVG `feTurbulence` primitive,
+    /// generated from the reference algorithm in SVG 1.1 section 15.19 that
+    /// Chromium and Firefox both implement, so the same parameters give the
+    /// same noise as a browser.
+    ///
+    /// Unlike the other filters this one does not sample its source image -
+    /// `feTurbulence` takes no input - it only sizes the output from it.
+    /// Each pixel gets four independent noise channels (RGBA, each in
+    /// `[0, 1]`) and the result is stored premultiplied. `fractalNoise` is
+    /// centered on 0.5 and `turbulence` on 0 in every channel, alpha
+    /// included, exactly as the primitive is specified; a chain typically
+    /// follows with a [`ColorMatrix`](Self::ColorMatrix) that remaps the
+    /// channels into a color and an opacity.
+    ///
+    /// The noise lives in its own coordinate space: `transform` maps that
+    /// space onto output pixels, so the pattern scales and moves with the
+    /// content it decorates instead of sticking to the device grid. Pixel
+    /// `(x, y)` is evaluated at `transform⁻¹ · (x, y)`; with the identity
+    /// transform one noise unit is one pixel, which is what a browser does
+    /// at 1:1 and what Firefox does at any zoom (Chromium additionally snaps
+    /// the mapped position to whole noise units).
+    ///
+    /// The primitive's values are defined in the filter's working color
+    /// space, which SVG defaults to linearRGB; end such a chain with
+    /// [`LinearRgbToSrgb`](Self::LinearRgbToSrgb) to get what a browser
+    /// displays for a default `<filter>`.
+    ///
+    /// Octaves past the tenth are skipped: octave `n` contributes at most
+    /// `1 / 2ⁿ`, so the ones skipped change the sum by less than half of an
+    /// 8-bit step, and the bound keeps the per-pixel cost finite on GLES 2.0
+    /// hardware, where loops need a constant bound.
+    Turbulence {
+        /// Base frequency per axis, in cycles per noise unit (SVG `baseFrequency`).
+        base_frequency: [f32; 2],
+        /// Number of octaves to sum (SVG `numOctaves`); 0 sums nothing.
+        num_octaves: u32,
+        /// Random seed (SVG `seed`, already truncated to an integer).
+        seed: i32,
+        /// Adjust the frequency and wrap the lattice so the noise tiles
+        /// seamlessly across the output image (SVG `stitchTiles="stitch"`).
+        stitch_tiles: bool,
+        /// `fractalNoise` or `turbulence` (SVG `type`).
+        kind: TurbulenceKind,
+        /// Maps noise space onto output pixels.
+        transform: Transform2D,
+    },
+    /// Converts unpremultiplied color from linearRGB to sRGB with the sRGB
+    /// transfer curve (IEC 61966-2-1), leaving alpha unchanged. SVG filters
+    /// run in linearRGB by default (`color-interpolation-filters`), so a
+    /// chain that reproduces one ends with this to hand the display the
+    /// sRGB values a browser shows. Adjacent to its inverse it folds away.
+    LinearRgbToSrgb,
+    /// The inverse of [`LinearRgbToSrgb`](Self::LinearRgbToSrgb): converts
+    /// unpremultiplied sRGB color to linearRGB, for filtering an ordinary
+    /// image the way a linearRGB SVG filter would.
+    SrgbToLinearRgb,
+}
+
+/// The noise function of [`ImageFilter::Turbulence`]: SVG `feTurbulence`'s
+/// `type` attribute.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
+pub enum TurbulenceKind {
+    /// Sums signed octaves: smooth, cloud-like values centered on 0.5.
+    FractalNoise,
+    /// Sums the absolute value of each octave: sharper, vein-like values
+    /// centered on 0. The SVG default.
+    #[default]
+    Turbulence,
 }
 
 impl ImageFilter {
@@ -582,10 +653,20 @@ impl ImageFilter {
     /// sequential result and from Chromium. `next` may overflow freely: its
     /// output is clamped at the end of the pass either way.
     ///
-    /// Returns `None` when either side is not a color matrix (a blur cannot
-    /// fold) or when `self` is not range-safe, leaving chain execution to run
-    /// the passes separately.
+    /// A color-space transfer followed by its inverse folds to the identity:
+    /// the pair is a mathematical no-op, and skipping it is more exact than
+    /// running it, which would round the linear intermediate to 8 bits.
+    ///
+    /// Returns `None` for any other pairing that is not two color matrices
+    /// (a blur or a turbulence cannot fold) or when `self` is not
+    /// range-safe, leaving chain execution to run the passes separately.
     pub fn fold_with(self, next: Self) -> Option<Self> {
+        if matches!(
+            (self, next),
+            (Self::LinearRgbToSrgb, Self::SrgbToLinearRgb) | (Self::SrgbToLinearRgb, Self::LinearRgbToSrgb)
+        ) {
+            return Some(Self::identity());
+        }
         let (Self::ColorMatrix { matrix: a }, Self::ColorMatrix { matrix: b }) = (self, next) else {
             return None;
         };
@@ -620,8 +701,37 @@ impl ImageFilter {
     /// it. Exhaustive on purpose - a new variant must declare its parity here.
     pub(crate) fn flips_output(&self) -> bool {
         match self {
-            Self::ColorMatrix { .. } => true,
+            Self::ColorMatrix { .. } | Self::Turbulence { .. } | Self::LinearRgbToSrgb | Self::SrgbToLinearRgb => true,
             Self::GaussianBlur { .. } => false,
+        }
+    }
+
+    /// The shader and its 20 parameter slots for a filter that runs as one
+    /// full-image pass over a `width` x `height` target; `None` for the
+    /// two-pass Gaussian blur, which the renderers drive themselves.
+    ///
+    /// The slots ride the scissor and paint matrix uniforms, which are dead
+    /// during a filter pass (no scissor, no paint gradient): the first 12
+    /// land in `scissor_mat`, the last 8 in `paint_mat`, so no uniform-array
+    /// growth is needed. Each shader documents its own layout; the color
+    /// matrix is its 20 values row-major, a transfer uses slot 0 as its
+    /// direction (1 = to sRGB), turbulence is laid out by
+    /// [`turbulence::shader_slots`](crate::turbulence::shader_slots).
+    pub(crate) fn single_pass(&self, width: f32, height: f32) -> Option<(ShaderType, [f32; 20])> {
+        let transfer = |to_srgb: f32| {
+            let mut slots = [0.0f32; 20];
+            slots[0] = to_srgb;
+            (ShaderType::FilterImageTransfer, slots)
+        };
+        match *self {
+            Self::GaussianBlur { .. } => None,
+            Self::ColorMatrix { matrix } => Some((ShaderType::FilterImageColorMatrix, matrix)),
+            Self::Turbulence { .. } => Some((
+                ShaderType::FilterImageTurbulence,
+                crate::turbulence::shader_slots(self, width, height),
+            )),
+            Self::LinearRgbToSrgb => Some(transfer(1.0)),
+            Self::SrgbToLinearRgb => Some(transfer(0.0)),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,9 @@ use text::{GlyphAtlas, TextContextImpl};
 
 mod image;
 use crate::image::ImageStore;
-pub use crate::image::{ImageFilter, ImageFlags, ImageId, ImageInfo, ImageSource, PixelFormat};
+pub use crate::image::{ImageFilter, ImageFlags, ImageId, ImageInfo, ImageSource, PixelFormat, TurbulenceKind};
+
+mod turbulence;
 
 mod color;
 pub use color::Color;
@@ -327,6 +329,10 @@ pub struct Canvas<T: Renderer> {
     // referenced by deferred draw commands, so they can only be freed once those
     // commands have been submitted to the renderer (i.e. after flush).
     transient_images: Vec<ImageId>,
+    // Turbulence lattice textures by seed, most recently used last. Bounded by
+    // `turbulence::LATTICE_CACHE_CAPACITY`; an evicted one is released through
+    // `transient_images` so a command already recorded against it still runs.
+    turbulence_lattices: Vec<(i32, ImageId)>,
 }
 
 /// Returns the enabled text-decoration lines as `(offset, thickness)` pairs,
@@ -385,6 +391,7 @@ where
             dist_tol: 0.01,
             gradients: GradientStore::new(),
             transient_images: Vec::new(),
+            turbulence_lattices: Vec::new(),
         };
 
         canvas.save();
@@ -415,6 +422,7 @@ where
             dist_tol: 0.01,
             gradients: GradientStore::new(),
             transient_images: Vec::new(),
+            turbulence_lattices: Vec::new(),
         };
 
         canvas.save();
@@ -799,15 +807,27 @@ where
     ///
     /// The filtering does not take any transformation set on the Canvas into account nor does it
     /// change the current rendering target.
+    ///
+    /// [`ImageFilter::Turbulence`] reads nothing from `source_image` - it only takes the output
+    /// size from it - and keeps a small per-seed cache of lattice textures (512 KB each, the
+    /// last four seeds used) alive across flushes.
     pub fn filter_image(&mut self, target_image: ImageId, filter: ImageFilter, source_image: ImageId) {
         let Ok((image_width, image_height)) = self.image_size(source_image) else {
             return;
         };
 
         // The renderer will receive a RenderFilteredImage command with two triangles attached that
-        // cover the image and the source image.
+        // cover the image and the source image. A turbulence pass generates rather than samples,
+        // so it binds its noise lattice where the source would go; the source still sizes the quad.
+        let sampled = match filter {
+            ImageFilter::Turbulence { seed, .. } => match self.turbulence_lattice(seed) {
+                Ok(lattice) => lattice,
+                Err(_) => return,
+            },
+            _ => source_image,
+        };
         let mut cmd = Command::new(CommandType::RenderFilteredImage { target_image, filter });
-        cmd.image = Some(source_image);
+        cmd.image = Some(sampled);
 
         let vertex_offset = self.verts.len();
 
@@ -834,6 +854,26 @@ where
         cmd.triangles_verts = Some((vertex_offset, 6));
 
         self.append_cmd(cmd)
+    }
+
+    /// The lattice texture for a turbulence seed, built on first use and kept
+    /// for the [`turbulence::LATTICE_CACHE_CAPACITY`] most recently used seeds.
+    /// An evicted lattice is released after the next flush, once any command
+    /// already recorded against it has run.
+    fn turbulence_lattice(&mut self, seed: i32) -> Result<ImageId, ErrorKind> {
+        if let Some(at) = self.turbulence_lattices.iter().position(|(s, _)| *s == seed) {
+            let entry = self.turbulence_lattices.remove(at);
+            self.turbulence_lattices.push(entry);
+            return Ok(entry.1);
+        }
+        let texels = turbulence::lattice_texels(seed);
+        let id = self.create_image(turbulence::lattice_source(&texels), turbulence::lattice_flags())?;
+        self.turbulence_lattices.push((seed, id));
+        if self.turbulence_lattices.len() > turbulence::LATTICE_CACHE_CAPACITY {
+            let (_, evicted) = self.turbulence_lattices.remove(0);
+            self.transient_images.push(evicted);
+        }
+        Ok(id)
     }
 
     /// Acquires a transient offscreen image that is released automatically
@@ -4500,6 +4540,61 @@ fn layout_stores_the_run_baseline() {
             layout.baseline()
         );
     }
+}
+
+/// Turbulence lattices are cached per seed with a fixed capacity: a repeated
+/// seed reuses its texture, the least recently used seed is evicted through
+/// the transient list (so a command recorded against it still runs before the
+/// delete), and a flush releases only the evicted ones.
+#[test]
+fn turbulence_lattice_cache_is_bounded() {
+    use crate::{ImageFilter, TurbulenceKind};
+    let renderer = RecordingRenderer::default();
+    let mut canvas = Canvas::new(renderer).unwrap();
+    canvas.set_size(64, 64, 1.0);
+    let src = canvas
+        .create_image_empty(16, 16, PixelFormat::Rgba8, ImageFlags::empty())
+        .unwrap();
+    let dst = canvas
+        .create_image_empty(16, 16, PixelFormat::Rgba8, ImageFlags::FLIP_Y)
+        .unwrap();
+    let noise = |seed: i32| ImageFilter::Turbulence {
+        base_frequency: [0.1, 0.1],
+        num_octaves: 2,
+        seed,
+        stitch_tiles: false,
+        kind: TurbulenceKind::FractalNoise,
+        transform: Transform2D::identity(),
+    };
+
+    for seed in 1..=turbulence::LATTICE_CACHE_CAPACITY as i32 {
+        canvas.filter_image(dst, noise(seed), src);
+    }
+    assert_eq!(canvas.turbulence_lattices.len(), turbulence::LATTICE_CACHE_CAPACITY);
+    assert!(canvas.transient_images.is_empty());
+
+    // A cache hit reorders, allocating nothing.
+    canvas.filter_image(dst, noise(1), src);
+    assert_eq!(canvas.turbulence_lattices.len(), turbulence::LATTICE_CACHE_CAPACITY);
+    assert_eq!(canvas.turbulence_lattices.last().unwrap().0, 1);
+    assert!(canvas.transient_images.is_empty());
+
+    // One past capacity evicts the least recently used seed (2, since 1 was
+    // just touched) into the transient list, not straight to the renderer.
+    let evicted = canvas.turbulence_lattices[0].1;
+    canvas.filter_image(dst, noise(99), src);
+    assert_eq!(canvas.turbulence_lattices.len(), turbulence::LATTICE_CACHE_CAPACITY);
+    assert!(canvas.turbulence_lattices.iter().all(|(s, _)| *s != 2));
+    assert_eq!(canvas.transient_images, vec![evicted]);
+    assert!(
+        canvas.images.info(evicted).is_some(),
+        "evicted lattice stays alive until flush"
+    );
+
+    canvas.flush_to_output(());
+    assert!(canvas.transient_images.is_empty());
+    assert!(canvas.images.info(evicted).is_none());
+    assert_eq!(canvas.turbulence_lattices.len(), turbulence::LATTICE_CACHE_CAPACITY);
 }
 
 /// Chain execution stays within a bounded transient budget: a run of

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -257,6 +257,11 @@ pub enum ShaderType {
     FillGradientTwoPointRadial,
     /// Fill image two-point radial gradient shader (multi-stop LUT variant).
     FillImageGradientTwoPointRadial,
+    /// Turbulence generator shader (SVG `feTurbulence`); samples the noise
+    /// lattice bound in place of the image.
+    FilterImageTurbulence,
+    /// sRGB transfer-curve shader: linearRGB to sRGB, or the reverse.
+    FilterImageTransfer,
 }
 
 impl ShaderType {
@@ -276,6 +281,8 @@ impl ShaderType {
             Self::FilterImageColorMatrix => 10,
             Self::FillGradientTwoPointRadial => 11,
             Self::FillImageGradientTwoPointRadial => 12,
+            Self::FilterImageTurbulence => 13,
+            Self::FilterImageTransfer => 14,
         }
     }
 

--- a/src/renderer/opengl.rs
+++ b/src/renderer/opengl.rs
@@ -42,9 +42,9 @@ pub struct OpenGl {
     view: [f32; 2],
     screen_view: [f32; 2],
     // All types of the vertex/fragment shader, indexed by shader_type when has_glyph_texture is true
-    main_programs_with_glyph_texture: [Option<MainProgram>; 13],
+    main_programs_with_glyph_texture: [Option<MainProgram>; 15],
     // Same shader programs but with has_glyph_texture being false
-    main_programs_without_glyph_texture: [Option<MainProgram>; 13],
+    main_programs_without_glyph_texture: [Option<MainProgram>; 15],
     current_program: u8,
     current_program_needs_glyph_texture: bool,
     vert_arr: Option<<glow::Context as glow::HasContext>::VertexArray>,
@@ -206,6 +206,26 @@ impl OpenGl {
                     ShaderType::FillImageGradientTwoPointRadial,
                     with_glyph_texture,
                 )?),
+                if with_glyph_texture {
+                    None
+                } else {
+                    Some(MainProgram::new(
+                        &context,
+                        antialias,
+                        ShaderType::FilterImageTurbulence,
+                        false,
+                    )?)
+                },
+                if with_glyph_texture {
+                    None
+                } else {
+                    Some(MainProgram::new(
+                        &context,
+                        antialias,
+                        ShaderType::FilterImageTransfer,
+                        false,
+                    )?)
+                },
             ])
         };
 
@@ -605,19 +625,29 @@ impl OpenGl {
     ) {
         match filter {
             ImageFilter::GaussianBlur { sigma } => self.render_gaussian_blur(images, cmd, target_image, sigma),
-            ImageFilter::ColorMatrix { matrix } => self.render_color_matrix(images, cmd, target_image, matrix),
+            single_pass => {
+                let target_image_info = images.get(target_image).unwrap().info();
+                let (shader_type, slots) = single_pass
+                    .single_pass(target_image_info.width() as f32, target_image_info.height() as f32)
+                    .expect("every filter but the Gaussian blur runs as one pass");
+                self.render_filter_pass(images, cmd, target_image, shader_type, slots)
+            }
         }
     }
 
-    fn render_color_matrix(
+    /// Runs a one-pass filter (color matrix, turbulence, transfer) over the
+    /// command's quad into `target_image`, sampling the command's image.
+    fn render_filter_pass(
         &mut self,
         images: &mut ImageStore<GlTexture>,
         cmd: Command,
         target_image: ImageId,
-        matrix: [f32; 20],
+        shader_type: ShaderType,
+        slots: [f32; 20],
     ) {
         let original_render_target = self.current_render_target;
         let source_image_info = images.get(cmd.image.unwrap()).unwrap().info();
+        let target_image_info = images.get(target_image).unwrap().info();
 
         let image_paint = crate::Paint::image(
             cmd.image.unwrap(),
@@ -638,21 +668,24 @@ impl OpenGl {
             0.,
             0.,
         );
-        params.shader_type = ShaderType::FilterImageColorMatrix;
-        // The color matrix rides the scissor/paint-matrix uniform slots, which are
-        // dead during a filter pass (no scissor, no paint gradient): frag[0..2]
-        // hold the first 12 values, frag[3..4] the last 8, so no uniform-array
-        // growth is needed. The shader reads them back as a row-major 4x5 matrix.
-        params.scissor_mat.copy_from_slice(&matrix[..12]);
-        params.paint_mat[..8].copy_from_slice(&matrix[12..20]);
+        params.shader_type = shader_type;
+        // The filter's parameters ride the scissor/paint-matrix uniform slots,
+        // which are dead during a filter pass (no scissor, no paint gradient):
+        // frag[0..2] hold the first 12 values, frag[3..4] the last 8, so no
+        // uniform-array growth is needed (see `ImageFilter::single_pass`).
+        params.scissor_mat.copy_from_slice(&slots[..12]);
+        params.paint_mat[..8].copy_from_slice(&slots[12..20]);
+        // A generating pass binds its lookup table as the image, so the output
+        // extent comes from the target rather than from what is sampled.
+        params.extent = [target_image_info.width() as f32, target_image_info.height() as f32];
 
         self.set_target(images, RenderTarget::Image(target_image));
         self.main_program().set_view(self.view);
         self.clear_rect(
             0,
             0,
-            source_image_info.width() as _,
-            source_image_info.height() as _,
+            target_image_info.width() as _,
+            target_image_info.height() as _,
             Color::rgbaf(0., 0., 0., 0.),
         );
         self.triangles(images, &cmd, &params);

--- a/src/renderer/opengl/main-fs.glsl
+++ b/src/renderer/opengl/main-fs.glsl
@@ -46,6 +46,8 @@ varying vec2 fpos;
  #define SHADER_TYPE_FilterImageColorMatrix 10
  #define SHADER_TYPE_FillGradientTwoPointRadial 11
  #define SHADER_TYPE_FillImageGradientTwoPointRadial 12
+ #define SHADER_TYPE_FilterImageTurbulence 13
+ #define SHADER_TYPE_FilterImageTransfer 14
 
 float sdroundrect(vec2 pt, vec2 ext, float rad) {
     vec2 ext2 = ext - vec2(rad,rad);
@@ -291,6 +293,104 @@ vec4 renderColorMatrix() {
     return outc;
 }
 
+// SVG feTurbulence (SVG 1.1 section 15.19), all four channels at once. `tex`
+// is the lattice texture built by src/turbulence.rs: texel (bx, by) of the
+// left 256 columns holds the unit gradient vectors of channels 0 and 1 at
+// lattice corner (bx, by), the right 256 columns those of channels 2 and 3,
+// each component stored as (g + 1) / 2. The reference code's integer
+// truncation and 0xff mask become floor() and mod() here - GLSL ES 1.00 has
+// no bitwise operators - and the PerlinN offset that kept its integers
+// positive drops out, so the stitch thresholds arrive from Rust without it.
+#define TURBULENCE_MAX_OCTAVES 10.0
+
+vec2 turbulenceWrap(vec2 corner) {
+    return corner - 256.0 * floor(corner / 256.0);
+}
+
+vec4 turbulenceGradients(vec2 corner, float pair) {
+    return texture2D(tex, vec2(corner.x + pair * 256.0 + 0.5, corner.y + 0.5) / vec2(512.0, 256.0)) * 2.0 - 1.0;
+}
+
+// One octave of classic Perlin noise at v: the spec's noise2() for the four
+// channels. stitch is (tile width, tile height, wrap x, wrap y) in lattice units.
+vec4 turbulenceOctave(vec2 v, vec4 stitch, bool stitching) {
+    vec2 b0 = floor(v);
+    vec2 r0 = v - b0;
+    vec2 b1 = b0 + 1.0;
+    vec2 r1 = r0 - 1.0;
+    if (stitching) {
+        if (b0.x >= stitch.z) b0.x -= stitch.x;
+        if (b1.x >= stitch.z) b1.x -= stitch.x;
+        if (b0.y >= stitch.w) b0.y -= stitch.y;
+        if (b1.y >= stitch.w) b1.y -= stitch.y;
+    }
+    b0 = turbulenceWrap(b0);
+    b1 = turbulenceWrap(b1);
+    vec2 c10 = vec2(b1.x, b0.y);
+    vec2 c01 = vec2(b0.x, b1.y);
+    vec4 gA00 = turbulenceGradients(b0, 0.0);
+    vec4 gB00 = turbulenceGradients(b0, 1.0);
+    vec4 gA10 = turbulenceGradients(c10, 0.0);
+    vec4 gB10 = turbulenceGradients(c10, 1.0);
+    vec4 gA01 = turbulenceGradients(c01, 0.0);
+    vec4 gB01 = turbulenceGradients(c01, 1.0);
+    vec4 gA11 = turbulenceGradients(b1, 0.0);
+    vec4 gB11 = turbulenceGradients(b1, 1.0);
+    vec2 r10 = vec2(r1.x, r0.y);
+    vec2 r01 = vec2(r0.x, r1.y);
+    vec4 u00 = vec4(dot(r0, gA00.xy), dot(r0, gA00.zw), dot(r0, gB00.xy), dot(r0, gB00.zw));
+    vec4 u10 = vec4(dot(r10, gA10.xy), dot(r10, gA10.zw), dot(r10, gB10.xy), dot(r10, gB10.zw));
+    vec4 u01 = vec4(dot(r01, gA01.xy), dot(r01, gA01.zw), dot(r01, gB01.xy), dot(r01, gB01.zw));
+    vec4 u11 = vec4(dot(r1, gA11.xy), dot(r1, gA11.zw), dot(r1, gB11.xy), dot(r1, gB11.zw));
+    vec2 s = r0 * r0 * (3.0 - 2.0 * r0);
+    return mix(mix(u00, u10, s.x), mix(u01, u11, s.x), s.y);
+}
+
+vec4 renderTurbulence() {
+    // Slots (see ImageFilter::single_pass): frag[0] = inverse transform a b c d,
+    // frag[1] = e f and the base frequency, frag[2] = octaves, fractal flag and
+    // the stitch tile size, frag[3] = the stitch wrap thresholds and flag.
+    // Each output pixel is evaluated at its integer index mapped into noise space.
+    vec2 px = floor(fpos.xy);
+    vec2 p = vec2(frag[0].x * px.x + frag[0].z * px.y + frag[1].x,
+                  frag[0].y * px.x + frag[0].w * px.y + frag[1].y);
+    vec2 v = p * frag[1].zw;
+    float octaves = frag[2].x;
+    bool fractal = frag[2].y > 0.5;
+    vec4 stitch = vec4(frag[2].zw, frag[3].xy);
+    bool stitching = frag[3].z > 0.5;
+    vec4 sum = vec4(0.0);
+    float ratio = 1.0;
+    for (float o = 0.0; o < TURBULENCE_MAX_OCTAVES; o += 1.0) {
+        // GLES 2.0 loops need a constant bound; the octave count breaks out.
+        if (o >= octaves) break;
+        vec4 n = turbulenceOctave(v, stitch, stitching);
+        sum += (fractal ? n : abs(n)) / ratio;
+        v *= 2.0;
+        ratio *= 2.0;
+        stitch *= 2.0;
+    }
+    vec4 c = clamp(fractal ? (sum + 1.0) / 2.0 : sum, 0.0, 1.0);
+    return vec4(c.rgb * c.a, c.a);
+}
+
+// The sRGB transfer curve (IEC 61966-2-1) on unpremultiplied color, alpha
+// untouched: frag[0].x > 0.5 converts linearRGB to sRGB, otherwise the reverse.
+vec4 renderTransfer() {
+    vec4 c = texture2D(tex, fpos.xy / extent);
+    if (c.a > 0.0) {
+        c.rgb /= c.a;
+    }
+    vec3 x = clamp(c.rgb, 0.0, 1.0);
+    vec3 y;
+    if (frag[0].x > 0.5) {
+        y = mix(x * 12.92, 1.055 * pow(x, vec3(1.0 / 2.4)) - 0.055, step(0.0031308, x));
+    } else {
+        y = mix(x / 12.92, pow((x + 0.055) / 1.055, vec3(2.4)), step(0.04045, x));
+    }
+    return vec4(y * c.a, c.a);
+}
+
 void main(void) {
     vec4 result;
 
@@ -336,6 +436,10 @@ void main(void) {
     result = renderGradientTwoPointRadial();
 #elif SELECT_SHADER == SHADER_TYPE_FillImageGradientTwoPointRadial
     result = renderImageGradientTwoPointRadial();
+#elif SELECT_SHADER == SHADER_TYPE_FilterImageTurbulence
+    result = renderTurbulence();
+#elif SELECT_SHADER == SHADER_TYPE_FilterImageTransfer
+    result = renderTransfer();
 #else
 #error A shader variant must be selected with the SELECT_SHADER pre-processor variable
 #endif
@@ -356,7 +460,7 @@ void main(void) {
     mask *= scissor;
     result *= mask;
 #else
-#if SELECT_SHADER != SHADER_TYPE_Stencil && SELECT_SHADER != SHADER_TYPE_FilterImage && SELECT_SHADER != SHADER_TYPE_FilterImageColorMatrix
+#if SELECT_SHADER != SHADER_TYPE_Stencil && SELECT_SHADER != SHADER_TYPE_FilterImage && SELECT_SHADER != SHADER_TYPE_FilterImageColorMatrix && SELECT_SHADER != SHADER_TYPE_FilterImageTurbulence && SELECT_SHADER != SHADER_TYPE_FilterImageTransfer
         // Not stencil fill
         // Combine alpha
         result *= strokeAlpha * scissor;

--- a/src/renderer/wgpu.rs
+++ b/src/renderer/wgpu.rs
@@ -686,12 +686,17 @@ impl Renderer for WGPURenderer {
                             target_image,
                         );
                     }
-                    crate::ImageFilter::ColorMatrix { matrix } => {
-                        color_matrix_filter(
+                    single_pass => {
+                        let target_info = images.get(target_image).unwrap().info;
+                        let (shader_type, slots) = single_pass
+                            .single_pass(target_info.width() as f32, target_info.height() as f32)
+                            .expect("every filter but the Gaussian blur runs as one pass");
+                        single_pass_filter(
                             &mut current_render_target,
                             images,
                             command,
-                            matrix,
+                            shader_type,
+                            slots,
                             &mut render_pass_builder,
                             &mut pipeline_and_bindgroup_mapper,
                             target_image,
@@ -967,12 +972,15 @@ fn gaussian_blur_filter(
 
 /// Single-pass color-matrix filter: sample the source once and apply the 4x5
 /// matrix. Mirrors `gaussian_blur_filter` but without the intermediate texture.
+/// Runs a one-pass filter (color matrix, turbulence, transfer) over the
+/// command's quad into `target_image`, sampling the command's image.
 #[allow(clippy::too_many_arguments)]
-fn color_matrix_filter(
+fn single_pass_filter(
     current_render_target: &mut RenderTarget,
     images: &mut ImageStore<Image>,
     command: super::Command,
-    matrix: [f32; 20],
+    shader_type: ShaderType,
+    slots: [f32; 20],
     render_pass_builder: &mut RenderPassBuilder<'_>,
     pipeline_and_bindgroup_mapper: &mut CommandToPipelineAndBindGroupMapper,
     target_image: ImageId,
@@ -1000,11 +1008,15 @@ fn color_matrix_filter(
         0.,
         0.,
     );
-    params.shader_type = ShaderType::FilterImageColorMatrix;
-    // The 4x5 matrix rides the dead scissor/paint-mat slots during the filter
-    // pass (see `renderColorMatrix` in the shader) — no uniform-array growth.
-    params.scissor_mat.copy_from_slice(&matrix[..12]);
-    params.paint_mat[..8].copy_from_slice(&matrix[12..20]);
+    let target_info = images.get(target_image).unwrap().info;
+    params.shader_type = shader_type;
+    // The filter's parameters ride the dead scissor/paint-mat slots during the
+    // pass (see `ImageFilter::single_pass`) — no uniform-array growth.
+    params.scissor_mat.copy_from_slice(&slots[..12]);
+    params.paint_mat[..8].copy_from_slice(&slots[12..20]);
+    // A generating pass binds its lookup table as the image, so the output
+    // extent comes from the target rather than from what is sampled.
+    params.extent = [target_info.width() as f32, target_info.height() as f32];
 
     render_pass_builder.set_render_target_image(images, target_image, wgpu::LoadOp::Clear(wgpu::Color::default()));
 

--- a/src/renderer/wgpu/shader.wgsl
+++ b/src/renderer/wgpu/shader.wgsl
@@ -36,6 +36,8 @@ const SHADER_TYPE_FillImageGradientConic: i32 = 9;
 const SHADER_TYPE_FilterImageColorMatrix: i32 = 10;
 const SHADER_TYPE_FillGradientTwoPointRadial: i32 = 11;
 const SHADER_TYPE_FillImageGradientTwoPointRadial: i32 = 12;
+const SHADER_TYPE_FilterImageTurbulence: i32 = 13;
+const SHADER_TYPE_FilterImageTransfer: i32 = 14;
 
 const TAU: f32 = 6.28318530717958647692528676655900577;
 
@@ -172,6 +174,12 @@ fn fs_main(vertex: VertexOutput) -> @location(0) vec4<f32> {
         case SHADER_TYPE_FillImageGradientTwoPointRadial: {
             result = renderImageGradientTwoPointRadial(vertex, params);
         }
+        case SHADER_TYPE_FilterImageTurbulence: {
+            return renderTurbulence(vertex, params);
+        }
+        case SHADER_TYPE_FilterImageTransfer: {
+            return renderTransfer(vertex, params);
+        }
         default: {
             result = vec4<f32>(0.0, 0.0, 1.0, 1.0);
         }
@@ -222,6 +230,114 @@ fn renderColorMatrix(vertex: VertexOutput, params: Params) -> vec4<f32> {
     let a = m3.w * c.r + m4.x * c.g + m4.y * c.b + m4.z * c.a + m4.w;
     let outc = clamp(vec4<f32>(r, g, b, a), vec4<f32>(0.0), vec4<f32>(1.0));
     return vec4<f32>(outc.rgb * outc.a, outc.a);
+}
+
+// SVG feTurbulence (SVG 1.1 section 15.19), all four channels at once. The
+// image texture is the lattice built by src/turbulence.rs: texel (bx, by) of
+// the left 256 columns holds the unit gradient vectors of channels 0 and 1 at
+// lattice corner (bx, by), the right 256 columns those of channels 2 and 3,
+// each component stored as (g + 1) / 2. The reference code's integer
+// truncation and 0xff mask become floor() and a floored modulo, the same
+// arithmetic as the GLSL ES 1.00 shader so both backends agree, and the
+// PerlinN offset that kept its integers positive drops out, so the stitch
+// thresholds arrive from Rust without it.
+const TURBULENCE_MAX_OCTAVES: f32 = 10.0;
+
+fn turbulenceWrap(corner: vec2<f32>) -> vec2<f32> {
+    return corner - 256.0 * floor(corner / 256.0);
+}
+
+fn turbulenceGradients(corner: vec2<f32>, pair: f32) -> vec4<f32> {
+    let uv = vec2<f32>(corner.x + pair * 256.0 + 0.5, corner.y + 0.5) / vec2<f32>(512.0, 256.0);
+    return textureSample(image_texture, image_sampler, uv) * 2.0 - 1.0;
+}
+
+// One octave of classic Perlin noise at v: the spec's noise2() for the four
+// channels. stitch is (tile width, tile height, wrap x, wrap y) in lattice units.
+fn turbulenceOctave(v: vec2<f32>, stitch: vec4<f32>, stitching: bool) -> vec4<f32> {
+    var b0 = floor(v);
+    let r0 = v - b0;
+    var b1 = b0 + 1.0;
+    let r1 = r0 - 1.0;
+    if (stitching) {
+        if (b0.x >= stitch.z) { b0.x -= stitch.x; }
+        if (b1.x >= stitch.z) { b1.x -= stitch.x; }
+        if (b0.y >= stitch.w) { b0.y -= stitch.y; }
+        if (b1.y >= stitch.w) { b1.y -= stitch.y; }
+    }
+    b0 = turbulenceWrap(b0);
+    b1 = turbulenceWrap(b1);
+    let c10 = vec2<f32>(b1.x, b0.y);
+    let c01 = vec2<f32>(b0.x, b1.y);
+    let gA00 = turbulenceGradients(b0, 0.0);
+    let gB00 = turbulenceGradients(b0, 1.0);
+    let gA10 = turbulenceGradients(c10, 0.0);
+    let gB10 = turbulenceGradients(c10, 1.0);
+    let gA01 = turbulenceGradients(c01, 0.0);
+    let gB01 = turbulenceGradients(c01, 1.0);
+    let gA11 = turbulenceGradients(b1, 0.0);
+    let gB11 = turbulenceGradients(b1, 1.0);
+    let r10 = vec2<f32>(r1.x, r0.y);
+    let r01 = vec2<f32>(r0.x, r1.y);
+    let u00 = vec4<f32>(dot(r0, gA00.xy), dot(r0, gA00.zw), dot(r0, gB00.xy), dot(r0, gB00.zw));
+    let u10 = vec4<f32>(dot(r10, gA10.xy), dot(r10, gA10.zw), dot(r10, gB10.xy), dot(r10, gB10.zw));
+    let u01 = vec4<f32>(dot(r01, gA01.xy), dot(r01, gA01.zw), dot(r01, gB01.xy), dot(r01, gB01.zw));
+    let u11 = vec4<f32>(dot(r1, gA11.xy), dot(r1, gA11.zw), dot(r1, gB11.xy), dot(r1, gB11.zw));
+    let s = r0 * r0 * (3.0 - 2.0 * r0);
+    return mix(mix(u00, u10, s.x), mix(u01, u11, s.x), s.y);
+}
+
+fn renderTurbulence(vertex: VertexOutput, params: Params) -> vec4<f32> {
+    // Slots (see ImageFilter::single_pass): scissor_mat[0] = inverse transform
+    // a b c d, scissor_mat[1] = e f and the base frequency, scissor_mat[2] =
+    // octaves, fractal flag and the stitch tile size, paint_mat[0] = the stitch
+    // wrap thresholds and flag. Each output pixel is evaluated at its integer
+    // index mapped into noise space.
+    let m0 = params.scissor_mat[0];
+    let m1 = params.scissor_mat[1];
+    let m2 = params.scissor_mat[2];
+    let m3 = params.paint_mat[0];
+    let px = floor(vertex.fpos.xy);
+    let p = vec2<f32>(m0.x * px.x + m0.z * px.y + m1.x, m0.y * px.x + m0.w * px.y + m1.y);
+    var v = p * m1.zw;
+    let octaves = m2.x;
+    let fractal = m2.y > 0.5;
+    var stitch = vec4<f32>(m2.zw, m3.xy);
+    let stitching = m3.z > 0.5;
+    var sum = vec4<f32>(0.0);
+    var ratio: f32 = 1.0;
+    for (var o: f32 = 0.0; o < TURBULENCE_MAX_OCTAVES; o += 1.0) {
+        // Constant loop bound with the octave count breaking out, as in the
+        // GLES 2.0 shader, so both backends sum the same octaves.
+        if (o >= octaves) {
+            break;
+        }
+        let n = turbulenceOctave(v, stitch, stitching);
+        sum += select(abs(n), n, fractal) / ratio;
+        v *= 2.0;
+        ratio *= 2.0;
+        stitch *= 2.0;
+    }
+    let c = clamp(select(sum, (sum + 1.0) / 2.0, fractal), vec4<f32>(0.0), vec4<f32>(1.0));
+    return vec4<f32>(c.rgb * c.a, c.a);
+}
+
+// The sRGB transfer curve (IEC 61966-2-1) on unpremultiplied color, alpha
+// untouched: scissor_mat[0].x > 0.5 converts linearRGB to sRGB, otherwise the
+// reverse.
+fn renderTransfer(vertex: VertexOutput, params: Params) -> vec4<f32> {
+    var c: vec4<f32> = textureSample(image_texture, image_sampler, vertex.fpos.xy / params.extent);
+    if (c.a > 0.0) {
+        c = vec4<f32>(c.rgb / c.a, c.a);
+    }
+    let x = clamp(c.rgb, vec3<f32>(0.0), vec3<f32>(1.0));
+    var y: vec3<f32>;
+    if (params.scissor_mat[0].x > 0.5) {
+        y = mix(x * 12.92, 1.055 * pow(x, vec3<f32>(1.0 / 2.4)) - 0.055, step(vec3<f32>(0.0031308), x));
+    } else {
+        y = mix(x / 12.92, pow((x + 0.055) / 1.055, vec3<f32>(2.4)), step(vec3<f32>(0.04045), x));
+    }
+    return vec4<f32>(y * c.a, c.a);
 }
 
 fn conicAngleFraction(vertex: VertexOutput, params: Params) -> f32 {

--- a/src/turbulence.rs
+++ b/src/turbulence.rs
@@ -1,0 +1,344 @@
+//! Perlin turbulence lattice for [`ImageFilter::Turbulence`], the SVG
+//! `feTurbulence` primitive.
+//!
+//! The SVG 1.1 specification (Filter Effects, section 15.19) defines
+//! `feTurbulence` by reference code: a Park-Miller pseudo-random generator
+//! seeds a 256-entry permutation and four tables of 256 unit gradient
+//! vectors (one per color channel), and each pixel sums octaves of classic
+//! Perlin noise looked up through them. Chromium (Skia's `SkPerlinNoiseShader`)
+//! and Firefox both implement that code as written, which is why the two
+//! browsers agree on every noise pixel and why this module transcribes it
+//! rather than reaching for a different noise.
+//!
+//! The lattice is built once per seed on the CPU and uploaded as a texture
+//! the fragment shader samples. The spec reaches a gradient through two
+//! dependent permutation reads (`selector[selector[bx] + by]`); the texture
+//! stores that composition already resolved, so every lattice fetch in the
+//! shader is addressed straight from the pixel position. That matters on
+//! the tile-based mobile GPUs femtovg targets (a Raspberry Pi Zero's
+//! VideoCore IV pipelines independent fetches but stalls on dependent ones),
+//! and it is what keeps a four-octave, four-channel pixel at 32 fetches
+//! instead of 160.
+
+use rgb::RGBA8;
+
+use crate::{ImageFilter, ImageFlags, ImageSource, TurbulenceKind};
+
+/// The composed lattice texture is `LATTICE_WIDTH` x `LATTICE_HEIGHT` texels:
+/// two 256x256 tiles side by side, one per pair of color channels.
+pub(crate) const LATTICE_WIDTH: usize = 512;
+pub(crate) const LATTICE_HEIGHT: usize = 256;
+
+/// Lattices are cached per seed; a seed animated every frame cycles through
+/// this many uploads before evicting, so a handful of static seeds stay put.
+pub(crate) const LATTICE_CACHE_CAPACITY: usize = 4;
+
+/// Octaves past this one are not summed. Octave `n` contributes at most
+/// `1 / 2^n`, so everything skipped changes the sum by less than half of an
+/// 8-bit step, and GLES 2.0 needs a constant loop bound to unroll against.
+pub(crate) const MAX_OCTAVES: u32 = 10;
+
+// The spec's PRNG constants: a minimal standard generator, m = 2^31 - 1.
+const RAND_M: i64 = 2147483647;
+const RAND_A: i64 = 16807;
+const RAND_Q: i64 = 127773; // m / a
+const RAND_R: i64 = 2836; // m % a
+const B_SIZE: usize = 0x100;
+
+fn setup_seed(mut seed: i64) -> i64 {
+    if seed <= 0 {
+        seed = -(seed % (RAND_M - 1)) + 1;
+    }
+    if seed > RAND_M - 1 {
+        seed = RAND_M - 1;
+    }
+    seed
+}
+
+fn random(seed: i64) -> i64 {
+    let mut result = RAND_A * (seed % RAND_Q) - RAND_R * (seed / RAND_Q);
+    if result <= 0 {
+        result += RAND_M;
+    }
+    result
+}
+
+/// The spec's `init(lSeed)`: the permutation and the four gradient tables,
+/// before the mirror copy into the upper half, which the composed texture
+/// makes unnecessary (see [`lattice_texels`]).
+fn build_lattice(seed: i32) -> ([u8; B_SIZE], [[[f64; 2]; B_SIZE]; 4]) {
+    let mut seed = setup_seed(seed as i64);
+    let mut selector = [0u8; B_SIZE];
+    let mut gradient = [[[0.0f64; 2]; B_SIZE]; 4];
+    for table in gradient.iter_mut() {
+        for (i, g) in table.iter_mut().enumerate() {
+            selector[i] = i as u8;
+            for component in g.iter_mut() {
+                seed = random(seed);
+                *component = ((seed % (2 * B_SIZE as i64)) - B_SIZE as i64) as f64 / B_SIZE as f64;
+            }
+            let len = (g[0] * g[0] + g[1] * g[1]).sqrt();
+            g[0] /= len;
+            g[1] /= len;
+        }
+    }
+    // `while (--i)`: swap entries 255 down to 1 with a random lower slot.
+    for i in (1..B_SIZE).rev() {
+        let k = selector[i];
+        seed = random(seed);
+        let j = (seed % B_SIZE as i64) as usize;
+        selector[i] = selector[j];
+        selector[j] = k;
+    }
+    (selector, gradient)
+}
+
+/// RGBA8 texels of the composed lattice for `seed`, row-major,
+/// [`LATTICE_WIDTH`] x [`LATTICE_HEIGHT`].
+///
+/// Texel `(bx + 256 * pair, by)` holds the gradients the spec's `noise2`
+/// reaches at lattice corner `(bx, by)` for channels `2 * pair` (in `r, g`)
+/// and `2 * pair + 1` (in `b, a`): `gradient[channel][selector[selector[bx] +
+/// by]]`. Indexing the mirrored upper half of the spec's tables, where
+/// `selector[i + by]` runs up to index 510, is the same as indexing
+/// `selector[(i + by) & 255]` in the lower half, which is what is stored.
+///
+/// Each gradient component is a unit-vector coordinate in `[-1, 1]` stored
+/// as `round((g + 1) / 2 * 255)`; the shader decodes `texel * 2 - 1`. That
+/// quantizes to 1/255 per component, which bounds the noise sum's deviation
+/// from the double-precision reference below 2/255 for any octave count and
+/// keeps the lattice at one fetch per corner per channel pair on GLES 2.0,
+/// which has no float textures to lean on.
+pub(crate) fn lattice_texels(seed: i32) -> Vec<RGBA8> {
+    let (selector, gradient) = build_lattice(seed);
+    let encode = |g: f64| ((g + 1.0) / 2.0 * 255.0).round() as u8;
+    let mut texels = vec![RGBA8::default(); LATTICE_WIDTH * LATTICE_HEIGHT];
+    for by in 0..B_SIZE {
+        for bx in 0..B_SIZE {
+            let corner = selector[(selector[bx] as usize + by) & 0xff] as usize;
+            for pair in 0..2 {
+                let g0 = gradient[2 * pair][corner];
+                let g1 = gradient[2 * pair + 1][corner];
+                texels[by * LATTICE_WIDTH + bx + pair * B_SIZE] =
+                    RGBA8::new(encode(g0[0]), encode(g0[1]), encode(g1[0]), encode(g1[1]));
+            }
+        }
+    }
+    texels
+}
+
+/// The image flags a lattice texture is created with: it is sampled by texel
+/// index, so nearest filtering, and it holds table data rather than color,
+/// so no premultiplication convention applies.
+pub(crate) fn lattice_flags() -> ImageFlags {
+    ImageFlags::NEAREST
+}
+
+/// Wraps lattice texels as an image source for upload.
+pub(crate) fn lattice_source(texels: &[RGBA8]) -> ImageSource<'_> {
+    ImageSource::Rgba(imgref::ImgRef::new(texels, LATTICE_WIDTH, LATTICE_HEIGHT))
+}
+
+/// Per-pass turbulence parameters in the form the shader consumes: the
+/// frequencies after the stitching adjustment, and the stitch wrap
+/// thresholds without the spec's `PerlinN` (4096) offset, which the shader
+/// does not need because it uses `floor` and `mod` where the reference code
+/// truncates and masks integers.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub(crate) struct PassParams {
+    pub base_frequency: [f32; 2],
+    pub stitching: bool,
+    /// `[width, height, wrap_x, wrap_y]` of the first octave's stitch tile in
+    /// lattice units; all zero when not stitching.
+    pub stitch: [f32; 4],
+}
+
+/// Derives the shader parameters for a pass whose stitch tile is
+/// `tile_size` noise units at `tile_origin`.
+///
+/// With stitching, the base frequencies are adjusted to an integral number
+/// of periods across the tile exactly as the spec's `turbulence()` does
+/// before it computes the wrap positions. Without stitching the frequencies
+/// are used as given, negative ones as zero.
+pub(crate) fn pass_params(
+    base_frequency: [f32; 2],
+    stitch_tiles: bool,
+    tile_origin: [f32; 2],
+    tile_size: [f32; 2],
+) -> PassParams {
+    let mut freq = [base_frequency[0].max(0.0) as f64, base_frequency[1].max(0.0) as f64];
+    if !stitch_tiles || !tile_size.iter().all(|size| size.is_finite() && *size > 0.0) {
+        return PassParams {
+            base_frequency: [freq[0] as f32, freq[1] as f32],
+            stitching: false,
+            stitch: [0.0; 4],
+        };
+    }
+    let tile = [tile_size[0] as f64, tile_size[1] as f64];
+    for axis in 0..2 {
+        if freq[axis] != 0.0 {
+            let lo = (tile[axis] * freq[axis]).floor() / tile[axis];
+            let hi = (tile[axis] * freq[axis]).ceil() / tile[axis];
+            freq[axis] = if freq[axis] / lo < hi / freq[axis] { lo } else { hi };
+        }
+    }
+    let width = (tile[0] * freq[0] + 0.5).floor();
+    let height = (tile[1] * freq[1] + 0.5).floor();
+    // The spec's `wrapX = (fTileX * fBaseFreqX + PerlinN) + nWidth`, compared
+    // against the integer-truncated `x * freq + PerlinN`; both sides carry the
+    // same 4096, so the shader compares `floor(x * freq)` against this instead.
+    let wrap_x = (tile_origin[0] as f64 * freq[0]).floor() + width;
+    let wrap_y = (tile_origin[1] as f64 * freq[1]).floor() + height;
+    PassParams {
+        base_frequency: [freq[0] as f32, freq[1] as f32],
+        stitching: true,
+        stitch: [width as f32, height as f32, wrap_x as f32, wrap_y as f32],
+    }
+}
+
+/// The 20 shader parameter slots for a turbulence pass over a `width` x
+/// `height` output (see [`ImageFilter::single_pass`]).
+///
+/// Layout: `[0..6]` the inverse of the noise-to-pixel transform, so the
+/// shader can map each pixel back into noise space; `[6..8]` the (stitch-
+/// adjusted) base frequency; `[8]` the octave count; `[9]` 1 for
+/// `fractalNoise`, 0 for `turbulence`; `[10..14]` the stitch tile's width,
+/// height and wrap thresholds; `[14]` 1 when stitching. The stitch tile is
+/// the output image mapped into noise space - the SVG default of the
+/// primitive subregion being the whole filter region.
+pub(crate) fn shader_slots(filter: &ImageFilter, width: f32, height: f32) -> [f32; 20] {
+    let ImageFilter::Turbulence {
+        base_frequency,
+        num_octaves,
+        stitch_tiles,
+        kind,
+        transform,
+        ..
+    } = *filter
+    else {
+        debug_assert!(false, "shader_slots is only meaningful for ImageFilter::Turbulence");
+        return [0.0; 20];
+    };
+    let inverse = transform.inverse();
+    let corners =
+        [(0.0, 0.0), (width, 0.0), (0.0, height), (width, height)].map(|(x, y)| inverse.transform_point(x, y));
+    let min_x = corners.iter().map(|c| c.0).fold(f32::INFINITY, f32::min);
+    let min_y = corners.iter().map(|c| c.1).fold(f32::INFINITY, f32::min);
+    let max_x = corners.iter().map(|c| c.0).fold(f32::NEG_INFINITY, f32::max);
+    let max_y = corners.iter().map(|c| c.1).fold(f32::NEG_INFINITY, f32::max);
+    let pass = pass_params(
+        base_frequency,
+        stitch_tiles,
+        [min_x, min_y],
+        [max_x - min_x, max_y - min_y],
+    );
+
+    let mut slots = [0.0f32; 20];
+    slots[..6].copy_from_slice(&inverse.0);
+    slots[6..8].copy_from_slice(&pass.base_frequency);
+    slots[8] = num_octaves.min(MAX_OCTAVES) as f32;
+    slots[9] = match kind {
+        TurbulenceKind::FractalNoise => 1.0,
+        TurbulenceKind::Turbulence => 0.0,
+    };
+    slots[10..14].copy_from_slice(&pass.stitch);
+    slots[14] = if pass.stitching { 1.0 } else { 0.0 };
+    slots
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Transform2D;
+
+    /// The spec's own check value for its generator: from seed 1, the
+    /// 10,000th number is 1043618065.
+    #[test]
+    fn prng_matches_the_specifications_check_value() {
+        let mut seed = setup_seed(1);
+        for _ in 0..10_000 {
+            seed = random(seed);
+        }
+        assert_eq!(seed, 1043618065);
+    }
+
+    #[test]
+    fn lattice_is_a_permutation_of_unit_gradients() {
+        let (selector, gradient) = build_lattice(7);
+        let mut seen = [false; B_SIZE];
+        for &s in &selector {
+            assert!(!seen[s as usize], "selector repeats {s}");
+            seen[s as usize] = true;
+        }
+        for table in &gradient {
+            for g in table {
+                let len = (g[0] * g[0] + g[1] * g[1]).sqrt();
+                assert!((len - 1.0).abs() < 1e-12, "gradient not unit length: {len}");
+            }
+        }
+        // Non-positive seeds are remapped by setup_seed, not rejected.
+        let _ = build_lattice(0);
+        let _ = build_lattice(-5);
+        assert_ne!(build_lattice(7).0, build_lattice(11).0);
+    }
+
+    #[test]
+    fn texels_resolve_the_composed_permutation() {
+        let seed = 3;
+        let (selector, gradient) = build_lattice(seed);
+        let texels = lattice_texels(seed);
+        assert_eq!(texels.len(), LATTICE_WIDTH * LATTICE_HEIGHT);
+        let decode = |b: u8| b as f64 / 255.0 * 2.0 - 1.0;
+        for (bx, by) in [(0usize, 0usize), (17, 200), (255, 255), (128, 1)] {
+            let corner = selector[(selector[bx] as usize + by) & 0xff] as usize;
+            for pair in 0..2 {
+                let t = texels[by * LATTICE_WIDTH + bx + pair * B_SIZE];
+                assert!((decode(t.r) - gradient[2 * pair][corner][0]).abs() <= 1.0 / 255.0);
+                assert!((decode(t.g) - gradient[2 * pair][corner][1]).abs() <= 1.0 / 255.0);
+                assert!((decode(t.b) - gradient[2 * pair + 1][corner][0]).abs() <= 1.0 / 255.0);
+                assert!((decode(t.a) - gradient[2 * pair + 1][corner][1]).abs() <= 1.0 / 255.0);
+            }
+        }
+    }
+
+    #[test]
+    fn stitching_snaps_frequency_to_whole_periods_across_the_tile() {
+        // 0.05 over a 64-wide tile is 3.2 periods; the nearer ratio is 3/64.
+        let p = pass_params([0.05, 0.05], true, [0.0, 0.0], [64.0, 64.0]);
+        assert!(p.stitching);
+        assert!((p.base_frequency[0] - 3.0 / 64.0).abs() < 1e-6);
+        assert_eq!(p.stitch, [3.0, 3.0, 3.0, 3.0]);
+        // The tile origin shifts the wrap thresholds by its lattice position.
+        let q = pass_params([0.05, 0.05], true, [100.0, 0.0], [64.0, 64.0]);
+        assert_eq!(q.stitch[2], (100.0f64 * 3.0 / 64.0).floor() as f32 + 3.0);
+        // No stitching leaves the frequencies alone and zeroes the tile.
+        let n = pass_params([0.05, 0.07], false, [0.0, 0.0], [64.0, 64.0]);
+        assert!(!n.stitching);
+        assert_eq!(n.base_frequency, [0.05, 0.07]);
+        assert_eq!(n.stitch, [0.0; 4]);
+        // Negative frequencies are treated as zero, as browsers do.
+        assert_eq!(
+            pass_params([-1.0, 0.1], false, [0.0; 2], [1.0; 2]).base_frequency[0],
+            0.0
+        );
+    }
+
+    #[test]
+    fn slots_carry_the_inverse_transform_and_the_image_as_tile() {
+        let filter = ImageFilter::Turbulence {
+            base_frequency: [0.05, 0.05],
+            num_octaves: 99,
+            seed: 1,
+            stitch_tiles: true,
+            kind: TurbulenceKind::FractalNoise,
+            transform: Transform2D::scaling(2.0, 2.0),
+        };
+        let s = shader_slots(&filter, 128.0, 128.0);
+        assert_eq!(&s[..6], &[0.5, 0.0, 0.0, 0.5, 0.0, 0.0]);
+        // The 128px image is a 64-unit tile in noise space: 3 periods of 3/64.
+        assert!((s[6] - 3.0 / 64.0).abs() < 1e-6);
+        assert_eq!(s[8], MAX_OCTAVES as f32);
+        assert_eq!(s[9], 1.0);
+        assert_eq!(&s[10..15], &[3.0, 3.0, 3.0, 3.0, 1.0]);
+    }
+}

--- a/tests/color_transfer_wgpu.rs
+++ b/tests/color_transfer_wgpu.rs
@@ -1,0 +1,170 @@
+//! Headless GPU tests for the color-space transfer filters
+//! (`ImageFilter::LinearRgbToSrgb` / `SrgbToLinearRgb`): the sRGB transfer
+//! curve of IEC 61966-2-1, checked at known points, on alpha, and as a
+//! round trip that the chain folds away.
+#![cfg(feature = "wgpu")]
+
+use femtovg::{Color, ImageFilter, ImageFlags, Paint, Path, PixelFormat, RenderTarget};
+
+mod common;
+use common::headless_device;
+
+const W: u32 = 16;
+const H: u32 = 16;
+
+/// Fills a source image with `src`, runs `filters` as a chain into a target
+/// under the documented chain convention, draws the target 1:1 onto a
+/// transparent output and returns the centre pixel, premultiplied RGBA8.
+fn chained_center(device: &wgpu::Device, queue: &wgpu::Queue, src: Color, filters: &[ImageFilter]) -> [u8; 4] {
+    let px = common::render_rgba(device, queue, W, H, Color::rgba(0, 0, 0, 0), |canvas| {
+        let source = canvas
+            .create_image_empty(W as usize, H as usize, PixelFormat::Rgba8, ImageFlags::PREMULTIPLIED)
+            .expect("source image");
+        canvas.set_render_target(RenderTarget::Image(source));
+        canvas.clear_rect(0, 0, W, H, src);
+        canvas.set_render_target(RenderTarget::Screen);
+
+        let target = canvas
+            .create_image_empty(
+                W as usize,
+                H as usize,
+                PixelFormat::Rgba8,
+                ImageFlags::PREMULTIPLIED | ImageFlags::FLIP_Y | ImageFlags::NEAREST,
+            )
+            .expect("target image");
+        canvas.filter_image_chain(target, filters, source);
+
+        let mut p = Path::new();
+        p.rect(0.0, 0.0, W as f32, H as f32);
+        canvas.fill_path(&p, &Paint::image(target, 0.0, 0.0, W as f32, H as f32, 0.0, 1.0));
+    });
+    let at = (((H / 2) * W + W / 2) * 4) as usize;
+    [px[at], px[at + 1], px[at + 2], px[at + 3]]
+}
+
+fn srgb_to_linear(x: f64) -> f64 {
+    if x <= 0.04045 {
+        x / 12.92
+    } else {
+        ((x + 0.055) / 1.055).powf(2.4)
+    }
+}
+
+fn linear_to_srgb(x: f64) -> f64 {
+    if x <= 0.0031308 {
+        x * 12.92
+    } else {
+        1.055 * x.powf(1.0 / 2.4) - 0.055
+    }
+}
+
+/// A straight color as the premultiplied RGBA8 the output holds.
+fn rgba8(c: Color) -> [u8; 4] {
+    let q = |v: f32| (v * 255.0).round() as u8;
+    [q(c.r * c.a), q(c.g * c.a), q(c.b * c.a), q(c.a)]
+}
+
+fn close(got: u8, want: f64, what: &str) {
+    let want = want * 255.0;
+    assert!(
+        (got as f64 - want).abs() <= 1.5,
+        "{what}: got {got}, expected {want:.2}"
+    );
+}
+
+/// Opaque mid-tones through each direction land on the curve.
+#[test]
+fn transfer_curves_match_iec_61966() {
+    let Some((device, queue)) = headless_device() else {
+        return;
+    };
+    for (r, g, b) in [(0.5, 0.25, 0.75), (0.02, 0.9, 0.1), (0.0, 1.0, 0.5)] {
+        let src = Color::rgbf(r, g, b);
+        let to_srgb = chained_center(&device, &queue, src, &[ImageFilter::LinearRgbToSrgb]);
+        close(to_srgb[0], linear_to_srgb(r as f64), "linear->sRGB r");
+        close(to_srgb[1], linear_to_srgb(g as f64), "linear->sRGB g");
+        close(to_srgb[2], linear_to_srgb(b as f64), "linear->sRGB b");
+        assert_eq!(to_srgb[3], 255);
+
+        let to_linear = chained_center(&device, &queue, src, &[ImageFilter::SrgbToLinearRgb]);
+        close(to_linear[0], srgb_to_linear(r as f64), "sRGB->linear r");
+        close(to_linear[1], srgb_to_linear(g as f64), "sRGB->linear g");
+        close(to_linear[2], srgb_to_linear(b as f64), "sRGB->linear b");
+        assert_eq!(to_linear[3], 255);
+    }
+    // The endpoints are fixed points of both curves.
+    for c in [Color::black(), Color::white()] {
+        let (a, b) = (
+            chained_center(&device, &queue, c, &[ImageFilter::LinearRgbToSrgb]),
+            chained_center(&device, &queue, c, &[ImageFilter::SrgbToLinearRgb]),
+        );
+        let want = rgba8(c);
+        assert_eq!(a, want);
+        assert_eq!(b, want);
+    }
+}
+
+/// The curve applies to unpremultiplied color, so a half-transparent pixel
+/// converts the same color as its opaque twin and keeps its alpha.
+#[test]
+fn transfer_is_on_unpremultiplied_color_and_keeps_alpha() {
+    let Some((device, queue)) = headless_device() else {
+        return;
+    };
+    let opaque = chained_center(
+        &device,
+        &queue,
+        Color::rgbf(0.5, 0.2, 0.8),
+        &[ImageFilter::LinearRgbToSrgb],
+    );
+    let half = chained_center(
+        &device,
+        &queue,
+        Color::rgbaf(0.5, 0.2, 0.8, 0.5),
+        &[ImageFilter::LinearRgbToSrgb],
+    );
+    assert!((half[3] as i32 - 128).abs() <= 1, "alpha changed: {}", half[3]);
+    for c in 0..3 {
+        // Premultiplied output: half the opaque value, within rounding.
+        let want = opaque[c] as f64 * half[3] as f64 / 255.0;
+        assert!(
+            (half[c] as f64 - want).abs() <= 2.0,
+            "channel {c}: got {}, expected {want:.1} (opaque {})",
+            half[c],
+            opaque[c]
+        );
+    }
+}
+
+/// A transfer followed by its inverse is folded to the identity pass, so the
+/// input comes back exactly - no 8-bit round trip through linear space.
+#[test]
+fn transfer_round_trip_folds_to_identity() {
+    let Some((device, queue)) = headless_device() else {
+        return;
+    };
+    let src = Color::rgbf(0.02, 0.5, 0.97);
+    let want = rgba8(src);
+    let a = chained_center(
+        &device,
+        &queue,
+        src,
+        &[ImageFilter::SrgbToLinearRgb, ImageFilter::LinearRgbToSrgb],
+    );
+    let b = chained_center(
+        &device,
+        &queue,
+        src,
+        &[ImageFilter::LinearRgbToSrgb, ImageFilter::SrgbToLinearRgb],
+    );
+    assert_eq!(a, want);
+    assert_eq!(b, want);
+    // The fold is the documented no-op, not a coincidence of the shader.
+    assert!(matches!(
+        ImageFilter::SrgbToLinearRgb.fold_with(ImageFilter::LinearRgbToSrgb),
+        Some(ImageFilter::ColorMatrix { .. })
+    ));
+    assert!(ImageFilter::LinearRgbToSrgb
+        .fold_with(ImageFilter::LinearRgbToSrgb)
+        .is_none());
+}

--- a/tests/turbulence_wgpu.rs
+++ b/tests/turbulence_wgpu.rs
@@ -1,0 +1,677 @@
+//! Headless GPU tests for `ImageFilter::Turbulence` (SVG `feTurbulence`).
+//!
+//! Ground truth is a direct port of the reference implementation in the SVG
+//! 1.1 specification (Filter Effects, section 15.19), which Chromium (Skia's
+//! `SkPerlinNoiseShader`) and Firefox implement to the letter - including its
+//! Park-Miller PRNG and its lattice construction - which is why two browsers
+//! agree on every noise pixel. The GPU pass has to reproduce that same
+//! lattice and arithmetic, so the tests compare it against the port, not
+//! against a browser screenshot.
+#![cfg(feature = "wgpu")]
+
+mod common;
+use common::headless_device;
+
+// ---------------------------------------------------------------------------
+// Reference implementation: SVG 1.1 section 15.19, transcribed. Kept in f64
+// as the spec has it; the GPU runs f32 and the tests allow for that.
+// ---------------------------------------------------------------------------
+
+const RAND_M: i64 = 2147483647; // 2**31 - 1
+const RAND_A: i64 = 16807; // 7**5; primitive root of m
+const RAND_Q: i64 = 127773; // m / a
+const RAND_R: i64 = 2836; // m % a
+const B_SIZE: usize = 0x100;
+const BM: i64 = 0xff;
+const PERLIN_N: f64 = 0x1000 as f64;
+
+fn setup_seed(mut seed: i64) -> i64 {
+    if seed <= 0 {
+        seed = -(seed % (RAND_M - 1)) + 1;
+    }
+    if seed > RAND_M - 1 {
+        seed = RAND_M - 1;
+    }
+    seed
+}
+
+fn random(seed: i64) -> i64 {
+    let mut result = RAND_A * (seed % RAND_Q) - RAND_R * (seed / RAND_Q);
+    if result <= 0 {
+        result += RAND_M;
+    }
+    result
+}
+
+struct Lattice {
+    selector: [usize; B_SIZE + B_SIZE + 2],
+    gradient: [[[f64; 2]; B_SIZE + B_SIZE + 2]; 4],
+}
+
+fn init(seed: i64) -> Lattice {
+    let mut seed = setup_seed(seed);
+    let mut lat = Lattice {
+        selector: [0; B_SIZE + B_SIZE + 2],
+        gradient: [[[0.0; 2]; B_SIZE + B_SIZE + 2]; 4],
+    };
+    for k in 0..4 {
+        for i in 0..B_SIZE {
+            lat.selector[i] = i;
+            for j in 0..2 {
+                seed = random(seed);
+                lat.gradient[k][i][j] =
+                    ((seed % (B_SIZE as i64 + B_SIZE as i64)) - B_SIZE as i64) as f64 / B_SIZE as f64;
+            }
+            let s =
+                (lat.gradient[k][i][0] * lat.gradient[k][i][0] + lat.gradient[k][i][1] * lat.gradient[k][i][1]).sqrt();
+            lat.gradient[k][i][0] /= s;
+            lat.gradient[k][i][1] /= s;
+        }
+    }
+    // `while (--i)` from BSize: shuffle indices BSize-1 down to 1.
+    let mut i = B_SIZE;
+    loop {
+        i -= 1;
+        if i == 0 {
+            break;
+        }
+        let k = lat.selector[i];
+        seed = random(seed);
+        let j = (seed % B_SIZE as i64) as usize;
+        lat.selector[i] = lat.selector[j];
+        lat.selector[j] = k;
+    }
+    for i in 0..B_SIZE + 2 {
+        lat.selector[B_SIZE + i] = lat.selector[i];
+        for k in 0..4 {
+            for j in 0..2 {
+                lat.gradient[k][B_SIZE + i][j] = lat.gradient[k][i][j];
+            }
+        }
+    }
+    lat
+}
+
+fn s_curve(t: f64) -> f64 {
+    t * t * (3.0 - 2.0 * t)
+}
+fn lerp(t: f64, a: f64, b: f64) -> f64 {
+    a + t * (b - a)
+}
+
+#[derive(Clone, Copy)]
+struct Stitch {
+    width: i64,
+    height: i64,
+    wrap_x: i64,
+    wrap_y: i64,
+}
+
+fn noise2(lat: &Lattice, channel: usize, vec: [f64; 2], stitch: Option<Stitch>) -> f64 {
+    let t = vec[0] + PERLIN_N;
+    let mut bx0 = t as i64;
+    let mut bx1 = bx0 + 1;
+    let rx0 = t - (t as i64) as f64;
+    let rx1 = rx0 - 1.0;
+    let t = vec[1] + PERLIN_N;
+    let mut by0 = t as i64;
+    let mut by1 = by0 + 1;
+    let ry0 = t - (t as i64) as f64;
+    let ry1 = ry0 - 1.0;
+    if let Some(s) = stitch {
+        if bx0 >= s.wrap_x {
+            bx0 -= s.width;
+        }
+        if bx1 >= s.wrap_x {
+            bx1 -= s.width;
+        }
+        if by0 >= s.wrap_y {
+            by0 -= s.height;
+        }
+        if by1 >= s.wrap_y {
+            by1 -= s.height;
+        }
+    }
+    let bx0 = (bx0 & BM) as usize;
+    let bx1 = (bx1 & BM) as usize;
+    let by0 = (by0 & BM) as usize;
+    let by1 = (by1 & BM) as usize;
+    let i = lat.selector[bx0];
+    let j = lat.selector[bx1];
+    let b00 = lat.selector[i + by0];
+    let b10 = lat.selector[j + by0];
+    let b01 = lat.selector[i + by1];
+    let b11 = lat.selector[j + by1];
+    let sx = s_curve(rx0);
+    let sy = s_curve(ry0);
+    let g = &lat.gradient[channel];
+    let u = rx0 * g[b00][0] + ry0 * g[b00][1];
+    let v = rx1 * g[b10][0] + ry0 * g[b10][1];
+    let a = lerp(sx, u, v);
+    let u = rx0 * g[b01][0] + ry1 * g[b01][1];
+    let v = rx1 * g[b11][0] + ry1 * g[b11][1];
+    let b = lerp(sx, u, v);
+    lerp(sy, a, b)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn turbulence(
+    lat: &Lattice,
+    channel: usize,
+    point: [f64; 2],
+    mut base_freq: [f64; 2],
+    num_octaves: u32,
+    fractal_sum: bool,
+    stitch_tile: Option<[f64; 4]>,
+) -> f64 {
+    let mut stitch = None;
+    if let Some([tx, ty, tw, th]) = stitch_tile {
+        // Adjust the base frequencies so the tile borders are continuous.
+        for (axis, size) in [(0, tw), (1, th)] {
+            let f = base_freq[axis];
+            if f != 0.0 {
+                let lo = (size * f).floor() / size;
+                let hi = (size * f).ceil() / size;
+                base_freq[axis] = if f / lo < hi / f { lo } else { hi };
+            }
+        }
+        let width = (tw * base_freq[0] + 0.5) as i64;
+        let height = (th * base_freq[1] + 0.5) as i64;
+        stitch = Some(Stitch {
+            width,
+            wrap_x: (tx * base_freq[0] + PERLIN_N) as i64 + width,
+            height,
+            wrap_y: (ty * base_freq[1] + PERLIN_N) as i64 + height,
+        });
+    }
+    let mut sum = 0.0;
+    let mut vec = [point[0] * base_freq[0], point[1] * base_freq[1]];
+    let mut ratio = 1.0;
+    for _ in 0..num_octaves {
+        let n = noise2(lat, channel, vec, stitch);
+        sum += if fractal_sum { n } else { n.abs() } / ratio;
+        vec[0] *= 2.0;
+        vec[1] *= 2.0;
+        ratio *= 2.0;
+        if let Some(s) = stitch.as_mut() {
+            s.width *= 2;
+            s.wrap_x = 2 * s.wrap_x - PERLIN_N as i64;
+            s.height *= 2;
+            s.wrap_y = 2 * s.wrap_y - PERLIN_N as i64;
+        }
+    }
+    sum
+}
+
+/// Unpremultiplied RGBA in [0, 1] for one pixel, per the spec's color mapping:
+/// fractalNoise maps `(sum + 1) / 2`, turbulence uses `sum` directly.
+fn reference_pixel(
+    lat: &Lattice,
+    point: [f64; 2],
+    base_freq: [f64; 2],
+    num_octaves: u32,
+    fractal: bool,
+    stitch_tile: Option<[f64; 4]>,
+) -> [f64; 4] {
+    let mut out = [0.0; 4];
+    for (c, o) in out.iter_mut().enumerate() {
+        let v = turbulence(lat, c, point, base_freq, num_octaves, fractal, stitch_tile);
+        *o = (if fractal { (v + 1.0) / 2.0 } else { v }).clamp(0.0, 1.0);
+    }
+    out
+}
+
+// ---------------------------------------------------------------------------
+
+/// The spec's own check value for its PRNG: from seed 1, the 10,000th number
+/// is 1043618065. If this fails nothing downstream can match a browser.
+#[test]
+fn prng_matches_the_specifications_check_value() {
+    let mut seed = setup_seed(1);
+    for _ in 0..10_000 {
+        seed = random(seed);
+    }
+    assert_eq!(seed, 1043618065);
+}
+
+/// The lattice is a deterministic function of the seed, gradients are unit
+/// length, and the upper half mirrors the lower half as the spec lays it out.
+#[test]
+fn lattice_is_deterministic_and_well_formed() {
+    let a = init(7);
+    let b = init(7);
+    assert_eq!(a.selector, b.selector);
+    for k in 0..4 {
+        for i in 0..B_SIZE + B_SIZE + 2 {
+            assert_eq!(a.gradient[k][i], b.gradient[k][i]);
+            let len = (a.gradient[k][i][0].powi(2) + a.gradient[k][i][1].powi(2)).sqrt();
+            assert!((len - 1.0).abs() < 1e-12, "gradient {k}/{i} not unit: {len}");
+        }
+    }
+    for i in 0..B_SIZE + 2 {
+        assert_eq!(a.selector[B_SIZE + i], a.selector[i]);
+    }
+    // A permutation of 0..256 in the lower half.
+    let mut seen = [false; B_SIZE];
+    for &s in &a.selector[..B_SIZE] {
+        assert!(!seen[s]);
+        seen[s] = true;
+    }
+    // Different seeds give different lattices (seed 0 and 1 map to the same
+    // start per setup_seed, so compare 7 against 11).
+    let c = init(11);
+    assert_ne!(a.selector, c.selector);
+}
+
+/// fractalNoise is centered on 0.5 and stays inside [0, 1]; turbulence is
+/// non-negative. Sanity on the reference itself before it judges the GPU.
+#[test]
+fn reference_noise_has_the_expected_range() {
+    let lat = init(1);
+    let mut lo = 1.0f64;
+    let mut hi = 0.0f64;
+    let mut sum = 0.0;
+    let n = 64 * 64;
+    for y in 0..64 {
+        for x in 0..64 {
+            let p = reference_pixel(&lat, [x as f64, y as f64], [0.05, 0.05], 3, true, None);
+            lo = lo.min(p[0]);
+            hi = hi.max(p[0]);
+            sum += p[0];
+            let t = reference_pixel(&lat, [x as f64, y as f64], [0.05, 0.05], 3, false, None);
+            assert!(t[0] >= 0.0);
+        }
+    }
+    let mean = sum / n as f64;
+    assert!(lo >= 0.0 && hi <= 1.0);
+    assert!((mean - 0.5).abs() < 0.05, "fractalNoise mean {mean}, expected ~0.5");
+    assert!(hi - lo > 0.2, "noise is flat: {lo}..{hi}");
+}
+
+// ---------------------------------------------------------------------------
+// GPU pass against the reference.
+// ---------------------------------------------------------------------------
+
+use femtovg::{Color, ImageFilter, ImageFlags, Paint, Path, PixelFormat, Transform2D, TurbulenceKind};
+
+fn noise_with(
+    kind: TurbulenceKind,
+    base_frequency: [f32; 2],
+    num_octaves: u32,
+    seed: i32,
+    stitch_tiles: bool,
+    transform: Transform2D,
+) -> ImageFilter {
+    ImageFilter::Turbulence {
+        base_frequency,
+        num_octaves,
+        seed,
+        stitch_tiles,
+        kind,
+        transform,
+    }
+}
+
+fn noise(kind: TurbulenceKind, base_frequency: [f32; 2], num_octaves: u32, seed: i32) -> ImageFilter {
+    noise_with(kind, base_frequency, num_octaves, seed, false, Transform2D::identity())
+}
+
+/// Runs `filters` as a chain over a `w` x `h` transparent source under the
+/// documented target convention, draws the target 1:1 onto a transparent
+/// output and returns its premultiplied RGBA8 pixels, rows top to bottom.
+fn render_chain(device: &wgpu::Device, queue: &wgpu::Queue, w: u32, h: u32, filters: &[ImageFilter]) -> Vec<u8> {
+    common::render_rgba(device, queue, w, h, Color::rgba(0, 0, 0, 0), |canvas| {
+        let source = canvas
+            .create_image_empty(w as usize, h as usize, PixelFormat::Rgba8, ImageFlags::PREMULTIPLIED)
+            .expect("source image");
+        let target = canvas
+            .create_image_empty(
+                w as usize,
+                h as usize,
+                PixelFormat::Rgba8,
+                ImageFlags::PREMULTIPLIED | ImageFlags::FLIP_Y | ImageFlags::NEAREST,
+            )
+            .expect("target image");
+        canvas.filter_image_chain(target, filters, source);
+        let mut p = Path::new();
+        p.rect(0.0, 0.0, w as f32, h as f32);
+        canvas.fill_path(&p, &Paint::image(target, 0.0, 0.0, w as f32, h as f32, 0.0, 1.0));
+    })
+}
+
+fn at(px: &[u8], w: u32, x: u32, y: u32) -> [u8; 4] {
+    let i = ((y * w + x) * 4) as usize;
+    [px[i], px[i + 1], px[i + 2], px[i + 3]]
+}
+
+/// The reference pixel as the premultiplied RGBA8 the GPU pass stores.
+fn reference_rgba8(p: [f64; 4]) -> [f64; 4] {
+    [
+        p[0] * p[3] * 255.0,
+        p[1] * p[3] * 255.0,
+        p[2] * p[3] * 255.0,
+        p[3] * 255.0,
+    ]
+}
+
+/// Compares every pixel of a render against the reference and returns the
+/// worst and mean absolute channel error in 8-bit steps.
+fn compare(px: &[u8], w: u32, h: u32, reference: impl Fn(u32, u32) -> [f64; 4]) -> (f64, f64) {
+    let mut worst = 0.0f64;
+    let mut total = 0.0f64;
+    for y in 0..h {
+        for x in 0..w {
+            let got = at(px, w, x, y);
+            let want = reference_rgba8(reference(x, y));
+            for c in 0..4 {
+                let err = (got[c] as f64 - want[c]).abs();
+                worst = worst.max(err);
+                total += err;
+            }
+        }
+    }
+    (worst, total / (w * h * 4) as f64)
+}
+
+/// The lattice stores gradients at 8 bits (see src/turbulence.rs), which
+/// bounds the noise sum's deviation below 2/255 before the output rounds;
+/// premultiplying two such channels adds a little more. Anything beyond this
+/// is a structural mistake (wrong corner, wrong orientation, wrong octave),
+/// which shows up as errors in the tens.
+const LATTICE_TOLERANCE: f64 = 4.0;
+
+#[test]
+fn fractal_noise_matches_the_reference() {
+    let Some((device, queue)) = headless_device() else {
+        return;
+    };
+    let (w, h) = (64, 48);
+    let lat = init(1);
+    let px = render_chain(
+        &device,
+        &queue,
+        w,
+        h,
+        &[noise(TurbulenceKind::FractalNoise, [0.05, 0.08], 3, 1)],
+    );
+    let (worst, mean) = compare(&px, w, h, |x, y| {
+        reference_pixel(&lat, [x as f64, y as f64], [0.05, 0.08], 3, true, None)
+    });
+    println!("fractalNoise vs reference: worst {worst:.1}/255, mean {mean:.3}/255");
+    assert!(worst <= LATTICE_TOLERANCE, "worst channel error {worst}/255");
+    assert!(mean <= 1.0, "mean channel error {mean}/255");
+    // And it is noise, not a constant: the alpha channel varies across the image.
+    let alphas: std::collections::BTreeSet<u8> = (0..w).map(|x| at(&px, w, x, h / 2)[3]).collect();
+    assert!(alphas.len() > 8, "alpha barely varies: {alphas:?}");
+}
+
+#[test]
+fn turbulence_matches_the_reference() {
+    let Some((device, queue)) = headless_device() else {
+        return;
+    };
+    let (w, h) = (64, 48);
+    let lat = init(7);
+    let px = render_chain(
+        &device,
+        &queue,
+        w,
+        h,
+        &[noise(TurbulenceKind::Turbulence, [0.1, 0.1], 4, 7)],
+    );
+    let (worst, mean) = compare(&px, w, h, |x, y| {
+        reference_pixel(&lat, [x as f64, y as f64], [0.1, 0.1], 4, false, None)
+    });
+    println!("turbulence vs reference: worst {worst:.1}/255, mean {mean:.3}/255");
+    assert!(worst <= LATTICE_TOLERANCE, "worst channel error {worst}/255");
+    assert!(mean <= 1.0, "mean channel error {mean}/255");
+}
+
+/// Two seeds give different noise; the same seed gives the same noise again
+/// (the lattice cache hands back the same texture).
+#[test]
+fn seed_selects_the_lattice() {
+    let Some((device, queue)) = headless_device() else {
+        return;
+    };
+    let (w, h) = (32, 32);
+    let a = render_chain(
+        &device,
+        &queue,
+        w,
+        h,
+        &[noise(TurbulenceKind::FractalNoise, [0.1, 0.1], 2, 3)],
+    );
+    let b = render_chain(
+        &device,
+        &queue,
+        w,
+        h,
+        &[noise(TurbulenceKind::FractalNoise, [0.1, 0.1], 2, 4)],
+    );
+    let a2 = render_chain(
+        &device,
+        &queue,
+        w,
+        h,
+        &[noise(TurbulenceKind::FractalNoise, [0.1, 0.1], 2, 3)],
+    );
+    assert_eq!(a, a2);
+    let differing = a.iter().zip(&b).filter(|(x, y)| x != y).count();
+    assert!(
+        differing > a.len() / 2,
+        "seeds 3 and 4 differ in only {differing} bytes"
+    );
+}
+
+/// The transform maps noise space onto pixels: under a 2x scale, output pixel
+/// (2x, 2y) samples the same noise point as (x, y) does at identity, and
+/// under a translation the pattern moves with it.
+#[test]
+fn transform_scales_and_moves_the_noise() {
+    let Some((device, queue)) = headless_device() else {
+        return;
+    };
+    let (w, h) = (64, 64);
+    let identity = render_chain(
+        &device,
+        &queue,
+        w,
+        h,
+        &[noise(TurbulenceKind::FractalNoise, [0.07, 0.05], 3, 5)],
+    );
+
+    let scaled = noise_with(
+        TurbulenceKind::FractalNoise,
+        [0.07, 0.05],
+        3,
+        5,
+        false,
+        Transform2D::scaling(2.0, 2.0),
+    );
+    let scaled = render_chain(&device, &queue, w, h, &[scaled]);
+    for y in 0..h / 2 {
+        for x in 0..w / 2 {
+            let (want, got) = (at(&identity, w, x, y), at(&scaled, w, 2 * x, 2 * y));
+            for c in 0..4 {
+                assert!(
+                    (want[c] as i32 - got[c] as i32).abs() <= 1,
+                    "scaled ({},{}) = {got:?}, identity ({x},{y}) = {want:?}",
+                    2 * x,
+                    2 * y
+                );
+            }
+        }
+    }
+
+    let moved = noise_with(
+        TurbulenceKind::FractalNoise,
+        [0.07, 0.05],
+        3,
+        5,
+        false,
+        Transform2D::translation(10.0, 6.0),
+    );
+    let moved = render_chain(&device, &queue, w, h, &[moved]);
+    for y in 6..h {
+        for x in 10..w {
+            let (want, got) = (at(&identity, w, x - 10, y - 6), at(&moved, w, x, y));
+            for c in 0..4 {
+                assert!(
+                    (want[c] as i32 - got[c] as i32).abs() <= 1,
+                    "moved ({x},{y}) = {got:?}, identity ({},{}) = {want:?}",
+                    x - 10,
+                    y - 6
+                );
+            }
+        }
+    }
+}
+
+/// stitchTiles: the reference is periodic across the tile once the frequency
+/// is snapped, and the GPU pass reproduces the stitched reference, so the
+/// noise wraps seamlessly at the image edge.
+#[test]
+fn stitching_matches_the_stitched_reference_and_is_periodic() {
+    let Some((device, queue)) = headless_device() else {
+        return;
+    };
+    let (w, h) = (64, 64);
+    let lat = init(2);
+    let tile = Some([0.0, 0.0, w as f64, h as f64]);
+
+    // The oracle's own seam: with the frequency snapped to whole periods and
+    // the lattice wrapped at the tile edge, the noise one tile across (or
+    // down) is the noise at the tile's start, so the edges meet seamlessly.
+    // Unstitched, the same positions are unrelated.
+    for y in [0.0, 5.0, 17.0, 63.0] {
+        let edge = reference_pixel(&lat, [w as f64, y], [0.05, 0.05], 3, true, tile);
+        let start = reference_pixel(&lat, [0.0, y], [0.05, 0.05], 3, true, tile);
+        let unstitched_edge = reference_pixel(&lat, [w as f64, y], [0.05, 0.05], 3, true, None);
+        let unstitched_start = reference_pixel(&lat, [0.0, y], [0.05, 0.05], 3, true, None);
+        for ch in 0..4 {
+            assert!((edge[ch] - start[ch]).abs() < 1e-9, "seam open at y={y}");
+        }
+        assert!(
+            (0..4).any(|ch| (unstitched_edge[ch] - unstitched_start[ch]).abs() > 1e-3),
+            "unstitched noise happens to match at y={y}"
+        );
+    }
+    for x in [0.0, 5.0, 17.0, 63.0] {
+        let edge = reference_pixel(&lat, [x, h as f64], [0.05, 0.05], 3, true, tile);
+        let start = reference_pixel(&lat, [x, 0.0], [0.05, 0.05], 3, true, tile);
+        for ch in 0..4 {
+            assert!((edge[ch] - start[ch]).abs() < 1e-9, "seam open at x={x}");
+        }
+    }
+
+    let stitched = noise_with(
+        TurbulenceKind::FractalNoise,
+        [0.05, 0.05],
+        3,
+        2,
+        true,
+        Transform2D::identity(),
+    );
+    let px = render_chain(&device, &queue, w, h, &[stitched]);
+    let (worst, mean) = compare(&px, w, h, |x, y| {
+        reference_pixel(&lat, [x as f64, y as f64], [0.05, 0.05], 3, true, tile)
+    });
+    println!("stitched fractalNoise vs reference: worst {worst:.1}/255, mean {mean:.3}/255");
+    assert!(worst <= LATTICE_TOLERANCE, "worst channel error {worst}/255");
+
+    // Stitched and unstitched renders differ (the frequency snapped from 0.05
+    // to 3/64 and the lattice wraps), so the flag reached the shader.
+    let plain = render_chain(
+        &device,
+        &queue,
+        w,
+        h,
+        &[noise(TurbulenceKind::FractalNoise, [0.05, 0.05], 3, 2)],
+    );
+    assert_ne!(px, plain);
+}
+
+/// Zero octaves sum nothing: fractalNoise is a flat 50% gray at 50% alpha,
+/// turbulence is transparent black.
+#[test]
+fn zero_octaves_is_the_constant_the_spec_gives() {
+    let Some((device, queue)) = headless_device() else {
+        return;
+    };
+    let (w, h) = (8, 8);
+    let fractal = render_chain(
+        &device,
+        &queue,
+        w,
+        h,
+        &[noise(TurbulenceKind::FractalNoise, [0.1, 0.1], 0, 1)],
+    );
+    let turbulence = render_chain(
+        &device,
+        &queue,
+        w,
+        h,
+        &[noise(TurbulenceKind::Turbulence, [0.1, 0.1], 0, 1)],
+    );
+    for y in 0..h {
+        for x in 0..w {
+            let f = at(&fractal, w, x, y);
+            assert!(
+                (f[3] as i32 - 128).abs() <= 1 && (f[0] as i32 - 64).abs() <= 1,
+                "fractal {f:?}"
+            );
+            assert_eq!(at(&turbulence, w, x, y), [0, 0, 0, 0]);
+        }
+    }
+}
+
+/// The corpus shape: noise, a color matrix that turns one channel into an
+/// opacity under a constant tint, and the linearRGB-to-sRGB transfer that a
+/// default SVG filter ends with. Checked end to end against the reference
+/// pushed through the same arithmetic.
+#[test]
+fn chain_with_matrix_and_transfer_matches_the_reference() {
+    let Some((device, queue)) = headless_device() else {
+        return;
+    };
+    let (w, h) = (48, 48);
+    let lat = init(7);
+    // claude-opus-5's grain matrix: constant warm tint, alpha = 0.9 * red noise.
+    #[rustfmt::skip]
+    let matrix = [
+        0.0, 0.0, 0.0, 0.0, 0.55,
+        0.0, 0.0, 0.0, 0.0, 0.36,
+        0.0, 0.0, 0.0, 0.0, 0.24,
+        0.9, 0.0, 0.0, 0.0, 0.0,
+    ];
+    let px = render_chain(
+        &device,
+        &queue,
+        w,
+        h,
+        &[
+            noise(TurbulenceKind::FractalNoise, [0.85, 0.85], 4, 7),
+            ImageFilter::ColorMatrix { matrix },
+            ImageFilter::LinearRgbToSrgb,
+        ],
+    );
+    let to_srgb = |v: f64| {
+        if v <= 0.0031308 {
+            v * 12.92
+        } else {
+            1.055 * v.powf(1.0 / 2.4) - 0.055
+        }
+    };
+    let (worst, mean) = compare(&px, w, h, |x, y| {
+        let n = reference_pixel(&lat, [x as f64, y as f64], [0.85, 0.85], 4, true, None);
+        // The matrix pass quantizes its output to 8 bits before the transfer.
+        let q = |v: f64| (v * 255.0).round() / 255.0;
+        let a = q((0.9 * n[0]).clamp(0.0, 1.0));
+        [to_srgb(0.55), to_srgb(0.36), to_srgb(0.24), a]
+    });
+    println!("grain chain vs reference: worst {worst:.1}/255, mean {mean:.3}/255");
+    // Three quantizing passes stack, so allow a little more than one.
+    assert!(worst <= LATTICE_TOLERANCE + 2.0, "worst channel error {worst}/255");
+    assert!(mean <= 1.0, "mean channel error {mean}/255");
+}


### PR DESCRIPTION
Adds `ImageFilter::Turbulence`, the SVG `feTurbulence` primitive, generated on the GPU from the algorithm the SVG 1.1 specification gives as reference code (Filter Effects, section 15.19) — and, because that primitive's values are defined in the filter's working color space, `ImageFilter::LinearRgbToSrgb` / `SrgbToLinearRgb`, the sRGB transfer curve as a pass. Independent of the #322 stack; branches off master.

### Why this primitive

#337's corpus data: 13 of the 27 BuseyBench portraits reach for `feTurbulence`, always for a skin-texture or film-grain overlay, and the one file still far off on master — `claude-opus-5.svg`, 3.5% structural with #324's clip paths in place, 4.5% without — is exactly this chain. It is also the cheapest gap on that list to close: a generator, one pass, no extra live buffers.

### Reference grounding

Chromium (Skia's `SkPerlinNoiseShader`) and Firefox both implement the spec's reference code as written — the Park-Miller generator (seed 1 yields 1043618065 as its 10,000th number, the spec's own check value), the 256-entry permutation, the four gradient tables, `noise2`, the octave sum and the `stitchTiles` frequency snap — which is why two browsers agree on every noise pixel. `src/turbulence.rs` transcribes that code; the tests carry a second, independent transcription in f64 as their oracle and compare the GPU output against it pixel by pixel.

Two things the reference code leaves to the implementation, and what this PR does with them:

- **Color space.** SVG runs a filter in `color-interpolation-filters` space, linearRGB by default, and `feTurbulence` generates *in* that space. Probed in Chromium: the same grain filter under the default and under `color-interpolation-filters="sRGB"` differs (mean 221 vs 192 on a 0.5-centered noise), so matching a browser requires the linear-to-sRGB conversion at the end of the chain. Rather than bake a color space into the generator, the transfer curve is its own filter: a chain reproducing a default `<filter>` ends with `LinearRgbToSrgb`, an ordinary image can be blurred the browser way with `[SrgbToLinearRgb, GaussianBlur, LinearRgbToSrgb]`, and an adjacent pair folds to the identity (which is more exact than running it through an 8-bit intermediate).
- **Where a pixel samples the noise.** The reference evaluates at integer pixel positions of the filter raster. `Turbulence` carries a `transform` from noise space to output pixels, and pixel `(x, y)` samples at `transform⁻¹ · (x, y)` — so the pattern scales with the content it decorates instead of sticking to the device grid. That is Firefox's behavior at any zoom (it scales the frequency by the CTM); Chromium additionally snaps the mapped position to whole noise units. At the corpus scale (0.85 cycles per user unit, 5 user units per device pixel) both browsers and this pass all produce decorrelated per-pixel grain, and the structural metric is what agrees.

### Design and cost (the femto budget)

- **The lattice is a texture with the dependent lookup pre-composed.** The spec reaches a gradient through `selector[selector[bx] + by]` — two dependent reads, then a gradient read, per corner, per channel: 40 fetches per octave, 24 of them dependent. The uploaded 512×256 RGBA8 texture stores `gradient[k][selector[selector[bx] + by]]` for all four channels at texel `(bx + 256·pair, by)`, so every fetch is addressed straight from the pixel position: **8 fetches per octave for all four channels, none dependent.** That is the shape a VideoCore IV pipelines (it stalls on dependent fetches), and the difference between a usable pass and an unusable one on a Raspberry Pi Zero. Gradients are quantized to 8 bits, which bounds the sum's deviation from the double-precision reference below 2/255 for any octave count; measured worst case over a 64×48 render is **0.8/255** (mean 0.26), stitched 0.8/255, 4-octave `turbulence` 1.1/255.
- **Memory:** 512 KB per seed, the last four seeds cached (2 MB ceiling), an evicted lattice released through the transient list after the next flush so a command already recorded against it still runs. No per-frame allocation on a cache hit; a seed animated every frame costs one upload per frame.
- **Shader budget:** parameters ride the dead scissor/paint-matrix uniform slots exactly as the color matrix does (no uniform growth); both backends run color matrix, turbulence and transfer through one shared single-pass filter path; GL gains two programs. GLSL ES 1.00 has no bitwise operators and needs constant loop bounds: the reference's integer truncation and `& 0xff` become `floor` and a floored modulo (the `PerlinN` offset that kept its integers positive drops out of the arithmetic), the octave loop is bounded at 10 with a break — octave *n* contributes at most 1/2ⁿ, so the skipped tail changes the sum by less than half an 8-bit step. Every `SELECT_SHADER` variant of the GL fragment shader compiles under `glslangValidator` as ES 1.00; the wgsl passes `naga`.
- **What it costs where it matters.** Per pixel: 8 fetches and ~60 ALU per octave. A full 1920×1080 frame of 4-octave noise is ~66M fetches — not a per-frame operation on a Pi Zero (order of a tenth of a second there, by fetch throughput). It does not need to be: the output is a pure function of (seed, transform, region), so the pattern of use is generate once into an image, draw that image with a paint. The corpus grain is a 484×720 user-unit region: ~0.4 Mpx at a 1080p portrait scale, ~12M fetches once (tens of milliseconds), a 1.5 MB image retained, two same-size scratches for the duration of the chain, and a textured quad per frame after that. A follow-up can fold noise → matrix → transfer into one pass (3 → 1 full-region passes) once the slot budget for it is settled.

### The `feComposite` question, answered

`claude-opus-5`'s grain is `feTurbulence → feColorMatrix → feComposite operator="in" in2="SourceGraphic"` on a fill-less rect (black by default) at opacity .16. An input scan cannot tell that the source is only a stencil there. Running the chain can, and it needs no new primitive: `operator="in"` is Porter-Duff source-in against the source graphic, which femtovg already has as `CompositeOperation::SourceIn`. On the #322 layer API the whole thing is: `begin_layer(opacity .16)` → draw the source → draw the noise image with `SourceIn` → `end_layer`. The harness now does exactly that; with #324's clip paths in place the file goes from **3.5% to 0.00%** structural against both browsers, with the face's sampled pixels within 2/255 of Chromium and Firefox. On master alone it goes from 4.49% to 1.87%, and every pixel of that remainder is one of its six clip groups drawing unclipped: the build with #324 and its clip switched off (`NO_CLIP=1`) renders md5-identically to the build without #324, on this file and on all 27.

### Corpus evidence

BuseyBench, 27 files, same Chromium 131 / Firefox Developer Edition references and thresholds as #337 (>20/255, 2-px erosion "structural"; browser-vs-browser envelope 0.19%), 460x260 at 1x. Measured twice: on master (0d09c8f, which already carries #322's group-shadow rule) plus this PR alone, where the corpus's clip paths draw unclipped because #324 is still open, and on master plus this PR plus #324. "Before" is the same binary with the turbulence mapping switched off (`NO_TURBULENCE=1`), which renders pixel-identically to master on all 27 files:

| mean structural, before → after | vs Chromium | vs Firefox |
|---|---|---|
| master + this PR | 0.632% → **0.527%** | 0.635% → **0.529%** |
| master + this PR + #324 | 0.165% → **0.026%** | 0.166% → **0.025%** |

| file | chain | master + this PR | with #324 |
|---|---|---|---|
| claude-opus-5 | turbulence → matrix → composite in SourceGraphic, opacity .16 | 4.49% → **1.87%** | 3.52% → **0.00%** |
| qwen3-8-max | turbulence → matrix → composite in SourceAlpha | 0.31% → **0.06%** | 0.25% → **0.00%** |
| claude-fable-5-1, ox-alpha | a turbulence rect that replaces its source | 0.03% → 0.03%, 0.00% → 0.00% | 0.00% → 0.00% |
| qwen3-8-2-4t-a95b, qwen3-8-flash | two replacing turbulence rects each | 0.21% → 0.23%, 0.18% → 0.19% | 0.00% → 0.00% |

Those six are the files whose chain this PR runs; the other 21 render identically with it on or off. Everything left on master alone is #324's: with #324 built in and its clip switched off (`NO_CLIP=1`) every one of the 27 files renders md5-identically to the build without #324, so claude-opus-5's 1.87% is its six clip groups drawing unclipped, qwen3-8-max's 0.06% its four, and the two qwen files that move by 0.02 and 0.004 points are a noise rect drawn where its group's clip should cut it.

![full frames with diff overlays](https://raw.githubusercontent.com/rebeckerspecialties/femtovg/demo-assets/busey-turbulence.png)

![3x crops against both browsers](https://raw.githubusercontent.com/rebeckerspecialties/femtovg/demo-assets/busey-turbulence-detail.png)

![master alone, master + this PR, and with #324, with diff overlays against Chromium](https://raw.githubusercontent.com/rebeckerspecialties/femtovg/demo-assets/busey-turbulence-master.png)

Left in the corpus, by design of the backend rather than of this PR: seven files end their noise chain in `feBlend mode="multiply"` against the source, which needs separable blend modes (#332) — their effect is a darkening of a few percent, below the structural threshold, which is why those files already sit at 0.00–0.19% — and one uses `feDisplacementMap`. The harness mappings and the A/B switches are written up in [`harness/README.md`](https://github.com/rebeckerspecialties/femtovg/blob/demo-assets/harness/README.md) (rules 3 and 4); per-file numbers are in `harness/busey-turbulence-metrics.json` (with #324) and `harness/busey-turbulence-master-metrics.json` (both builds, all four switch sets, both browsers) on that branch.

### Tests

`tests/turbulence_wgpu.rs`: the spec's PRNG check value; lattice well-formedness; GPU `fractalNoise` and `turbulence` against the f64 reference (every pixel, every channel; the tolerance is the 8-bit lattice bound, a structural mistake shows up in the tens); the transform (2× scale maps pixel (2x, 2y) onto identity's (x, y), a translation moves the pattern — both within 1/255); stitching against the stitched reference plus the reference's own seam property; zero octaves as the spec's constants; the corpus chain shape end to end (noise → matrix → transfer). `tests/color_transfer_wgpu.rs`: the curve at known points both ways, unpremultiplied application with alpha kept, and the round trip folding to identity. Unit tests cover the lattice texels, the stitch frequency snap, the slot layout and the bounded seed cache. Full wgpu suite passes (CI's gpu-tests job on the branch merged with master 0d09c8f); `cargo check` on the GL backend; fmt and clippy clean.


