### PR TITLE
Scale sub-pixel stroke alpha by the width ratio, not its square

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- Fixed strokes thinner than a pixel drawing too faint: their alpha was scaled
+  by the square of the device width (a nanovg heuristic), so a 0.2 px line
+  carried 4% of its coverage and a 0.5 px line 25%. The scale is now linear -
+  a 0.5 px line is 50% - which is the coverage Skia's hairline path puts down
+  and what both browsers render. Fine detail drawn with sub-pixel strokes
+  (hatching, iris lines, thin outlines at small zoom) was visibly lighter than
+  in a browser before.
 - Added `Canvas::filter_image_chain()`, which applies a list of image filters in
   one call the way a Canvas `ctx.filter` list (`"blur(5px) brightness(1.2)"`) or
   an SVG filter chain does. Consecutive color-matrix filters fold into a single

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1420,11 +1420,16 @@ where
         let mut line_width = (stroke.line_width * transform.average_scale()).max(0.0);
 
         if line_width < self.fringe_width {
-            // If the stroke width is less than pixel size, use alpha to emulate coverage.
-            // Since coverage is area, scale by alpha*alpha.
+            // A stroke thinner than the fringe is drawn at fringe width with its
+            // alpha scaled by the ratio, so it puts down the ink its area calls
+            // for: a fringe-wide stroke integrates to one pixel per unit length,
+            // so a w-pixel line carries w. That is the linear coverage Skia's
+            // hairline path applies (SkDrawTreatAAStrokeAsHairline scales the
+            // paint alpha by the device width); nanovg squared the ratio, which
+            // left a 0.5 px line at a quarter of its coverage.
             let alpha = (line_width / self.fringe_width).clamp(0.0, 1.0);
 
-            paint_flavor.mul_alpha(alpha * alpha);
+            paint_flavor.mul_alpha(alpha);
             line_width = self.fringe_width;
         }
 

--- a/tests/hairline_stroke_wgpu.rs
+++ b/tests/hairline_stroke_wgpu.rs
@@ -1,0 +1,77 @@
+//! Strokes thinner than a pixel must put down the ink their area calls for.
+//!
+//! femtovg draws such a stroke at fringe width with its alpha scaled down; a
+//! fringe-wide antialiased stroke integrates to one pixel of coverage per unit
+//! length, so the scale has to be the width ratio itself. Browsers render
+//! sub-pixel strokes as exact coverage (Skia's hairline path scales the paint
+//! alpha linearly by the device width), and the nanovg heuristic this replaces
+//! squared the ratio, leaving a 0.5 px line at a quarter of its coverage.
+#![cfg(feature = "wgpu")]
+
+use femtovg::{Color, Paint, Path};
+
+mod common;
+use common::headless_device;
+
+const W: u32 = 128;
+const H: u32 = 64;
+
+/// Alpha coverage per unit length of a horizontal white stroke of `width` at
+/// `y`, summed over the rows the antialiasing can reach and measured away
+/// from the caps.
+fn ink_per_unit_length(device: &wgpu::Device, queue: &wgpu::Queue, width: f32, y: f32) -> f64 {
+    let px = common::render_rgba(device, queue, W, H, Color::rgba(0, 0, 0, 0), |canvas| {
+        let mut path = Path::new();
+        path.move_to(8.0, y);
+        path.line_to(120.0, y);
+        let mut paint = Paint::color(Color::rgb(255, 255, 255));
+        paint.set_line_width(width);
+        paint.set_anti_alias(true);
+        canvas.stroke_path(&path, &paint);
+    });
+    let (x0, x1) = (16u32, 112u32);
+    let rows = (y as i32 - 4)..(y as i32 + 5);
+    let mut sum = 0.0;
+    for row in rows {
+        for col in x0..x1 {
+            sum += px[((row as u32 * W + col) * 4 + 3) as usize] as f64 / 255.0;
+        }
+    }
+    sum / (x1 - x0) as f64
+}
+
+/// Coverage per unit length equals the width, on a pixel boundary and through
+/// pixel centres alike, from 0.2 px up through widths the fringe does not
+/// touch. Before the fix 0.2 px measured 0.04 and 0.5 px measured 0.25.
+#[test]
+fn sub_pixel_strokes_cover_their_area() {
+    let Some((device, queue)) = headless_device() else {
+        return;
+    };
+    for width in [0.2f32, 0.4, 0.5, 0.6, 0.8, 1.0, 1.5, 2.0] {
+        for y in [32.0f32, 32.5] {
+            let ink = ink_per_unit_length(&device, &queue, width, y);
+            let want = width as f64;
+            assert!(
+                (ink - want).abs() <= 0.08 * want + 0.02,
+                "width {width} at y={y}: {ink:.3} px of coverage per unit length, expected {want:.3}"
+            );
+        }
+    }
+}
+
+/// The ink scales linearly with the width, not quadratically: halving a
+/// sub-pixel width halves the coverage.
+#[test]
+fn sub_pixel_coverage_is_linear_in_width() {
+    let Some((device, queue)) = headless_device() else {
+        return;
+    };
+    let a = ink_per_unit_length(&device, &queue, 0.8, 32.5);
+    let b = ink_per_unit_length(&device, &queue, 0.4, 32.5);
+    assert!(
+        (a / b - 2.0).abs() < 0.25,
+        "0.8 px / 0.4 px coverage ratio {:.2}, expected 2",
+        a / b
+    );
+}


