### PR TITLE
Render Gaussian blurs above the shader bound as quadrature passes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,14 @@ All notable changes to this project will be documented in this file.
   ramp was left transparent (or holding stale texture data) instead of the last
   stop's color, as SVG's default `spreadMethod="pad"` and Canvas gradients
   render it. Showed as a wedge cut out of the Firefox logo's flame.
+- Added layer masks: `LayerEffects::with_mask()` multiplies a layer's alpha by
+  a mask image placed in device space, using either its luminance times alpha
+  (SVG `mask`'s default `mask-type`, via the new
+  `ImageFilter::luminance_to_alpha()`) or its alpha. Masks apply after the
+  layer's filters, as in SVG, and reserve their coverage images with the
+  layer's store, so a masked layer the transient budget cannot fit passes
+  through as a whole (`begin_layer()` returns `false`) rather than composite
+  unmasked.
 - Added layers: `Canvas::begin_layer()` and `end_layer()` draw a group into an
   offscreen image and composite it back with `LayerEffects` - group opacity, so
   overlapping shapes fade as one like an SVG group, and/or an image-filter

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Run with `cargo run --example text`
 * [x] Composition modes (SourceOver, SourceIn, SourceOut, Atop, etc..)
 * [x] Image filters - gaussian blur and color matrices (the CSS filter functions), chained in a single call
 * [x] Layers - group capture with declared opacity and layer filters (Canvas 2D beginLayer/endLayer, SVG group effects)
+* [x] Layer masks - luminance and alpha (SVG mask / mask-type)
 * [x] Global alpha
 * [x] Text filling and stroking
 * [x] Text shaping

--- a/src/error.rs
+++ b/src/error.rs
@@ -42,8 +42,8 @@ pub enum ErrorKind {
     UnsupportedImageFormat,
     /// The requested operation is not supported (for example screenshot by wgpu renderer).
     UnsupportedOperation,
-    /// Acquiring another transient image (a layer backing store, filter scratch
-    /// or shadow coverage) would exceed [`crate::Canvas::set_transient_image_budget`].
+    /// Acquiring another transient image (a layer backing store, filter scratch,
+    /// shadow or mask coverage) would exceed [`crate::Canvas::set_transient_image_budget`].
     TransientImageBudgetExceeded,
 }
 

--- a/src/image.rs
+++ b/src/image.rs
@@ -550,6 +550,24 @@ impl ImageFilter {
         }
     }
 