### PR DESCRIPTION
A stroke thinner than a pixel is drawn at fringe width with its alpha reduced to stand in for coverage. The reduction was the **square** of the width ratio, inherited from nanovg, whose comment reasons that "coverage is area". Coverage per unit length of a `w`-pixel line is `w`, not `w²`: a fringe-wide antialiased stroke integrates to one pixel per unit length, so a 0.5 px line was put down at a quarter of its ink and a 0.2 px line at four percent. The ratio now applies linearly.

### Reference grounding

Skia's hairline path does exactly this: `SkDrawTreatAAStrokeAsHairline` hands the device width back as the coverage and `SkDraw::drawPath` scales the paint alpha by it, linearly. Both browsers render a sub-pixel stroke as its exact coverage. Measured with a 1:1 probe (white lines on `#202020`, ink summed across the rows the antialiasing reaches, per unit length, on a pixel boundary and through pixel centres):

| width (px) | exact | Chromium 131 | femtovg before | femtovg after |
|---|---|---|---|---|
| 0.2 | 0.200 | 0.197 / 0.197 | 0.036 / 0.040 (0.18×) | 0.197 / 0.202 (0.99×) |
| 0.4 | 0.400 | 0.395 / 0.395 | 0.161 / 0.161 (0.40×) | 0.404 / 0.399 (1.01×) |
| 0.6 | 0.600 | 0.601 / 0.596 | 0.359 / 0.359 (0.60×) | 0.601 / 0.601 (1.00×) |
| 0.8 | 0.800 | 0.794 / 0.798 | 0.637 / 0.641 (0.80×) | 0.798 / 0.798 (1.00×) |
| 1.0 | 1.000 | 1.000 / 1.000 | 0.996 / 1.000 | 0.996 / 1.000 |
| 2.0 | 2.000 | 2.251 / 2.004 | 2.251 / 2.000 | 2.251 / 2.000 |

Before, the ink went as `w²` (0.8 px carried 4× the ink of 0.4 px); after, as `w`. Widths at or above the fringe are untouched.

### Real-world driver

BuseyBench irises: the portraits draw iris "spokes" as 1.1–1.4 user-unit strokes at opacity .55–.75 and iris rims as 1.6–3 user-unit strokes, which at the 200 px display size are 0.21–0.27 px and 0.3–0.6 px lines. femtovg drew them at 7–25 % of their coverage, so the irises came out flatter and their rims lighter than in either browser; together with #336 (every `<circle>` usvg emits is clockwise, and femtovg dilated clockwise fills by a pixel of radius, which turned 0.3–0.6 px catchlights into 2 px blobs) this is what made the eyes read differently at 1x while matching at 4x. Bottom rows of the sheet are the probe; the eye rows show the two fixes landing in turn.

![eyes at 1x across builds, and the sub-pixel probe](https://raw.githubusercontent.com/rebeckerspecialties/femtovg/demo-assets/busey-eyes-subpixel.png)

Corpus effect, on top of the #322 stack, #338 and #336: BuseyBench mean pixel difference vs Chromium 0.93% → 0.85%, structural 0.027% → 0.026% (Firefox 0.84% → 0.74% pixel, 0.026% → 0.025% structural).

### What this does not change

The stroke is still rasterized at fringe width under the triangular antialiasing ramp, so a sub-pixel line is spread over about two pixels where a browser confines it to the pixels it crosses. The total ink now matches; the profile stays softer. Exact sub-pixel *fills* (the other half of #327) are a separate, smaller residual: with #336 a 0.5 px disc measures 0.6–1.8 px² of ink against 0.79 exact, Chromium 0.75.

### Tests

`tests/hairline_stroke_wgpu.rs`: coverage per unit length equals the width for 0.2–2 px, on a boundary and through centres (before: 0.2 px measured 0.039), and the ink is linear in the width (before: the 0.8/0.4 ratio was 3.98). A unit test in `src/lib.rs` pins the same thing on the recorded command through the `RecordingRenderer`, so the default `cargo test` covers it too: a 0.4 px line records alpha 0.4 and a 0.8 px line twice that, the ratio is against the fringe rather than a user unit (0.25 units at 2× DPI is 0.5), both stencil-stroke passes carry the same paint, and a stroke at the fringe or wider keeps its full alpha.

**Backends.** The scale is applied to the paint before the `Params` are built, so every backend receives it only through the same premultiplied colour slots; the GL and wgpu `strokeMask` bodies are the same expression and the GL shader has no GLES-only branch. A headless CGL render of the GL backend over the same probe measures ink per unit length identical to the wgpu backend's to three decimals at every width, with the old squared scale rebuilt as well, and Chromium 131 measured the same way gives 0.196 / 0.394 / 0.796 for 0.2 / 0.4 / 0.8 px (the 0.98 factor is Skia's `(coverage·256)>>8` truncation). There is no GL rendering test infrastructure in the repo; that render needed about a hundred lines on glutin's surfaceless CGL context and is a separate follow-up.

Full wgpu suite green; GL backend `cargo check`; fmt and clippy clean. Budget: one multiply fewer per thin stroke.