+    /// The `feColorMatrix type="luminanceToAlpha"` conversion: the output
+    /// alpha is the input's luminance and the color channels go to zero,
+    /// which is how SVG luminance masks read their content. Uses the Rec.
+    /// 709 weights above, the ones Skia's luma filter applies for Chromium's
+    /// masks; the SVG row (0.2125, 0.7154, 0.0721) differs by at most
+    /// 0.0002. Like every color matrix it runs on straight (unpremultiplied)
+    /// color, so the luminance is the color's own, not scaled by alpha.
+    pub fn luminance_to_alpha() -> Self {
+        #[rustfmt::skip]
+        let matrix = [
+            0.0,      0.0,      0.0,      0.0, 0.0,
+            0.0,      0.0,      0.0,      0.0, 0.0,
+            0.0,      0.0,      0.0,      0.0, 0.0,
+            Self::LR, Self::LG, Self::LB, 0.0, 0.0,
+        ];
+        ImageFilter::ColorMatrix { matrix }
+    }
+
     /// CSS `opacity(amount)`; `amount` is clamped to `[0, 1]` and scales alpha.
     pub fn opacity(amount: f32) -> Self {
         let a = amount.clamp(0.0, 1.0);
@@ -788,6 +806,20 @@ mod filter_fold_tests {
     /// constant column composes in order. `brightness(0.5)` and `invert(1.0)`
     /// are both range-safe, so both directions fold, and they do not commute:
     /// brighten-then-invert is `1 - 0.5c`, invert-then-brighten is `0.5 - 0.5c`.
+    /// luminanceToAlpha writes the Rec. 709 luminance into alpha and nothing
+    /// into the color rows, so white converts to full coverage and a pure
+    /// green pixel to 0.7152 of it.
+    #[test]
+    fn luminance_to_alpha_moves_luminance_into_alpha_only() {
+        let ImageFilter::ColorMatrix { matrix } = ImageFilter::luminance_to_alpha() else {
+            panic!("luminance_to_alpha is a color matrix");
+        };
+        assert!(matrix[..15].iter().all(|c| *c == 0.0), "color rows are zero");
+        assert_eq!(&matrix[15..], &[0.2126, 0.7152, 0.0722, 0.0, 0.0]);
+        let white: f32 = matrix[15..18].iter().sum();
+        assert!((white - 1.0).abs() < 1e-4, "white is full coverage, got {white}");
+    }
+
     #[test]
     fn folding_respects_order_and_identity() {
         let bright = ImageFilter::brightness(0.5);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1272,24 +1272,16 @@ where
         self.clear_rect(0, 0, width as u32, height as u32, Color::rgbaf(0.0, 0.0, 0.0, 0.0));
 
         // Shift device space so the captured rect's origin lands on (0, 0),
-        // exactly like the shadow pass maps its padded bbox.
+        // exactly like the shadow pass maps its padded bbox. Shadow state is
+        // a layer rendering attribute too: it applies to the layer's result
+        // at end_layer, so it must not also apply to every draw inside, or
+        // the layer's children would each cast their own shadow and then the
+        // layer would cast one more over the lot.
         let mut layer_transform = Transform2D::translation(-minx, -miny);
         layer_transform.premultiply(&state.transform);
-        self.state_mut().transform = layer_transform;
-        self.state_mut().alpha = 1.0;
-        self.state_mut().composite_operation = CompositeOperationState::default();
-        // Shadow state is a layer rendering attribute too: it applies to the
-        // layer's result at end_layer, so it must not also apply to every
-        // draw inside, or the layer's children would each cast their own
-        // shadow and then the layer would cast one more over the lot.
-        {
-            let state = self.state_mut();
-            state.shadow_color = Color::rgbaf(0.0, 0.0, 0.0, 0.0);
-            state.shadow_blur = 0.0;
-            state.shadow_offset = [0.0, 0.0];
-        }
-        if !keep_scissor {
-            self.state_mut().scissor = Scissor::default();
+        self.enter_offscreen_state(layer_transform);
+        if keep_scissor {
+            self.state_mut().scissor = state.scissor;
         }
         true
     }
@@ -1351,17 +1343,13 @@ where
         // 2D's beginLayer applies the shadow to the layer's result and SVG's
         // feDropShadow applies to a filtered group. Inside the layer the
         // shadow state was reset, so nothing has been shadowed twice.
-        let saved_transform = self.state().transform;
-        let saved_alpha = self.state().alpha;
-        self.state_mut().transform = Transform2D::identity();
-        self.state_mut().alpha = 1.0;
-
-        let mut layer_rect = Path::new();
-        layer_rect.rect(minx, miny, record.width as f32, record.height as f32);
-        self.fill_path_internal(&layer_rect, &layer_paint.flavor, false, FillRule::NonZero);
-
-        self.state_mut().transform = saved_transform;
-        self.state_mut().alpha = saved_alpha;
+        self.fill_device_rect(
+            minx,
+            miny,
+            record.width as f32,
+            record.height as f32,
+            &layer_paint.flavor,
+        );
 
         // The composite that reads the layer is recorded; its images can back
         // the next layer of this size.
@@ -1375,6 +1363,38 @@ where
         if source != capture {
             self.release_transient_image(source);
         }
+    }
+
+    /// Puts the current state into the shape every offscreen pass draws
+    /// under: `transform` as the pass's device space, full alpha, no scissor,
+    /// source-over and no shadow. The caller's `save()` holds the state this
+    /// replaces.
+    fn enter_offscreen_state(&mut self, transform: Transform2D) {
+        let state = self.state_mut();
+        state.transform = transform;
+        state.alpha = 1.0;
+        state.scissor = Scissor::default();
+        state.composite_operation = CompositeOperationState::default();
+        state.shadow_color = Color::rgbaf(0.0, 0.0, 0.0, 0.0);
+        state.shadow_blur = 0.0;
+        state.shadow_offset = [0.0, 0.0];
+    }
+
+    /// Fills a device-space rect with `paint` under the identity transform,
+    /// at full alpha and without antialiasing: the blit an offscreen pass
+    /// ends with. The scissor, composite operation and shadow state stay the
+    /// caller's - that is how a layer's composite honors the outer scissor
+    /// and casts the group's shadow.
+    fn fill_device_rect(&mut self, x: f32, y: f32, width: f32, height: f32, paint: &PaintFlavor) {
+        let saved_transform = self.state().transform;
+        let saved_alpha = self.state().alpha;
+        self.state_mut().transform = Transform2D::identity();
+        self.state_mut().alpha = 1.0;
+        let mut rect = Path::new();
+        rect.rect(x, y, width, height);
+        self.fill_path_internal(&rect, paint, false, FillRule::NonZero);
+        self.state_mut().transform = saved_transform;
+        self.state_mut().alpha = saved_alpha;
     }
 
     // Transforms
@@ -2088,16 +2108,12 @@ where
 
         // Build the offset transform for coverage rendering: original CTM with an
         // extra device-space translation that shifts the shape into the offscreen.
-        let mut coverage_transform = Transform2D::translation(-minx, -miny);
-        coverage_transform.premultiply(&state.transform);
-        self.state_mut().transform = coverage_transform;
         // Render the source at full strength: the shadow color's alpha and the
         // global alpha are applied later (the former via the SourceIn mask below,
         // the latter when compositing the finished shadow under the shape).
-        self.state_mut().alpha = 1.0;
-        self.state_mut().scissor = Scissor::default();
-        self.state_mut().composite_operation = CompositeOperationState::default();
-        self.state_mut().shadow_color = Color::rgbaf(0.0, 0.0, 0.0, 0.0);
+        let mut coverage_transform = Transform2D::translation(-minx, -miny);
+        coverage_transform.premultiply(&state.transform);
+        self.enter_offscreen_state(coverage_transform);
 
         // 1. Rasterize the source with its real paint so the offscreen holds the
         //    source's true per-pixel alpha (semi-transparent fills, gradient/image
@@ -2112,11 +2128,8 @@ where
         //    a half-strength shadow. The mask must cover the whole offscreen in its
         //    own pixel space, so draw it with the identity transform (not the
         //    shape's coverage transform, which is scaled/translated).
-        self.state_mut().transform = Transform2D::identity();
         self.state_mut().composite_operation = CompositeOperationState::new(CompositeOperation::SourceIn);
-        let mut mask_rect = Path::new();
-        mask_rect.rect(0.0, 0.0, width as f32, height as f32);
-        self.fill_path_internal(&mask_rect, &PaintFlavor::Color(shadow_color), false, FillRule::NonZero);
+        self.fill_device_rect(0.0, 0.0, width as f32, height as f32, &PaintFlavor::Color(shadow_color));
 
         self.restore();
 
@@ -2147,18 +2160,10 @@ where
 
         // Composite in plain device space (identity transform) at the offset
         // position, honoring the caller's scissor and composite operation.
-        let saved_transform = self.state().transform;
-        let saved_alpha = self.state().alpha;
-        self.state_mut().transform = Transform2D::identity();
-        self.state_mut().alpha = 1.0;
+        // A shadow casts no shadow of its own: mute the shadow state around
+        // the blit.
         self.state_mut().shadow_color = Color::rgbaf(0.0, 0.0, 0.0, 0.0);
-
-        let mut shadow_rect = Path::new();
-        shadow_rect.rect(dst_x, dst_y, width as f32, height as f32);
-        self.fill_path_internal(&shadow_rect, &shadow_paint.flavor, false, FillRule::NonZero);
-
-        self.state_mut().transform = saved_transform;
-        self.state_mut().alpha = saved_alpha;
+        self.fill_device_rect(dst_x, dst_y, width as f32, height as f32, &shadow_paint.flavor);
         self.state_mut().shadow_color = shadow_color;
 
         // The composite that reads them is recorded; the next shadow of this

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -369,6 +369,36 @@ pub struct Canvas<T: Renderer> {
 pub struct LayerEffects {
     opacity: f32,
     filters: Vec<ImageFilter>,
+    mask: Option<LayerMask>,
+}
+
+/// How a layer mask's coverage is derived from its image.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum MaskKind {
+    /// Coverage is the mask content's luminance (Rec. 709 weights on its
+    /// sRGB values) times its alpha - SVG `mask`'s default `mask-type`.
+    Luminance,
+    /// Coverage is the mask content's own alpha channel.
+    Alpha,
+}
+
+/// The transients a mask draws its coverage through: the mask normalized
+/// into layer space and, for a luminance mask, the alpha it converts to.
+#[derive(Clone, Copy, Debug)]
+struct MaskImages {
+    normalized: ImageId,
+    converted: Option<ImageId>,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct LayerMask {
+    image: ImageId,
+    kind: MaskKind,
+    // Device-space placement of the mask image.
+    x: f32,
+    y: f32,
+    width: f32,
+    height: f32,
 }
 
 impl LayerEffects {
@@ -377,6 +407,7 @@ impl LayerEffects {
         Self {
             opacity: 1.0,
             filters: Vec::new(),
+            mask: None,
         }
     }
 
@@ -403,6 +434,35 @@ impl LayerEffects {
         self.filters = filters.to_vec();
         self
     }
+
+    /// Masks the layer by `image`, placed at the device-space rect
+    /// `(x, y, width, height)` - device space because a mask is a raster
+    /// captured the way the layer is - with coverage derived per `kind`:
+    /// SVG `mask` semantics, [`MaskKind::Luminance`] being SVG's default
+    /// mask-type, computed on the mask's sRGB values as SVG's default
+    /// `color-interpolation` has it. Applied after the filter chain, SVG's
+    /// order for a group carrying both `filter` and `mask`. Pixels the mask
+    /// rect does not cover are fully masked out.
+    ///
+    /// The mask image is borrowed, not owned: render mask content into your
+    /// own image (upload or render target - its `ImageFlags` orientation is
+    /// respected) and release it on your own schedule after the flush. The
+    /// coverage images the mask draws through are reserved at
+    /// [`begin_layer`](Canvas::begin_layer) with the layer's store, so a
+    /// masked layer the transient budget cannot fit passes through as a
+    /// whole (`begin_layer` returns `false`) rather than composite unmasked.
+    #[must_use]
+    pub fn with_mask(mut self, image: ImageId, kind: MaskKind, x: f32, y: f32, width: f32, height: f32) -> Self {
+        self.mask = Some(LayerMask {
+            image,
+            kind,
+            x,
+            y,
+            width,
+            height,
+        });
+        self
+    }
 }
 
 /// Default cap on live transient image memory: 256 MiB, room for a handful
@@ -414,6 +474,10 @@ struct LayerRecord {
     // degenerate): draws went to the previous target unchanged and end_layer
     // only rebalances state.
     image: Option<ImageId>,
+    // The mask's coverage images, reserved with the store: a masked layer
+    // either captures with everything its composite needs or passes through
+    // as a whole, never composites unmasked.
+    mask_images: Option<MaskImages>,
     previous_target: RenderTarget,
     origin: (f32, f32),
     width: usize,
@@ -1006,7 +1070,8 @@ where
     }
 
     /// Caps the memory held by transient images - layer backing stores,
-    /// filtered results, filter-chain scratches and shadow coverage - at
+    /// filtered results, filter-chain scratches, shadow coverage and mask
+    /// coverage - at
     /// `bytes` (default 256 MiB). Within a frame a layer's images are reused
     /// by the next layer of the same size once its composite is recorded, so
     /// what counts against the cap is the deepest nesting, not the number of
@@ -1015,7 +1080,9 @@ where
     /// MB. Past the cap [`begin_layer`](Self::begin_layer) returns `false` and
     /// the layer passes through with its effects dropped,
     /// [`filter_image_chain`](Self::filter_image_chain) returns
-    /// [`ErrorKind::TransientImageBudgetExceeded`], and shadows are skipped;
+    /// [`ErrorKind::TransientImageBudgetExceeded`], shadows are skipped and
+    /// a masked layer, which reserves its coverage images with its store,
+    /// passes through as a whole;
     /// [`transient_image_bytes`](Self::transient_image_bytes) reports what a
     /// frame actually held.
     ///
@@ -1196,6 +1263,7 @@ where
                 .ok();
             self.layers.push(LayerRecord {
                 image,
+                mask_images: None,
                 previous_target: self.current_render_target,
                 origin: (0.0, 0.0),
                 width: void,
@@ -1254,8 +1322,25 @@ where
                 .ok()
         };
 
+        // The mask is applied at end_layer, so its coverage images are
+        // reserved here with the store: a layer that could not get them then
+        // would have to composite unmasked, and the return value promises no
+        // effect is dropped silently.
+        let mask_images = match (image, &effects.mask) {
+            (Some(_), Some(mask)) => self.reserve_mask_images(width, height, mask.kind),
+            _ => None,
+        };
+        let image = match (image, effects.mask.is_some() && mask_images.is_none()) {
+            (Some(image), true) => {
+                self.release_transient_image(image);
+                None
+            }
+            (image, _) => image,
+        };
+
         self.layers.push(LayerRecord {
             image,
+            mask_images,
             previous_target: self.current_render_target,
             origin: (minx, miny),
             width,
@@ -1326,9 +1411,18 @@ where
         let alpha = record.outer_alpha * record.effects.opacity;
         if alpha <= 0.0 {
             self.release_layer_images(image, source);
+            if let Some(images) = record.mask_images {
+                self.release_mask_images(images);
+            }
             return;
         }
         let (minx, miny) = record.origin;
+
+        // The mask applies after the filter chain - SVG's order for a group
+        // carrying both - and multiplies the layer's alpha in place.
+        if let (Some(mask), Some(images)) = (record.effects.mask, record.mask_images) {
+            self.apply_layer_mask(source, &record, mask, images, source != image);
+        }
         let tint = Color::rgbaf(1.0, 1.0, 1.0, alpha);
         let mut layer_paint =
             Paint::image_tint(source, minx, miny, record.width as f32, record.height as f32, 0.0, tint);
@@ -1395,6 +1489,121 @@ where
         self.fill_path_internal(&rect, paint, false, FillRule::NonZero);
         self.state_mut().transform = saved_transform;
         self.state_mut().alpha = saved_alpha;
+    }
+
+    /// Acquires a mask's coverage transients for a layer store of
+    /// `width` x `height`: the mask normalized into layer space, sampled
+    /// upright through FLIP_Y like a capture, and for luminance masks the
+    /// conversion target, whose color-matrix pass leaves storage upright.
+    /// `None`, holding nothing, when the budget cannot fit them.
+    fn reserve_mask_images(&mut self, width: usize, height: usize, kind: MaskKind) -> Option<MaskImages> {
+        let normalized = self
+            .acquire_transient_image(width, height, ImageFlags::PREMULTIPLIED | ImageFlags::FLIP_Y)
+            .ok()?;
+        let converted = match kind {
+            MaskKind::Alpha => None,
+            MaskKind::Luminance => match self.acquire_transient_image(width, height, ImageFlags::PREMULTIPLIED) {
+                Ok(converted) => Some(converted),
+                Err(_) => {
+                    self.release_transient_image(normalized);
+                    return None;
+                }
+            },
+        };
+        Some(MaskImages { normalized, converted })
+    }
+
+    fn release_mask_images(&mut self, images: MaskImages) {
+        self.release_transient_image(images.normalized);
+        if let Some(converted) = images.converted {
+            self.release_transient_image(converted);
+        }
+    }
+
+    /// Multiplies `layer`'s alpha by the mask's coverage, in layer space,
+    /// drawing through the coverage images reserved at `begin_layer`.
+    ///
+    /// Orientation: a draw into an image target lands in flipped storage, so
+    /// draw-space row 0 writes the storage row holding a raw capture's top
+    /// but a filtered result's bottom (the chain flipped storage parity
+    /// once). Both coverage images sample upright - `normalized` through
+    /// FLIP_Y like a capture, `converted` without it like a filtered result -
+    /// so the coverage draw runs under the identity for a raw capture and
+    /// under a vertical flip for a filtered one.
+    fn apply_layer_mask(
+        &mut self,
+        layer: ImageId,
+        record: &LayerRecord,
+        mask: LayerMask,
+        images: MaskImages,
+        layer_is_filtered: bool,
+    ) {
+        let (width, height) = (record.width as f32, record.height as f32);
+        let (minx, miny) = record.origin;
+        let previous_target = self.current_render_target;
+        self.save();
+
+        // Normalize the mask into layer space with an ordinary draw, so the
+        // caller's storage convention (an upload or a render target, whatever
+        // ImageFlags it carries) never enters the parity rule above. The
+        // backdrop sets what uncovered pixels mean. A luminance mask lands
+        // over opaque black: every pixel is then opaque, the color-matrix
+        // pass's unpremultiply is the identity, and the luminance it writes
+        // from the premultiplied color is luminance x alpha - SVG's mask
+        // value - in one pass, with the uncovered rest reading black,
+        // coverage 0. An alpha mask lands over transparent and its own alpha
+        // is the coverage.
+        let backdrop = match mask.kind {
+            MaskKind::Luminance => Color::black(),
+            MaskKind::Alpha => Color::rgbaf(0.0, 0.0, 0.0, 0.0),
+        };
+        self.set_render_target(RenderTarget::Image(images.normalized));
+        self.clear_rect(0, 0, record.width as u32, record.height as u32, backdrop);
+        self.enter_offscreen_state(Transform2D::identity());
+        let mask_paint = Paint::image(
+            mask.image,
+            mask.x - minx,
+            mask.y - miny,
+            mask.width,
+            mask.height,
+            0.0,
+            1.0,
+        );
+        self.fill_device_rect(
+            mask.x - minx,
+            mask.y - miny,
+            mask.width,
+            mask.height,
+            &mask_paint.flavor,
+        );
+
+        let coverage = match images.converted {
+            Some(converted) => {
+                self.filter_image(converted, ImageFilter::luminance_to_alpha(), images.normalized);
+                converted
+            }
+            None => images.normalized,
+        };
+
+        // layer.alpha *= coverage.alpha over the whole store.
+        self.set_render_target(RenderTarget::Image(layer));
+        let transform = if layer_is_filtered {
+            Transform2D::new(1.0, 0.0, 0.0, -1.0, 0.0, height)
+        } else {
+            Transform2D::identity()
+        };
+        self.enter_offscreen_state(transform);
+        self.state_mut().composite_operation = CompositeOperationState::new(CompositeOperation::DestinationIn);
+        let coverage_paint = Paint::image(coverage, 0.0, 0.0, width, height, 0.0, 1.0);
+        let mut store = Path::new();
+        store.rect(0.0, 0.0, width, height);
+        self.fill_path_internal(&store, &coverage_paint.flavor, false, FillRule::NonZero);
+
+        self.restore();
+        self.set_render_target(previous_target);
+        // The draws that read the coverage are recorded; the next masked
+        // layer of this size draws its mask into the same images.
+        self.release_mask_images(images);
     }
 
     // Transforms
@@ -5341,6 +5550,77 @@ fn shadow_stores_round_to_eight_pixels() {
     canvas.fill_path(&path, &Paint::color(Color::rgb(200, 0, 0)));
     let info = canvas.images.info(canvas.transients.images[0]).unwrap();
     assert_eq!((info.width(), info.height()), (40, 40));
+}
+
+/// Masked sibling layers reuse the mask's transients too: a luminance mask
+/// needs the layer capture, the normalized mask and its alpha conversion,
+/// once for any number of siblings.
+#[test]
+fn masked_siblings_reuse_mask_transients() {
+    let renderer = RecordingRenderer::default();
+    let mut canvas = Canvas::new(renderer).unwrap();
+    canvas.set_size(200, 120, 1.0);
+    let mask = canvas
+        .create_image_empty(200, 120, PixelFormat::Rgba8, ImageFlags::empty())
+        .unwrap();
+    for _ in 0..4 {
+        assert!(canvas.begin_layer(&LayerEffects::new().with_mask(mask, MaskKind::Luminance, 0.0, 0.0, 200.0, 120.0)));
+        assert!(canvas.layers.last().unwrap().image.is_some());
+        // Reserved with the store: nothing of the mask's is left to chance
+        // at end_layer.
+        assert_eq!(
+            canvas.transients.images.len(),
+            3,
+            "capture, normalized mask, converted mask"
+        );
+        assert!(
+            canvas.transients.free.is_empty(),
+            "all three are held while the layer is open"
+        );
+        canvas.end_layer();
+        assert_eq!(
+            canvas.transients.free.len(),
+            3,
+            "and returned once its composite is recorded"
+        );
+    }
+    assert_eq!(
+        canvas.transients.images.len(),
+        3,
+        "four masked siblings, one set of images"
+    );
+    canvas.flush_to_output(());
+    assert_eq!(canvas.transients.images.len(), 0);
+}
+
+/// A masked layer whose coverage images do not fit the budget passes through
+/// as a whole - `begin_layer` says so - instead of capturing and then
+/// compositing unmasked at end_layer.
+#[test]
+fn a_masked_layer_without_room_for_its_coverage_passes_through() {
+    let renderer = RecordingRenderer::default();
+    let mut canvas = Canvas::new(renderer).unwrap();
+    canvas.set_size(64, 64, 1.0);
+    let mask = canvas
+        .create_image_empty(64, 64, PixelFormat::Rgba8, ImageFlags::empty())
+        .unwrap();
+    // Room for the capture and the normalized mask, not the luminance conversion.
+    canvas.set_transient_image_budget(2 * 64 * 64 * 4);
+    let luminance = LayerEffects::new().with_mask(mask, MaskKind::Luminance, 0.0, 0.0, 64.0, 64.0);
+    assert!(!canvas.begin_layer(&luminance), "no coverage, no layer");
+    assert!(canvas.layers.last().unwrap().image.is_none());
+    assert!(
+        canvas.transients.free.len() == canvas.transients.images.len(),
+        "nothing stays held"
+    );
+    canvas.end_layer();
+    // The same budget fits an alpha mask, which needs no conversion.
+    let alpha = LayerEffects::new().with_mask(mask, MaskKind::Alpha, 0.0, 0.0, 64.0, 64.0);
+    assert!(canvas.begin_layer(&alpha));
+    canvas.end_layer();
+    canvas.set_transient_image_budget(3 * 64 * 64 * 4);
+    assert!(canvas.begin_layer(&luminance), "three images fit three images' worth");
+    canvas.end_layer();
 }
 
 /// Shadows draw through the pool too: the coverage and blurred images of one

--- a/src/path/cache.rs
+++ b/src/path/cache.rs
@@ -896,11 +896,18 @@ impl PathCache {
             && maybe_t1_bottom_right.x == maybe_t2_top_right.x
             && maybe_t2_bottom_right.y == maybe_t1_bottom_left.y
         {
+            // A mirrored transform hands the corners over in the opposite
+            // order, so take the extent by min/max rather than by position in
+            // the strip: the fill is the same rect either way, and the blit
+            // maps its texture coordinates through the paint transform, flip
+            // included.
+            let (x0, x1) = (maybe_t1_top_left.x, maybe_t2_top_right.x);
+            let (y0, y1) = (maybe_t1_top_left.y, maybe_t1_bottom_left.y);
             Some(crate::Rect::new(
-                maybe_t1_top_left.x,
-                maybe_t1_top_left.y,
-                maybe_t2_top_right.x - maybe_t1_top_left.x,
-                maybe_t1_bottom_left.y - maybe_t1_top_left.y,
+                x0.min(x1),
+                y0.min(y1),
+                (x1 - x0).abs(),
+                (y1 - y0).abs(),
             ))
         } else {
             None
@@ -1123,6 +1130,28 @@ mod tests {
         path_cache.expand_fill(1.0, LineJoin::Miter, 10.0);
 
         assert_eq!(path_cache.contours[0].convexity, Convexity::Concave);
+    }
+
+    /// A rect stays a rect under a mirrored transform: the corners arrive in
+    /// the opposite order, and the fast image-blit path used to read that as
+    /// a negative extent and draw nothing.
+    #[test]
+    fn a_mirrored_rect_fill_is_still_a_rect() {
+        let mut path = Path::new();
+        path.rect(10.0, 20.0, 30.0, 40.0);
+
+        let upright = Transform2D::identity();
+        let mut cache = PathCache::new(path.verbs(), &upright, 0.25, 0.01);
+        cache.expand_fill(0.0, LineJoin::Miter, 10.0);
+        let rect = cache.path_fill_is_rect().expect("an upright rect");
+        assert_eq!((rect.x, rect.y, rect.w, rect.h), (10.0, 20.0, 30.0, 40.0));
+
+        // y' = 100 - y: the rect lands at y in 40..80; x' = -x: at x in -40..-10.
+        let mirrored = Transform2D::new(-1.0, 0.0, 0.0, -1.0, 0.0, 100.0);
+        let mut cache = PathCache::new(path.verbs(), &mirrored, 0.25, 0.01);
+        cache.expand_fill(0.0, LineJoin::Miter, 10.0);
+        let rect = cache.path_fill_is_rect().expect("a mirrored rect is still a rect");
+        assert_eq!((rect.x, rect.y, rect.w, rect.h), (-40.0, 40.0, 30.0, 40.0));
     }
 }
 

--- a/tests/image_blit_wgpu.rs
+++ b/tests/image_blit_wgpu.rs
@@ -1,0 +1,129 @@
+//! Headless GPU test for the unclipped image-blit fast path a non-antialiased
+//! rect fill with an image paint takes (`ShaderType::TextureCopyUnclipped`):
+//! under a mirrored transform the rect's corners arrive in the opposite
+//! order, which used to read as a negative extent and draw nothing at all -
+//! while the same fill with antialiasing, which takes the general path, drew
+//! the mirrored image. Skips without a GPU adapter.
+#![cfg(feature = "wgpu")]
+
+use femtovg::{renderer::WGPURenderer, Canvas, Color, ImageFlags, Paint, Path, Transform2D};
+
+mod common;
+use common::headless_device;
+
+const W: u32 = 64;
+const H: u32 = 64;
+
+fn render(device: &wgpu::Device, queue: &wgpu::Queue, draw: impl FnOnce(&mut Canvas<WGPURenderer>)) -> Vec<u8> {
+    let target = device.create_texture(&wgpu::TextureDescriptor {
+        label: Some("image blit test target"),
+        size: wgpu::Extent3d {
+            width: W,
+            height: H,
+            depth_or_array_layers: 1,
+        },
+        mip_level_count: 1,
+        sample_count: 1,
+        dimension: wgpu::TextureDimension::D2,
+        format: wgpu::TextureFormat::Rgba8Unorm,
+        usage: wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::COPY_SRC,
+        view_formats: &[],
+    });
+    let renderer = WGPURenderer::new(device.clone(), queue.clone());
+    let mut canvas = Canvas::new(renderer).expect("canvas");
+    canvas.set_size(W, H, 1.0);
+    canvas.clear_rect(0, 0, W, H, Color::white());
+    draw(&mut canvas);
+    queue.submit(canvas.flush_to_output(&target));
+
+    let unpadded = W * 4;
+    let align = wgpu::COPY_BYTES_PER_ROW_ALIGNMENT;
+    let padded = unpadded.div_ceil(align) * align;
+    let readback = device.create_buffer(&wgpu::BufferDescriptor {
+        label: None,
+        size: (padded * H) as u64,
+        usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
+        mapped_at_creation: false,
+    });
+    let mut enc = device.create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
+    enc.copy_texture_to_buffer(
+        wgpu::TexelCopyTextureInfo {
+            texture: &target,
+            mip_level: 0,
+            origin: wgpu::Origin3d::ZERO,
+            aspect: wgpu::TextureAspect::All,
+        },
+        wgpu::TexelCopyBufferInfo {
+            buffer: &readback,
+            layout: wgpu::TexelCopyBufferLayout {
+                offset: 0,
+                bytes_per_row: Some(padded),
+                rows_per_image: Some(H),
+            },
+        },
+        wgpu::Extent3d {
+            width: W,
+            height: H,
+            depth_or_array_layers: 1,
+        },
+    );
+    queue.submit(Some(enc.finish()));
+    let slice = readback.slice(..);
+    slice.map_async(wgpu::MapMode::Read, |_| {});
+    device.poll(wgpu::PollType::wait_indefinitely()).unwrap();
+    let mapped = slice.get_mapped_range().expect("readback");
+    let mut out = vec![0u8; (unpadded * H) as usize];
+    for row in 0..H as usize {
+        let src = row * padded as usize;
+        let dst = row * unpadded as usize;
+        out[dst..dst + unpadded as usize].copy_from_slice(&mapped[src..src + unpadded as usize]);
+    }
+    out
+}
+
+fn px(buf: &[u8], x: u32, y: u32) -> [u8; 3] {
+    let i = ((y * W + x) * 4) as usize;
+    [buf[i], buf[i + 1], buf[i + 2]]
+}
+
+/// A red-over-transparent image (red on its top half) filled as a rect under
+/// y' = H - y must come out red on the BOTTOM half, antialiased or not.
+#[test]
+fn a_rect_image_fill_draws_mirrored_under_a_flipped_transform() {
+    let Some((device, queue)) = headless_device() else {
+        eprintln!("skipping: no wgpu adapter available");
+        return;
+    };
+    for anti_alias in [true, false] {
+        let out = render(&device, &queue, |canvas| {
+            let mut buf = vec![femtovg::rgb::RGBA8::new(0, 0, 0, 0); (W * H) as usize];
+            for p in buf.iter_mut().take((W * H / 2) as usize) {
+                *p = femtovg::rgb::RGBA8::new(255, 0, 0, 255);
+            }
+            let image = canvas
+                .create_image(
+                    femtovg::imgref::Img::new(buf.as_slice(), W as usize, H as usize),
+                    ImageFlags::empty(),
+                )
+                .unwrap();
+            canvas.set_transform(&Transform2D::new(1.0, 0.0, 0.0, -1.0, 0.0, H as f32));
+            let mut rect = Path::new();
+            rect.rect(0.0, 0.0, W as f32, H as f32);
+            let mut paint = Paint::image(image, 0.0, 0.0, W as f32, H as f32, 0.0, 1.0);
+            paint.set_anti_alias(anti_alias);
+            canvas.fill_path(&rect, &paint);
+        });
+        let top = px(&out, 32, 12);
+        let bottom = px(&out, 32, 52);
+        assert_eq!(
+            top,
+            [255, 255, 255],
+            "anti_alias={anti_alias}: the image's red top lands at the bottom, got {top:?}"
+        );
+        assert_eq!(
+            bottom,
+            [255, 0, 0],
+            "anti_alias={anti_alias}: mirrored red expected at the bottom, got {bottom:?} (white means the fill was dropped)"
+        );
+    }
+}

--- a/tests/layer_effects_wgpu.rs
+++ b/tests/layer_effects_wgpu.rs
@@ -239,6 +239,419 @@ fn layer_composite_honors_outer_scissor() {
     assert_eq!(px(&out, 50, 50), [255, 255, 255], "outside the scissor must stay white");
 }
 
+fn circle_mask_image(canvas: &mut Canvas<WGPURenderer>) -> femtovg::ImageId {
+    // White circle on transparent: full luminance coverage inside, none outside.
+    let mask = canvas
+        .create_image_empty(
+            48,
+            48,
+            femtovg::PixelFormat::Rgba8,
+            femtovg::ImageFlags::PREMULTIPLIED | femtovg::ImageFlags::FLIP_Y,
+        )
+        .unwrap();
+    canvas.save();
+    canvas.set_render_target(femtovg::RenderTarget::Image(mask));
+    canvas.clear_rect(0, 0, 48, 48, Color::rgbaf(0.0, 0.0, 0.0, 0.0));
+    canvas.reset_transform();
+    let mut p = Path::new();
+    p.circle(24.0, 24.0, 20.0);
+    canvas.fill_path(&p, &Paint::color(Color::white()));
+    canvas.set_render_target(femtovg::RenderTarget::Screen);
+    canvas.restore();
+    mask
+}
+
+/// A luminance mask shows the layer inside its white region and hides it
+/// outside (uncovered pixels mask out fully) - SVG mask semantics.
+#[test]
+fn luminance_mask_gates_the_layer() {
+    let Some((device, queue)) = headless_device() else {
+        eprintln!("skipping: no wgpu adapter available");
+        return;
+    };
+    let out = render(&device, &queue, |canvas| {
+        let mask = circle_mask_image(canvas);
+        assert!(canvas.begin_layer(&LayerEffects::new().with_mask(
+            mask,
+            femtovg::MaskKind::Luminance,
+            8.0,
+            8.0,
+            48.0,
+            48.0
+        )));
+        red_rect(canvas, 0.0, 0.0, 64.0, 64.0);
+        canvas.end_layer();
+    });
+    let inside = px(&out, 32, 32); // circle centre (mask at 8..56)
+    let outside_circle = px(&out, 12, 12); // inside mask rect, outside circle
+    let outside_rect = px(&out, 60, 60); // outside the mask rect entirely
+    assert!(
+        close(inside[0], 255) && close(inside[1], 0),
+        "inside the mask circle the layer shows, got {inside:?}"
+    );
+    assert_eq!(
+        outside_circle,
+        [255, 255, 255],
+        "outside the circle the layer is masked out"
+    );
+    assert_eq!(
+        outside_rect,
+        [255, 255, 255],
+        "beyond the mask rect the layer is masked out"
+    );
+}
+
+/// A black region of a luminance mask hides content even though its alpha is
+/// opaque - proving coverage is luminance, not alpha.
+#[test]
+fn luminance_mask_uses_luminance_not_alpha() {
+    let Some((device, queue)) = headless_device() else {
+        eprintln!("skipping: no wgpu adapter available");
+        return;
+    };
+    let out = render(&device, &queue, |canvas| {
+        // Opaque half-white / half-black mask.
+        let mask = canvas
+            .create_image_empty(
+                64,
+                64,
+                femtovg::PixelFormat::Rgba8,
+                femtovg::ImageFlags::PREMULTIPLIED | femtovg::ImageFlags::FLIP_Y,
+            )
+            .unwrap();
+        canvas.save();
+        canvas.set_render_target(femtovg::RenderTarget::Image(mask));
+        canvas.clear_rect(0, 0, 64, 64, Color::black());
+        canvas.reset_transform();
+        let mut p = Path::new();
+        p.rect(0.0, 0.0, 32.0, 64.0);
+        canvas.fill_path(&p, &Paint::color(Color::white()));
+        canvas.set_render_target(femtovg::RenderTarget::Screen);
+        canvas.restore();
+
+        assert!(canvas.begin_layer(&LayerEffects::new().with_mask(
+            mask,
+            femtovg::MaskKind::Luminance,
+            0.0,
+            0.0,
+            64.0,
+            64.0
+        )));
+        red_rect(canvas, 0.0, 0.0, 64.0, 64.0);
+        canvas.end_layer();
+    });
+    assert!(
+        close(px(&out, 16, 32)[0], 255) && close(px(&out, 16, 32)[1], 0),
+        "white mask half shows the layer"
+    );
+    assert_eq!(
+        px(&out, 48, 32),
+        [255, 255, 255],
+        "black (but opaque) mask half hides the layer - luminance, not alpha"
+    );
+}
+
+/// Masking a FILTERED layer keeps both the mask and the content upright -
+/// the storage-parity flag selection for the filtered case.
+#[test]
+fn masked_filtered_layer_keeps_orientation() {
+    let Some((device, queue)) = headless_device() else {
+        eprintln!("skipping: no wgpu adapter available");
+        return;
+    };
+    let out = render(&device, &queue, |canvas| {
+        // Mask: white on the TOP half only.
+        let mask = canvas
+            .create_image_empty(
+                64,
+                64,
+                femtovg::PixelFormat::Rgba8,
+                femtovg::ImageFlags::PREMULTIPLIED | femtovg::ImageFlags::FLIP_Y,
+            )
+            .unwrap();
+        canvas.save();
+        canvas.set_render_target(femtovg::RenderTarget::Image(mask));
+        canvas.clear_rect(0, 0, 64, 64, Color::rgbaf(0.0, 0.0, 0.0, 0.0));
+        canvas.reset_transform();
+        let mut p = Path::new();
+        p.rect(0.0, 0.0, 64.0, 32.0);
+        canvas.fill_path(&p, &Paint::color(Color::white()));
+        canvas.set_render_target(femtovg::RenderTarget::Screen);
+        canvas.restore();
+
+        assert!(canvas.begin_layer(
+            &LayerEffects::new()
+                .with_filters(&[ImageFilter::brightness(1.0)])
+                .with_mask(mask, femtovg::MaskKind::Luminance, 0.0, 0.0, 64.0, 64.0),
+        ));
+        // Red on top, blue on bottom.
+        red_rect(canvas, 0.0, 0.0, 64.0, 32.0);
+        let mut p = Path::new();
+        p.rect(0.0, 32.0, 64.0, 32.0);
+        canvas.fill_path(&p, &Paint::color(Color::rgb(0, 0, 255)));
+        canvas.end_layer();
+    });
+    let top = px(&out, 32, 12);
+    let bottom = px(&out, 32, 52);
+    assert!(
+        close(top[0], 255) && close(top[2], 0),
+        "top-half mask over a filtered layer must show the RED top, got {top:?}"
+    );
+    assert_eq!(
+        bottom,
+        [255, 255, 255],
+        "bottom must be masked out, got {bottom:?} - blue here means the mask or content mirrored"
+    );
+}
+
+/// A luminance mask's coverage is luminance x alpha (SVG mask semantics):
+/// white fading to transparent must fade the layer out, not hold it at
+/// full coverage the way a straight luminanceToAlpha conversion would.
+/// Regression for background-noodles-left-dark.svg, whose white->transparent
+/// gradient mask was ignored entirely.
+#[test]
+fn luminance_mask_multiplies_alpha() {
+    let Some((device, queue)) = headless_device() else {
+        eprintln!("skipping: no wgpu adapter available");
+        return;
+    };
+    let out = render(&device, &queue, |canvas| {
+        canvas.clear_rect(0, 0, W, H, Color::white());
+
+        // Canvas-sized white->transparent vertical fade, captured mid-frame
+        // the way SVG integrations rasterize <mask> content.
+        let mask = canvas
+            .create_image_empty(
+                W as usize,
+                H as usize,
+                femtovg::PixelFormat::Rgba8,
+                femtovg::ImageFlags::PREMULTIPLIED | femtovg::ImageFlags::FLIP_Y,
+            )
+            .unwrap();
+        canvas.save();
+        canvas.set_render_target(femtovg::RenderTarget::Image(mask));
+        canvas.clear_rect(0, 0, W, H, Color::rgbaf(0.0, 0.0, 0.0, 0.0));
+        canvas.reset_transform();
+        let mut r = Path::new();
+        r.rect(0.0, 0.0, W as f32, H as f32);
+        let fade = Paint::linear_gradient(
+            0.0,
+            0.0,
+            0.0,
+            H as f32,
+            Color::white(),
+            Color::rgbaf(1.0, 1.0, 1.0, 0.0),
+        );
+        canvas.fill_path(&r, &fade);
+        canvas.set_render_target(femtovg::RenderTarget::Screen);
+        canvas.restore();
+
+        assert!(canvas.begin_layer(&LayerEffects::new().with_mask(
+            mask,
+            femtovg::MaskKind::Luminance,
+            0.0,
+            0.0,
+            W as f32,
+            H as f32,
+        )));
+        let mut p = Path::new();
+        p.rect(0.0, 0.0, W as f32, H as f32);
+        canvas.fill_path(&p, &Paint::color(Color::rgb(255, 0, 0)));
+        canvas.end_layer();
+    });
+    // Top row: coverage ~1 -> red survives.
+    assert!(
+        close(px(&out, 32, 1)[0], 255) && close(px(&out, 32, 1)[1], 0),
+        "top should stay red, got {:?}",
+        px(&out, 32, 1)
+    );
+    // Midpoint: coverage ~0.5 -> half red over white.
+    let mid = px(&out, 32, H / 2);
+    assert!(
+        (mid[1] as i32 - 128).abs() <= 12 && close(mid[0], 255),
+        "midpoint should be half-faded red, got {mid:?}"
+    );
+    // Bottom row: coverage ~0 -> white shows through.
+    let bottom = px(&out, 32, H - 1);
+    assert!(bottom[1] > 240, "bottom should fade to white, got {bottom:?}");
+}
+
+/// Draws `draw` into a fresh 64x64 render-target image and hands it back as
+/// a mask: the way an SVG integration rasterizes `<mask>` content.
+fn mask_from_draw(canvas: &mut Canvas<WGPURenderer>, draw: impl FnOnce(&mut Canvas<WGPURenderer>)) -> femtovg::ImageId {
+    let mask = canvas
+        .create_image_empty(
+            64,
+            64,
+            femtovg::PixelFormat::Rgba8,
+            femtovg::ImageFlags::PREMULTIPLIED | femtovg::ImageFlags::FLIP_Y,
+        )
+        .unwrap();
+    canvas.save();
+    canvas.set_render_target(femtovg::RenderTarget::Image(mask));
+    canvas.clear_rect(0, 0, 64, 64, Color::rgbaf(0.0, 0.0, 0.0, 0.0));
+    canvas.reset_transform();
+    draw(canvas);
+    canvas.set_render_target(femtovg::RenderTarget::Screen);
+    canvas.restore();
+    mask
+}
+
+/// The two mask kinds read opposite things from the same mask: an opaque
+/// black half keeps the layer under an alpha mask and hides it under a
+/// luminance mask; a transparent half does the reverse.
+#[test]
+fn alpha_mask_reads_alpha_and_luminance_mask_reads_luminance() {
+    let Some((device, queue)) = headless_device() else {
+        eprintln!("skipping: no wgpu adapter available");
+        return;
+    };
+    for (kind, left_shows) in [(femtovg::MaskKind::Alpha, true), (femtovg::MaskKind::Luminance, false)] {
+        let out = render(&device, &queue, |canvas| {
+            // Left half opaque black, right half transparent.
+            let mask = mask_from_draw(canvas, |c| {
+                let mut p = Path::new();
+                p.rect(0.0, 0.0, 32.0, 64.0);
+                c.fill_path(&p, &Paint::color(Color::black()));
+            });
+            assert!(canvas.begin_layer(&LayerEffects::new().with_mask(mask, kind, 0.0, 0.0, 64.0, 64.0)));
+            red_rect(canvas, 0.0, 0.0, 64.0, 64.0);
+            canvas.end_layer();
+        });
+        let left = px(&out, 16, 32);
+        let right = px(&out, 48, 32);
+        if left_shows {
+            assert!(
+                close(left[0], 255) && close(left[1], 0),
+                "{kind:?}: opaque black keeps the layer, got {left:?}"
+            );
+        } else {
+            assert_eq!(left, [255, 255, 255], "{kind:?}: black hides the layer, got {left:?}");
+        }
+        assert_eq!(
+            right,
+            [255, 255, 255],
+            "{kind:?}: transparent hides the layer, got {right:?}"
+        );
+    }
+}
+
+/// An uploaded mask (no FLIP_Y: row 0 is the top) lands upright too - the
+/// normalization draw honors whatever orientation the mask image declares.
+#[test]
+fn uploaded_mask_is_upright() {
+    let Some((device, queue)) = headless_device() else {
+        eprintln!("skipping: no wgpu adapter available");
+        return;
+    };
+    let out = render(&device, &queue, |canvas| {
+        // Top half white, bottom half transparent, straight from memory.
+        let mut buf = vec![femtovg::rgb::RGBA8::new(0, 0, 0, 0); 64 * 64];
+        for p in buf.iter_mut().take(64 * 32) {
+            *p = femtovg::rgb::RGBA8::new(255, 255, 255, 255);
+        }
+        let mask = canvas
+            .create_image(
+                femtovg::imgref::Img::new(buf.as_slice(), 64, 64),
+                femtovg::ImageFlags::empty(),
+            )
+            .unwrap();
+        assert!(canvas.begin_layer(&LayerEffects::new().with_mask(
+            mask,
+            femtovg::MaskKind::Luminance,
+            0.0,
+            0.0,
+            64.0,
+            64.0
+        )));
+        red_rect(canvas, 0.0, 0.0, 64.0, 64.0);
+        canvas.end_layer();
+    });
+    let top = px(&out, 32, 12);
+    let bottom = px(&out, 32, 52);
+    assert!(
+        close(top[0], 255) && close(top[1], 0),
+        "white top keeps the layer, got {top:?}"
+    );
+    assert_eq!(
+        bottom,
+        [255, 255, 255],
+        "transparent bottom hides it, got {bottom:?} - red means the upload mirrored"
+    );
+}
+
+/// The mask rect is device space and stays put under a device-pixel-ratio
+/// scale: with scale(2) and a scissor, the store is bounded by the scaled
+/// scissor and the mask lands where its device rect says.
+#[test]
+fn mask_placement_is_device_space_under_a_scale() {
+    let Some((device, queue)) = headless_device() else {
+        eprintln!("skipping: no wgpu adapter available");
+        return;
+    };
+    let out = render(&device, &queue, |canvas| {
+        // White on the top 24 rows of a 48-px mask placed at device (8, 8).
+        let mask = mask_from_draw(canvas, |c| {
+            let mut p = Path::new();
+            p.rect(0.0, 0.0, 48.0, 24.0);
+            c.fill_path(&p, &Paint::color(Color::white()));
+        });
+        canvas.scale(2.0, 2.0);
+        canvas.scissor(4.0, 4.0, 24.0, 24.0); // device (8, 8) .. (56, 56)
+        assert!(canvas.begin_layer(&LayerEffects::new().with_mask(
+            mask,
+            femtovg::MaskKind::Luminance,
+            8.0,
+            8.0,
+            48.0,
+            48.0
+        )));
+        red_rect(canvas, 0.0, 0.0, 32.0, 32.0); // device 0 .. 64
+        canvas.end_layer();
+    });
+    let upper = px(&out, 32, 20); // in the scissor, under the mask's white rows
+    let lower = px(&out, 32, 44); // in the scissor, under the mask's transparent rows
+    let outside = px(&out, 4, 4); // outside the scissor
+    assert!(
+        close(upper[0], 255) && close(upper[1], 0),
+        "masked-in region under scale, got {upper:?}"
+    );
+    assert_eq!(lower, [255, 255, 255], "masked-out region under scale, got {lower:?}");
+    assert_eq!(outside, [255, 255, 255], "outside the scaled scissor, got {outside:?}");
+}
+
+/// Luminance coverage uses the Rec. 709 weights on the mask's own color: a
+/// solid green mask keeps 71.5 % of a red layer over white, a solid blue one
+/// 7.2 %, so the green channel carries the weight, not an equal average.
+#[test]
+fn luminance_mask_weights_are_rec709() {
+    let Some((device, queue)) = headless_device() else {
+        eprintln!("skipping: no wgpu adapter available");
+        return;
+    };
+    for (color, coverage) in [(Color::rgb(0, 255, 0), 0.7152f32), (Color::rgb(0, 0, 255), 0.0722f32)] {
+        let out = render(&device, &queue, |canvas| {
+            let mask = mask_from_draw(canvas, |c| c.clear_rect(0, 0, 64, 64, color));
+            assert!(canvas.begin_layer(&LayerEffects::new().with_mask(
+                mask,
+                femtovg::MaskKind::Luminance,
+                0.0,
+                0.0,
+                64.0,
+                64.0
+            )));
+            red_rect(canvas, 0.0, 0.0, 64.0, 64.0);
+            canvas.end_layer();
+        });
+        let c = px(&out, 32, 32);
+        let expected = (255.0 * (1.0 - coverage)).round() as i32;
+        assert!(
+            close(c[0], 255) && close(c[1], expected) && close(c[2], expected),
+            "coverage {coverage} of red over white should read (255, {expected}, {expected}), got {c:?}"
+        );
+    }
+}
+
 fn readback(device: &wgpu::Device, queue: &wgpu::Queue, target: &wgpu::Texture) -> Vec<u8> {
     let unpadded = W * 4;
     let padded = unpadded.div_ceil(wgpu::COPY_BYTES_PER_ROW_ALIGNMENT) * wgpu::COPY_BYTES_PER_ROW_ALIGNMENT;


### PR DESCRIPTION
Renders Gaussian blurs above the shader's sigma bound at their true width. The blur shader is a 24-tap unit-spaced loop, a GLES 2.0 constant-loop workaround that predates this stack, so sigma is clamped to 8 device pixels per pass; anything wider came out narrower than the browsers draw it. On the Google Workspace icon the blur is 2.38 SVG units, 9.9 px at 1.0× and 23 px at 2.35×, and the residual against Chromium 131 grew from 0.06 % of pixels at 1.6× to 4.43 % at 2.35× as a diagonal ribbon along the blurred edge. Stacked on #323 (its chain planner is where the split lives, so this diff shows #323's commits until that merges); #325 tracks the remaining kernel-shape divergence at small sigma and is not addressed here.

### Design

Gaussians compose in quadrature: a blur of sigma S is exactly k passes of S/√k, so a blur above the bound B = 8 plans as k = ⌈(S/B)²⌉ passes, each within the bound. The expansion happens in `filter_passes()` after the colour-matrix fold, so `filter_image_chain`, a layer's scratch reservation and `end_layer` all read one plan; the scratch count stays two (ping-pong) and the parity rule is unchanged, since a blur pass preserves the flip. Layers pad their store by the true chain reach (quadrature sum, 3σ + 2) instead of the clamped one, so a wide blur no longer loses its tails at the store edge, bounded by the backend's texture limit: a full-width 1080p layer whose reach would pass a VideoCore IV's 2048 px still captures with its reach truncated at the store edge rather than passing through with every effect dropped. The memory consequence is stated in the `begin_layer` and budget docs. Each pass's kernel stops at 2.875σ (the loop's last tap), so a split blur composes to within 2 % of the nominal sigma. `render_shadow` runs the same plan between its coverage and blurred images and pads by the true sigma. The single-pass `filter_image` keeps the bound and says so.

Two guards: a chain-level ceiling of sigma 128 (256 passes; the cost is quadratic, Skia and WebKit go to 532 through box blurs and downscaling, which is #325's territory), and, because a texture created inside a command stream lives until the submit retires, the wgpu backend now keeps one horizontal-pass buffer per size instead of one per pass, which under the split would have held k store-sized textures at once.

### Result

Google Workspace icon, 460×260 pivot-zoom ladder against Chromium 131:

| zoom | 0.6× | 0.9× | 1.0× | 1.3× | 1.6× | 1.9× | 2.1× | 2.35× |
| --- | --- | --- | --- | --- | --- | --- | --- | --- |
| before, px > 20/255 | 0.05 % | 0.03 % | 0.06 % | 0.08 % | 0.06 % | 0.60 % | 2.90 % | 4.43 % |
| after | 0.05 % | 0.03 % | 0.07 % | 0.08 % | 0.04 % | 0.08 % | 0.08 % | 0.06 % |
| after, structural | 0.000 % | 0.000 % | 0.000 % | 0.000 % | 0.000 % | 0.000 % | 0.000 % | 0.000 % |

Against the analytic profile of a blurred step edge, 0.5·(1 + erf(x/(σ√2))): a sigma-16 chain, a sigma-20 layer and a shadow of blur 40 all land within 1.3/255 at every column; the clamped single pass was 41/255 off the sigma-16 profile (and within 1/255 of the sigma-8 profile it actually drew). Blurs within the bound plan as before and render bit-identically.

**BuseyBench**, 27 files at the documented 1×/2×/4× triple against Chromium 131, with the whole open stack. At 1× and 2× the scores are unchanged (mean structural 0.026 % and 0.358 %; a wide blur only exceeds the bound at 4×). At 4× the files whose large blurs are blurs improve: `gemini-3-1-pro-preview-custom-tools` (stdDeviation 40, sigma 31 px, sixteen passes) 1.28 % → 0.67 % structural, `qwen3-8-flash` 0.23 % → 0.00 %, `glm-5v-turbo` 0.19 % → 0.00 %, and over the 22 files without the idiom below the 4× mean goes 0.096 % → 0.046 %. Four files read worse at 4× (gpt-5-6-sol-pro 5.1 % → 8.2 %, gpt-5-6-terra-pro, claude-fable-5-1, gemini-3-7-flash), and every one of them is the evaluation harness, not the renderer: their filters are the manual drop-shadow idiom (`feGaussianBlur in="SourceAlpha"` → `feOffset` → recolour → `feMerge` under the source), which the harness still maps to a blur of the whole group, so a truer blur enlarges a wrong picture; with those groups stripped on both sides, before and after render identically at 0.000 % structural. Mapping that idiom to the group shadow is the harness follow-up. The separable-blend share (#332: `feBlend mode="multiply"` chains and one `mix-blend-mode: screen`) was measured by stripping the blends on the reference side and is separable and small: 0.03 / 0.21 / 0.58 points on gpt-5-2-pro at 1× / 2× / 4× with the idiom present and 0.000 without it, 0.04 / 0.65 on gemini-3-7-flash; nothing here changes what #332 has to do.

![Google Workspace icon at 2.35x and 2.1x, BuseyBench gemini-3-1-pro-preview-custom-tools and qwen3-8-flash at 4x: before, after, Chromium 131, and the diffs against Chromium in red](https://raw.githubusercontent.com/rebeckerspecialties/femtovg/demo-assets/blur-quadrature-evidence.png)

![Google Workspace icon pivot-zoom ladder 0.6x to 2.35x and back: before, after, Chromium 131, Firefox 157, and the diffs](https://raw.githubusercontent.com/rebeckerspecialties/femtovg/demo-assets/blur-quadrature-zoom.gif)

**Cost.** Passes grow as ⌈(σ/8)²⌉, so this is a trade of GPU time for correctness where sigma exceeds the bound. Under a zoom the pass count steps with the device sigma: the icon costs about 2, 5 and 6 ms more per frame at 1.6×, 2.1× and 2.35× (4, 7 and 9 passes, this machine's debug build), and nothing in the split can be reused from frame to frame, since it is pixel work on content that changes with the zoom; the pass plan and coefficients are microseconds. What a zoom sweep did expose is unrelated to the split: every frame deletes its whole transient set at the flush and recreates it, which rebeckerspecialties/femtovg#11 addresses separately. On the corpus: on the eight largest-blur corpus files at 4× the frame holds 0.9–10 MB more transient memory (the store pads by the true reach) and takes 5–28 % longer per frame on this machine's debug build; at 2× both are within noise. On a tiler class device a viewport-sized blur of sigma 40 is 25 passes, which is why the ceiling exists and why a downscaled path for very large sigma is the natural sequel under #325.

### Tests

Unit: a blur within the bound stays one pass; 16 splits into four passes of 8 and 23 into nine of 23/3 (squares summing to 23²); the split keeps the chain's parity and scratch count; a layer pads by the true reach; a filtered layer reserves by the pass plan; a large shadow blur runs as quadrature passes with the composite reading the last pass's target. GPU: the three profile tests above, and chains of sigma 3 and 8 byte-identical to the single pass. Plus a layer at the texture limit keeping its blur with a bounded pad, and the pad rule itself. 302 GPU tests and the default suite green; fmt and clippy clean in the touched code.

